### PR TITLE
Feature/vehicle details

### DIFF
--- a/app/ui/src/app/edit/components/VehicleRow.tsx
+++ b/app/ui/src/app/edit/components/VehicleRow.tsx
@@ -29,6 +29,7 @@ import {
   VEHICLE_DESKTOP_INPUT,
   VEHICLE_DESKTOP_NUMBER_INPUT,
   VEHICLE_DESKTOP_SELECT,
+  VEHICLE_DESKTOP_WIDE_INPUT,
   VEHICLE_GRID_INNER,
   VEHICLE_LOCKED_CELL,
   VEHICLE_MOBILE_CARD,
@@ -150,6 +151,7 @@ export default function VehicleRow({
   vehicleTouched,
 }: VehicleRowProps) {
   const nameInvalid = vehicleTouched && !v.name.trim();
+  const startLocationInvalid = vehicleTouched && !(v.startLocation ?? "").trim();
   const typeInvalid = vehicleTouched && !v.type;
   const capMeasureInvalid = vehicleTouched && !v.capacityUnit;
   const capacityInvalid = vehicleTouched && v.capacity <= 0;
@@ -165,6 +167,10 @@ export default function VehicleRow({
           <MobileFieldLabel>Name</MobileFieldLabel>
           <div className={VEHICLE_LOCKED_CELL}>
             <span className="text-base text-black truncate">{v.name}</span>
+          </div>
+          <MobileFieldLabel>Start Location</MobileFieldLabel>
+          <div className={VEHICLE_LOCKED_CELL}>
+            <span className="text-base text-black truncate">{v.startLocation}</span>
           </div>
           <MobileFieldLabel>Type</MobileFieldLabel>
           <div className={VEHICLE_LOCKED_CELL}>
@@ -219,6 +225,14 @@ export default function VehicleRow({
           className={`${inputClass(nameInvalid)} bg-white`}
           placeholder="Name"
           aria-label="Vehicle name"
+        />
+        <MobileFieldLabel>Start Location</MobileFieldLabel>
+        <input
+          value={v.startLocation ?? ""}
+          onChange={(e) => updateVehicle(v.id, "startLocation", e.target.value)}
+          className={`${inputClass(startLocationInvalid)} bg-white`}
+          placeholder="Address"
+          aria-label="Start location"
         />
         <MobileFieldLabel>Type</MobileFieldLabel>
         <select
@@ -326,6 +340,9 @@ export default function VehicleRow({
           <span className="text-sm xl:text-base text-black truncate">{v.name}</span>
         </div>
         <div className={VEHICLE_LOCKED_CELL}>
+          <span className="text-sm xl:text-base text-black truncate">{v.startLocation}</span>
+        </div>
+        <div className={VEHICLE_LOCKED_CELL}>
           <span className="text-sm xl:text-base text-black truncate">{capitalize(v.type)}</span>
         </div>
         <div className={VEHICLE_LOCKED_CELL}>
@@ -400,6 +417,13 @@ export default function VehicleRow({
         className={`${VEHICLE_DESKTOP_INPUT} ${fieldBorder(vehicleTouched && !v.name.trim())}`}
         placeholder=""
         aria-label="Vehicle name"
+      />
+      <input
+        value={v.startLocation ?? ""}
+        onChange={(e) => updateVehicle(v.id, "startLocation", e.target.value)}
+        className={`${VEHICLE_DESKTOP_WIDE_INPUT} ${fieldBorder(startLocationInvalid)}`}
+        placeholder=""
+        aria-label="Start location"
       />
       <select
         value={v.type}

--- a/app/ui/src/app/edit/components/VehicleRow.tsx
+++ b/app/ui/src/app/edit/components/VehicleRow.tsx
@@ -1,4 +1,4 @@
-"use client";
+ï»¿"use client";
 
 /**
  * One vehicle in the grid: read-only summary, full-width edit for existing rows, or inline new row.
@@ -209,7 +209,7 @@ export default function VehicleRow({
       );
     }
 
-    // Editing (existing or new) GÇö shared fields; wrapper and actions differ by editingExisting
+    // Editing (existing or new) Gï¿½ï¿½ shared fields; wrapper and actions differ by editingExisting
     return (
       <div className={v.editingExisting ? VEHICLE_MOBILE_EDITING_CARD : VEHICLE_MOBILE_CARD}>
         <MobileFieldLabel>Name</MobileFieldLabel>

--- a/app/ui/src/app/edit/components/VehicleRow.tsx
+++ b/app/ui/src/app/edit/components/VehicleRow.tsx
@@ -223,7 +223,7 @@ export default function VehicleRow({
       );
     }
 
-    // Editing (existing or new) G�� shared fields; wrapper and actions differ by editingExisting
+    // Editing (existing or new) shared fields; wrapper and actions differ by editingExisting
     return (
       <div className={v.editingExisting ? VEHICLE_MOBILE_EDITING_CARD : VEHICLE_MOBILE_CARD}>
         <MobileFieldLabel>Name</MobileFieldLabel>

--- a/app/ui/src/app/edit/components/VehicleRow.tsx
+++ b/app/ui/src/app/edit/components/VehicleRow.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 /**
  * One vehicle in the grid: read-only summary, full-width edit for existing rows, or inline new row.

--- a/app/ui/src/app/edit/components/VehicleRow.tsx
+++ b/app/ui/src/app/edit/components/VehicleRow.tsx
@@ -42,6 +42,14 @@ import {
   VEHICLE_PILL_HALF_DANGER,
   ICON_BUTTON_9,
   ICON_BUTTON_9_DANGER,
+  VEHICLE_DESKTOP_ACTION_CELL,
+  VEHICLE_DESKTOP_AVAILABLE_CELL,
+  VEHICLE_DESKTOP_LOCKED_TEXT,
+  VEHICLE_MOBILE_AVAILABLE_LABEL,
+  VEHICLE_MOBILE_AVAILABLE_ROW,
+  VEHICLE_MOBILE_EDITING_ACTIONS,
+  VEHICLE_MOBILE_LOCKED_ACTIONS,
+  VEHICLE_MOBILE_LOCKED_TEXT,
   fieldBorder,
 } from "../formStyles";
 
@@ -166,35 +174,35 @@ export default function VehicleRow({
         <div className={VEHICLE_MOBILE_CARD}>
           <MobileFieldLabel>Name</MobileFieldLabel>
           <div className={VEHICLE_LOCKED_CELL}>
-            <span className="text-base text-black truncate">{v.name}</span>
+            <span className={VEHICLE_MOBILE_LOCKED_TEXT}>{v.name}</span>
           </div>
           <MobileFieldLabel>Start Location</MobileFieldLabel>
           <div className={VEHICLE_LOCKED_CELL}>
-            <span className="text-base text-black truncate">{v.startLocation}</span>
+            <span className={VEHICLE_MOBILE_LOCKED_TEXT}>{v.startLocation}</span>
           </div>
           <MobileFieldLabel>Type</MobileFieldLabel>
           <div className={VEHICLE_LOCKED_CELL}>
-            <span className="text-base text-black truncate">{capitalize(v.type)}</span>
+            <span className={VEHICLE_MOBILE_LOCKED_TEXT}>{capitalize(v.type)}</span>
           </div>
           <MobileFieldLabel>Capacity Unit</MobileFieldLabel>
           <div className={VEHICLE_LOCKED_CELL}>
-            <span className="text-base text-black truncate">{capitalize(v.capacityUnit)}</span>
+            <span className={VEHICLE_MOBILE_LOCKED_TEXT}>{capitalize(v.capacityUnit)}</span>
           </div>
           <MobileFieldLabel>Capacity</MobileFieldLabel>
           <div className={VEHICLE_LOCKED_CELL}>
-            <span className="text-base text-black truncate">{v.capacity}</span>
+            <span className={VEHICLE_MOBILE_LOCKED_TEXT}>{v.capacity}</span>
           </div>
-          <div className="flex items-center justify-between gap-3 pt-1">
-            <span className="text-sm text-black">Available</span>
+          <div className={VEHICLE_MOBILE_AVAILABLE_ROW}>
+            <span className={VEHICLE_MOBILE_AVAILABLE_LABEL}>Available</span>
             <div className={VEHICLE_AVAILABLE_SEGMENT_WRAPPER}>
               <AvailableSegmented available={v.available} />
             </div>
           </div>
           <MobileFieldLabel>Departure Time</MobileFieldLabel>
           <div className={VEHICLE_LOCKED_CELL}>
-            <span className="text-base text-black truncate">{v.departureTime}</span>
+            <span className={VEHICLE_MOBILE_LOCKED_TEXT}>{v.departureTime}</span>
           </div>
-          <div className="flex gap-2 pt-2">
+          <div className={VEHICLE_MOBILE_LOCKED_ACTIONS}>
             <button
               type="button"
               onClick={() => unlockVehicle(v.id)}
@@ -273,8 +281,8 @@ export default function VehicleRow({
           placeholder=""
           aria-label="Vehicle capacity"
         />
-        <div className="flex items-center justify-between gap-3 pt-1">
-          <span className="text-sm text-black">Available</span>
+        <div className={VEHICLE_MOBILE_AVAILABLE_ROW}>
+          <span className={VEHICLE_MOBILE_AVAILABLE_LABEL}>Available</span>
           <div className={VEHICLE_AVAILABLE_SEGMENT_WRAPPER}>
             <AvailableSegmented
               available={v.available}
@@ -299,7 +307,7 @@ export default function VehicleRow({
           ))}
         </select>
         {v.editingExisting ? (
-          <div className="flex flex-col gap-2 pt-2">
+          <div className={VEHICLE_MOBILE_EDITING_ACTIONS}>
             <button
               type="button"
               onClick={() => confirmVehicle(v.id)}
@@ -337,27 +345,27 @@ export default function VehicleRow({
     return (
       <>
         <div className={VEHICLE_LOCKED_CELL}>
-          <span className="text-sm xl:text-base text-black truncate">{v.name}</span>
+          <span className={VEHICLE_DESKTOP_LOCKED_TEXT}>{v.name}</span>
         </div>
         <div className={VEHICLE_LOCKED_CELL}>
-          <span className="text-sm xl:text-base text-black truncate">{v.startLocation}</span>
+          <span className={VEHICLE_DESKTOP_LOCKED_TEXT}>{v.startLocation}</span>
         </div>
         <div className={VEHICLE_LOCKED_CELL}>
-          <span className="text-sm xl:text-base text-black truncate">{capitalize(v.type)}</span>
+          <span className={VEHICLE_DESKTOP_LOCKED_TEXT}>{capitalize(v.type)}</span>
         </div>
         <div className={VEHICLE_LOCKED_CELL}>
-          <span className="text-sm xl:text-base text-black truncate">{capitalize(v.capacityUnit)}</span>
+          <span className={VEHICLE_DESKTOP_LOCKED_TEXT}>{capitalize(v.capacityUnit)}</span>
         </div>
         <div className={VEHICLE_LOCKED_CELL}>
-          <span className="text-sm xl:text-base text-black truncate">{v.capacity}</span>
+          <span className={VEHICLE_DESKTOP_LOCKED_TEXT}>{v.capacity}</span>
         </div>
-        <div className="flex items-center justify-center h-11 min-w-0 px-0.5">
+        <div className={VEHICLE_DESKTOP_AVAILABLE_CELL}>
           <AvailableSegmented available={v.available} />
         </div>
         <div className={VEHICLE_LOCKED_CELL}>
-          <span className="text-sm xl:text-base text-black truncate">{v.departureTime}</span>
+          <span className={VEHICLE_DESKTOP_LOCKED_TEXT}>{v.departureTime}</span>
         </div>
-        <div className="flex items-center gap-1">
+        <div className={VEHICLE_DESKTOP_ACTION_CELL}>
           <button
             type="button"
             onClick={() => unlockVehicle(v.id)}
@@ -386,7 +394,7 @@ export default function VehicleRow({
   // Editing (existing: full-width blue panel) or new row (inline in the grid).
   // The only structural differences are the wrapper div and the Confirm button.
   const actionCell = (
-    <div className="flex items-center gap-1">
+    <div className={VEHICLE_DESKTOP_ACTION_CELL}>
       {v.editingExisting && (
         <button
           type="button"
@@ -461,7 +469,7 @@ export default function VehicleRow({
         placeholder=""
         aria-label="Vehicle capacity"
       />
-      <div className="flex items-center justify-center h-11 min-w-0 px-0.5">
+      <div className={VEHICLE_DESKTOP_AVAILABLE_CELL}>
         <AvailableSegmented
           available={v.available}
           onChange={(next) => updateVehicle(v.id, "available", next)}

--- a/app/ui/src/app/edit/components/VehicleRow.tsx
+++ b/app/ui/src/app/edit/components/VehicleRow.tsx
@@ -1,0 +1,478 @@
+"use client";
+
+/**
+ * One vehicle in the grid: read-only summary, full-width edit for existing rows, or inline new row.
+ * Desktop: seven-column grid cells. Mobile: stacked card with labels above fields.
+ *
+ * The `layout` prop is kept because mobile vs desktop differ in real structure (stacked card vs
+ * grid fragments), not only responsive CSS on one tree.
+ */
+
+import { useRef, type ReactNode } from "react";
+import { TIME_OPTIONS } from "../constants/timeOptions";
+import type { VehicleRow as VehicleRowType, VehicleType, CapacityUnit } from "../types/delivery";
+import { capitalize } from "../utils/deliveryHelpers";
+import {
+  DESKTOP_VEHICLE_GRID_CLASS,
+  MOBILE_FIELD_LABEL,
+  VEHICLE_AVAILABLE_SEGMENT_BUTTON,
+  VEHICLE_AVAILABLE_SEGMENT_READ_ONLY_SPAN,
+  VEHICLE_AVAILABLE_SEGMENT_ROW,
+  VEHICLE_AVAILABLE_SEGMENT_THUMB,
+  VEHICLE_AVAILABLE_SEGMENT_THUMB_NO,
+  VEHICLE_AVAILABLE_SEGMENT_THUMB_YES,
+  VEHICLE_AVAILABLE_SEGMENTED_TRACK,
+  VEHICLE_AVAILABLE_SEGMENT_WRAPPER,
+  VEHICLE_CONFIRM_DESKTOP,
+  VEHICLE_DESKTOP_DEPARTURE_SELECT,
+  VEHICLE_DESKTOP_EDITING_PANEL,
+  VEHICLE_DESKTOP_INPUT,
+  VEHICLE_DESKTOP_NUMBER_INPUT,
+  VEHICLE_DESKTOP_SELECT,
+  VEHICLE_GRID_INNER,
+  VEHICLE_LOCKED_CELL,
+  VEHICLE_MOBILE_CARD,
+  VEHICLE_MOBILE_EDITING_CARD,
+  VEHICLE_MOBILE_INPUT,
+  VEHICLE_MOBILE_SELECT,
+  VEHICLE_PILL_FULL_DANGER,
+  VEHICLE_PILL_FULL_PRIMARY,
+  VEHICLE_PILL_HALF,
+  VEHICLE_PILL_HALF_DANGER,
+  ICON_BUTTON_9,
+  ICON_BUTTON_9_DANGER,
+  fieldBorder,
+} from "../formStyles";
+
+type VehicleLayout = "desktop" | "mobile";
+
+type VehicleRowProps = {
+  layout?: VehicleLayout;
+  vehicle: VehicleRowType;
+  vehiclesCount: number;
+  updateVehicle: <K extends keyof VehicleRowType>(id: number, key: K, value: VehicleRowType[K]) => void;
+  deleteVehicle: (id: number) => void;
+  unlockVehicle: (id: number) => void;
+  confirmVehicle: (id: number) => void;
+  vehicleTouched: boolean;
+};
+
+function MobileFieldLabel({ children }: { children: ReactNode }) {
+  return <span className={MOBILE_FIELD_LABEL}>{children}</span>;
+}
+
+function AvailableSegmented({
+  available,
+  onChange,
+}: {
+  available: boolean;
+  onChange?: (next: boolean) => void;
+}) {
+  const readOnly = onChange == null;
+  const noRef = useRef<HTMLButtonElement>(null);
+  const yesRef = useRef<HTMLButtonElement>(null);
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(e.key)) return;
+    e.preventDefault();
+    if (readOnly) return;
+    const next = !available;
+    onChange?.(next);
+    // Move focus to the newly activated option after re-render
+    requestAnimationFrame(() => {
+      (next ? yesRef : noRef).current?.focus();
+    });
+  }
+
+  const trackClass = `${VEHICLE_AVAILABLE_SEGMENTED_TRACK}${readOnly ? " pointer-events-none" : ""}`;
+  const thumbClass = `${VEHICLE_AVAILABLE_SEGMENT_THUMB} ${available ? VEHICLE_AVAILABLE_SEGMENT_THUMB_YES : VEHICLE_AVAILABLE_SEGMENT_THUMB_NO}`;
+
+  return (
+    <div role="radiogroup" aria-label="Available" className={trackClass}>
+      <div className={thumbClass} aria-hidden />
+      <div className={VEHICLE_AVAILABLE_SEGMENT_ROW}>
+        {readOnly ? (
+          <>
+            <span role="radio" aria-checked={!available} className={VEHICLE_AVAILABLE_SEGMENT_READ_ONLY_SPAN}>
+              No
+            </span>
+            <span role="radio" aria-checked={available} className={VEHICLE_AVAILABLE_SEGMENT_READ_ONLY_SPAN}>
+              Yes
+            </span>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={!available}
+              ref={noRef}
+              className={VEHICLE_AVAILABLE_SEGMENT_BUTTON}
+              onClick={() => onChange(false)}
+              onKeyDown={handleKeyDown}
+            >
+              No
+            </button>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={available}
+              ref={yesRef}
+              className={VEHICLE_AVAILABLE_SEGMENT_BUTTON}
+              onClick={() => onChange(true)}
+              onKeyDown={handleKeyDown}
+            >
+              Yes
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const TRASH_ICON = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2" />
+    <line x1="10" y1="11" x2="10" y2="17" />
+    <line x1="14" y1="11" x2="14" y2="17" />
+  </svg>
+);
+
+export default function VehicleRow({
+  layout = "desktop",
+  vehicle: v,
+  vehiclesCount,
+  updateVehicle,
+  deleteVehicle,
+  unlockVehicle,
+  confirmVehicle,
+  vehicleTouched,
+}: VehicleRowProps) {
+  const nameInvalid = vehicleTouched && !v.name.trim();
+  const typeInvalid = vehicleTouched && !v.type;
+  const capMeasureInvalid = vehicleTouched && !v.capacityUnit;
+  const capacityInvalid = vehicleTouched && v.capacity <= 0;
+  const departureInvalid = vehicleTouched && !v.departureTime.trim();
+
+  const inputClass = (invalid: boolean) => `${VEHICLE_MOBILE_INPUT} ${fieldBorder(invalid, "mobile")}`;
+  const selectClass = (invalid: boolean) => `${VEHICLE_MOBILE_SELECT} ${fieldBorder(invalid, "mobile")}`;
+  if (layout === "mobile") {
+    // Locked read-only card
+    if (v.locked) {
+      return (
+        <div className={VEHICLE_MOBILE_CARD}>
+          <MobileFieldLabel>Name</MobileFieldLabel>
+          <div className={VEHICLE_LOCKED_CELL}>
+            <span className="text-base text-black truncate">{v.name}</span>
+          </div>
+          <MobileFieldLabel>Type</MobileFieldLabel>
+          <div className={VEHICLE_LOCKED_CELL}>
+            <span className="text-base text-black truncate">{capitalize(v.type)}</span>
+          </div>
+          <MobileFieldLabel>Capacity Unit</MobileFieldLabel>
+          <div className={VEHICLE_LOCKED_CELL}>
+            <span className="text-base text-black truncate">{capitalize(v.capacityUnit)}</span>
+          </div>
+          <MobileFieldLabel>Capacity</MobileFieldLabel>
+          <div className={VEHICLE_LOCKED_CELL}>
+            <span className="text-base text-black truncate">{v.capacity}</span>
+          </div>
+          <div className="flex items-center justify-between gap-3 pt-1">
+            <span className="text-sm text-black">Available</span>
+            <div className={VEHICLE_AVAILABLE_SEGMENT_WRAPPER}>
+              <AvailableSegmented available={v.available} />
+            </div>
+          </div>
+          <MobileFieldLabel>Departure Time</MobileFieldLabel>
+          <div className={VEHICLE_LOCKED_CELL}>
+            <span className="text-base text-black truncate">{v.departureTime}</span>
+          </div>
+          <div className="flex gap-2 pt-2">
+            <button
+              type="button"
+              onClick={() => unlockVehicle(v.id)}
+              className={VEHICLE_PILL_HALF}
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={() => deleteVehicle(v.id)}
+              disabled={vehiclesCount <= 1}
+              className={VEHICLE_PILL_HALF_DANGER}
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    // Editing (existing or new) GÇö shared fields; wrapper and actions differ by editingExisting
+    return (
+      <div className={v.editingExisting ? VEHICLE_MOBILE_EDITING_CARD : VEHICLE_MOBILE_CARD}>
+        <MobileFieldLabel>Name</MobileFieldLabel>
+        <input
+          value={v.name}
+          onChange={(e) => updateVehicle(v.id, "name", e.target.value)}
+          className={`${inputClass(nameInvalid)} bg-white`}
+          placeholder="Name"
+          aria-label="Vehicle name"
+        />
+        <MobileFieldLabel>Type</MobileFieldLabel>
+        <select
+          value={v.type}
+          onChange={(e) => updateVehicle(v.id, "type", e.target.value as VehicleType)}
+          className={`${selectClass(typeInvalid)} bg-white`}
+          aria-label="Vehicle type"
+        >
+          <option value="" disabled>
+            Select
+          </option>
+          <option value="truck">Truck</option>
+          <option value="car">Car</option>
+          <option value="bicycle">Bicycle</option>
+        </select>
+        <MobileFieldLabel>Capacity Unit</MobileFieldLabel>
+        <select
+          value={v.capacityUnit}
+          onChange={(e) => updateVehicle(v.id, "capacityUnit", e.target.value as CapacityUnit)}
+          className={`${selectClass(capMeasureInvalid)} bg-white`}
+          aria-label="Capacity unit"
+        >
+          <option value="" disabled>
+            Select
+          </option>
+          <option value="units">Units</option>
+          <option value="lbs">Lbs</option>
+          <option value="kgs">Kgs</option>
+          <option value="volume">Volume</option>
+        </select>
+        <MobileFieldLabel>Capacity</MobileFieldLabel>
+        <input
+          type="number"
+          min={0}
+          value={v.capacity || ""}
+          onChange={(e) => updateVehicle(v.id, "capacity", e.target.value === "" ? 0 : parseInt(e.target.value, 10) || 0)}
+          className={`${inputClass(capacityInvalid)} bg-white`}
+          placeholder=""
+          aria-label="Vehicle capacity"
+        />
+        <div className="flex items-center justify-between gap-3 pt-1">
+          <span className="text-sm text-black">Available</span>
+          <div className={VEHICLE_AVAILABLE_SEGMENT_WRAPPER}>
+            <AvailableSegmented
+              available={v.available}
+              onChange={(next) => updateVehicle(v.id, "available", next)}
+            />
+          </div>
+        </div>
+        <MobileFieldLabel>Departure time</MobileFieldLabel>
+        <select
+          value={v.departureTime}
+          onChange={(e) => updateVehicle(v.id, "departureTime", e.target.value)}
+          className={`${selectClass(departureInvalid)} bg-white`}
+          aria-label="Departure time"
+        >
+          <option value="" disabled>
+            Select
+          </option>
+          {TIME_OPTIONS.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+        {v.editingExisting ? (
+          <div className="flex flex-col gap-2 pt-2">
+            <button
+              type="button"
+              onClick={() => confirmVehicle(v.id)}
+              className={VEHICLE_PILL_FULL_PRIMARY}
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              onClick={() => deleteVehicle(v.id)}
+              disabled={vehiclesCount <= 1}
+              className={VEHICLE_PILL_FULL_DANGER}
+            >
+              Delete
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => deleteVehicle(v.id)}
+            disabled={vehiclesCount <= 1}
+            className={`${VEHICLE_PILL_FULL_DANGER} mt-2`}
+          >
+            Delete
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // --- Desktop layout ---
+
+  // Locked: gray cells mirroring the grid columns; unlock or delete
+  if (v.locked) {
+    return (
+      <>
+        <div className={VEHICLE_LOCKED_CELL}>
+          <span className="text-sm xl:text-base text-black truncate">{v.name}</span>
+        </div>
+        <div className={VEHICLE_LOCKED_CELL}>
+          <span className="text-sm xl:text-base text-black truncate">{capitalize(v.type)}</span>
+        </div>
+        <div className={VEHICLE_LOCKED_CELL}>
+          <span className="text-sm xl:text-base text-black truncate">{capitalize(v.capacityUnit)}</span>
+        </div>
+        <div className={VEHICLE_LOCKED_CELL}>
+          <span className="text-sm xl:text-base text-black truncate">{v.capacity}</span>
+        </div>
+        <div className="flex items-center justify-center h-11 min-w-0 px-0.5">
+          <AvailableSegmented available={v.available} />
+        </div>
+        <div className={VEHICLE_LOCKED_CELL}>
+          <span className="text-sm xl:text-base text-black truncate">{v.departureTime}</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => unlockVehicle(v.id)}
+            className={ICON_BUTTON_9}
+            title="Edit"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+              <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onClick={() => deleteVehicle(v.id)}
+            disabled={vehiclesCount <= 1}
+            className={ICON_BUTTON_9_DANGER}
+            title="Delete"
+          >
+            {TRASH_ICON}
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  // Editing (existing: full-width blue panel) or new row (inline in the grid).
+  // The only structural differences are the wrapper div and the Confirm button.
+  const actionCell = (
+    <div className="flex items-center gap-1">
+      {v.editingExisting && (
+        <button
+          type="button"
+          onClick={() => confirmVehicle(v.id)}
+          className={VEHICLE_CONFIRM_DESKTOP}
+          title="Confirm edits"
+        >
+          Confirm
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={() => deleteVehicle(v.id)}
+        disabled={vehiclesCount <= 1}
+        className={ICON_BUTTON_9_DANGER}
+        title="Delete"
+      >
+        {TRASH_ICON}
+      </button>
+    </div>
+  );
+
+  const fieldCells = (
+    <>
+      <input
+        value={v.name}
+        onChange={(e) => updateVehicle(v.id, "name", e.target.value)}
+        className={`${VEHICLE_DESKTOP_INPUT} ${fieldBorder(vehicleTouched && !v.name.trim())}`}
+        placeholder=""
+        aria-label="Vehicle name"
+      />
+      <select
+        value={v.type}
+        onChange={(e) => updateVehicle(v.id, "type", e.target.value as VehicleType)}
+        className={`${VEHICLE_DESKTOP_SELECT} ${fieldBorder(vehicleTouched && !v.type)}`}
+        aria-label="Vehicle type"
+      >
+        <option value="" disabled>
+          Select
+        </option>
+        <option value="truck">Truck</option>
+        <option value="car">Car</option>
+        <option value="bicycle">Bicycle</option>
+      </select>
+      <select
+        value={v.capacityUnit}
+        onChange={(e) => updateVehicle(v.id, "capacityUnit", e.target.value as CapacityUnit)}
+        className={`${VEHICLE_DESKTOP_SELECT} ${fieldBorder(vehicleTouched && !v.capacityUnit)}`}
+        aria-label="Capacity unit"
+      >
+        <option value="" disabled>
+          Select
+        </option>
+        <option value="units">Units</option>
+        <option value="lbs">Lbs</option>
+        <option value="kgs">Kgs</option>
+        <option value="volume">Volume</option>
+      </select>
+      <input
+        type="number"
+        min={0}
+        value={v.capacity || ""}
+        onChange={(e) => updateVehicle(v.id, "capacity", e.target.value === "" ? 0 : parseInt(e.target.value, 10) || 0)}
+        className={`${VEHICLE_DESKTOP_NUMBER_INPUT} ${fieldBorder(vehicleTouched && v.capacity <= 0)}`}
+        placeholder=""
+        aria-label="Vehicle capacity"
+      />
+      <div className="flex items-center justify-center h-11 min-w-0 px-0.5">
+        <AvailableSegmented
+          available={v.available}
+          onChange={(next) => updateVehicle(v.id, "available", next)}
+        />
+      </div>
+      <select
+        value={v.departureTime}
+        onChange={(e) => updateVehicle(v.id, "departureTime", e.target.value)}
+        className={`${VEHICLE_DESKTOP_DEPARTURE_SELECT} ${fieldBorder(vehicleTouched && !v.departureTime.trim())}`}
+        aria-label="Departure time"
+      >
+        <option value="" disabled>
+          Select
+        </option>
+        {TIME_OPTIONS.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      {actionCell}
+    </>
+  );
+
+  if (v.editingExisting) {
+    return (
+      <>
+        <div className={VEHICLE_DESKTOP_EDITING_PANEL}>
+          <div className={`grid ${DESKTOP_VEHICLE_GRID_CLASS} ${VEHICLE_GRID_INNER}`}>
+            {fieldCells}
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  return <>{fieldCells}</>;
+}

--- a/app/ui/src/app/edit/components/VehicleSection.tsx
+++ b/app/ui/src/app/edit/components/VehicleSection.tsx
@@ -48,6 +48,7 @@ export default function VehicleSection({
       {/* Desktop: headers + vehicle rows in one grid */}
       <div className={`${VEHICLE_GRID_WRAP} ${DESKTOP_VEHICLE_GRID_CLASS}`}>
         <span className={VEHICLE_HEADER_CELL_START}>Name</span>
+        <span className={VEHICLE_HEADER_CELL_START}>Start Location</span>
         <span className={VEHICLE_HEADER_CELL_START}>Type</span>
         <span className={VEHICLE_HEADER_CELL_START}>Capacity Unit</span>
         <span className={VEHICLE_HEADER_CELL_START}>Capacity</span>
@@ -70,7 +71,7 @@ export default function VehicleSection({
       </div>
 
       {/* Mobile: stacked cards */}
-      <div className="md:hidden space-y-6">
+      <div className="lg:hidden space-y-6">
         {vehicles.map((v) => (
           <VehicleRow
             key={`vehicle-mobile-${v.id}`}

--- a/app/ui/src/app/edit/components/VehicleSection.tsx
+++ b/app/ui/src/app/edit/components/VehicleSection.tsx
@@ -89,7 +89,7 @@ export default function VehicleSection({
 
       {/* Add button */}
       <div className="mt-4">
-        <button
+        <button type="button"
           onClick={addVehicle}
           disabled={!addEnabled}
           className={addEnabled ? VEHICLE_ADD_ENABLED : VEHICLE_ADD_DISABLED}

--- a/app/ui/src/app/edit/components/VehicleSection.tsx
+++ b/app/ui/src/app/edit/components/VehicleSection.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+/**
+ * Vehicle grid: column headers plus one VehicleRow per vehicle, and an Add control below.
+ */
+
+import VehicleRow from "./VehicleRow";
+import type { VehicleRow as VehicleRowType } from "../types/delivery";
+import {
+  DESKTOP_VEHICLE_GRID_CLASS,
+  VEHICLE_ADD_DISABLED,
+  VEHICLE_ADD_ENABLED,
+  VEHICLE_GRID_WRAP,
+  VEHICLE_HEADER_CELL_CENTER,
+  VEHICLE_HEADER_CELL_START,
+  VEHICLE_SECTION_TITLE,
+} from "../formStyles";
+
+type VehicleSectionProps = {
+  vehicles: VehicleRowType[];
+  addVehicle: () => void;
+  updateVehicle: <K extends keyof VehicleRowType>(id: number, key: K, value: VehicleRowType[K]) => void;
+  deleteVehicle: (id: number) => void;
+  unlockVehicle: (id: number) => void;
+  confirmVehicle: (id: number) => void;
+  vehicleTouched: boolean;
+  allVehiclesLocked: boolean;
+  activeVehicleIsValid: boolean;
+};
+
+export default function VehicleSection({
+  vehicles,
+  addVehicle,
+  updateVehicle,
+  deleteVehicle,
+  unlockVehicle,
+  confirmVehicle,
+  vehicleTouched,
+  allVehiclesLocked,
+  activeVehicleIsValid,
+}: VehicleSectionProps) {
+  const addEnabled = allVehiclesLocked || activeVehicleIsValid;
+
+  return (
+    <section>
+      <h2 className={VEHICLE_SECTION_TITLE}>Enter vehicle details</h2>
+
+      {/* Desktop: headers + vehicle rows in one grid */}
+      <div className={`${VEHICLE_GRID_WRAP} ${DESKTOP_VEHICLE_GRID_CLASS}`}>
+        <span className={VEHICLE_HEADER_CELL_START}>Name</span>
+        <span className={VEHICLE_HEADER_CELL_START}>Type</span>
+        <span className={VEHICLE_HEADER_CELL_START}>Capacity Unit</span>
+        <span className={VEHICLE_HEADER_CELL_START}>Capacity</span>
+        <span className={VEHICLE_HEADER_CELL_CENTER}>Available</span>
+        <span className={VEHICLE_HEADER_CELL_START}>Departure Time</span>
+        <span />
+        {vehicles.map((v) => (
+          <VehicleRow
+            key={`vehicle-${v.id}`}
+            layout="desktop"
+            vehicle={v}
+            vehiclesCount={vehicles.length}
+            updateVehicle={updateVehicle}
+            deleteVehicle={deleteVehicle}
+            unlockVehicle={unlockVehicle}
+            confirmVehicle={confirmVehicle}
+            vehicleTouched={vehicleTouched}
+          />
+        ))}
+      </div>
+
+      {/* Mobile: stacked cards */}
+      <div className="md:hidden space-y-6">
+        {vehicles.map((v) => (
+          <VehicleRow
+            key={`vehicle-mobile-${v.id}`}
+            layout="mobile"
+            vehicle={v}
+            vehiclesCount={vehicles.length}
+            updateVehicle={updateVehicle}
+            deleteVehicle={deleteVehicle}
+            unlockVehicle={unlockVehicle}
+            confirmVehicle={confirmVehicle}
+            vehicleTouched={vehicleTouched}
+          />
+        ))}
+      </div>
+
+      {/* Add button */}
+      <div className="mt-4">
+        <button
+          onClick={addVehicle}
+          disabled={!addEnabled}
+          className={addEnabled ? VEHICLE_ADD_ENABLED : VEHICLE_ADD_DISABLED}
+        >
+          Add
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/app/ui/src/app/edit/components/VehicleSection.tsx
+++ b/app/ui/src/app/edit/components/VehicleSection.tsx
@@ -23,7 +23,7 @@ type VehicleSectionProps = {
   deleteVehicle: (id: number) => void;
   unlockVehicle: (id: number) => void;
   confirmVehicle: (id: number) => void;
-  vehicleTouched: boolean;
+  touchedIds: Set<number>;
   allVehiclesLocked: boolean;
   activeVehicleIsValid: boolean;
 };
@@ -35,7 +35,7 @@ export default function VehicleSection({
   deleteVehicle,
   unlockVehicle,
   confirmVehicle,
-  vehicleTouched,
+  touchedIds,
   allVehiclesLocked,
   activeVehicleIsValid,
 }: VehicleSectionProps) {
@@ -65,7 +65,7 @@ export default function VehicleSection({
             deleteVehicle={deleteVehicle}
             unlockVehicle={unlockVehicle}
             confirmVehicle={confirmVehicle}
-            vehicleTouched={vehicleTouched}
+            vehicleTouched={touchedIds.has(v.id)}
           />
         ))}
       </div>
@@ -82,7 +82,7 @@ export default function VehicleSection({
             deleteVehicle={deleteVehicle}
             unlockVehicle={unlockVehicle}
             confirmVehicle={confirmVehicle}
-            vehicleTouched={vehicleTouched}
+            vehicleTouched={touchedIds.has(v.id)}
           />
         ))}
       </div>

--- a/app/ui/src/app/edit/constants/timeOptions.ts
+++ b/app/ui/src/app/edit/constants/timeOptions.ts
@@ -1,0 +1,13 @@
+/** 12-hour clock labels in 15-minute steps (e.g. "1:00 AM") for time-of-day pickers. */
+export const TIME_OPTIONS: string[] = (() => {
+  const options: string[] = [];
+  for (let h = 0; h < 24; h++) {
+    for (let m = 0; m < 60; m += 15) {
+      const hour12 = h % 12 || 12;
+      const ampm = h < 12 ? "AM" : "PM";
+      const minStr = m.toString().padStart(2, "0");
+      options.push(`${hour12}:${minStr} ${ampm}`);
+    }
+  }
+  return options;
+})();

--- a/app/ui/src/app/edit/formStyles.ts
+++ b/app/ui/src/app/edit/formStyles.ts
@@ -1,4 +1,4 @@
-﻿/**
+﻿﻿/**
  * Shared Tailwind class tokens for the delivery edit form. Prefer complete string literals so
  * Tailwind's scanner includes all utilities. Vehicle editing panel constants compose
  * `EDITING_EXISTING_HIGHLIGHT` at module load (still scanned in this file).
@@ -26,14 +26,13 @@ export function fieldBorder(invalid: boolean, mode: "desktop" | "mobile" = "desk
     if (invalid) {
       return "border-red-500 focus:border-red-500";
     }
-    return "focus:border-zinc-400";
+    return "border-zinc-300 focus:border-zinc-400";
   }
   if (invalid) {
     return "border-red-500 focus:border-red-500";
   }
   return "border-zinc-300 focus:border-zinc-500";
 }
-
 /** Editing an existing unlocked row G�� same ring, border, and fill on address + vehicle surfaces. */
 export const EDITING_EXISTING_HIGHLIGHT =
   "border border-blue-200 bg-blue-50 ring-2 ring-blue-200";

--- a/app/ui/src/app/edit/formStyles.ts
+++ b/app/ui/src/app/edit/formStyles.ts
@@ -56,10 +56,13 @@ export const ICON_BUTTON_9_DANGER =
 
 /** Name/type/measure/departure flex; capacity + Available (No/Yes pill) stay fixed width below xl. */
 export const DESKTOP_VEHICLE_GRID_CLASS =
-  "md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_88px_112px_minmax(0,1fr)_auto] xl:grid-cols-[1fr_1fr_1fr_144px_112px_144px_1fr]";
+  "lg:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)_minmax(0,1fr)_minmax(0,1fr)_72px_108px_minmax(0,1fr)_auto] xl:grid-cols-[1fr_1.5fr_1fr_1fr_112px_112px_140px_auto]";
 
 export const VEHICLE_DESKTOP_INPUT =
   "h-11 bg-white rounded-md border px-3 xl:px-4 text-sm xl:text-base text-black focus:outline-none min-w-0";
+
+export const VEHICLE_DESKTOP_WIDE_INPUT =
+  "h-11 w-full bg-white rounded-md border px-3 xl:px-4 text-sm xl:text-base text-black focus:outline-none min-w-0";
 
 export const VEHICLE_DESKTOP_SELECT =
   "h-11 w-full bg-white rounded-md border px-3 xl:px-4 text-sm xl:text-base text-black focus:outline-none cursor-pointer select-chevron capitalize min-w-0";
@@ -124,7 +127,7 @@ export const VEHICLE_HEADER_CELL_START =
 export const VEHICLE_HEADER_CELL_CENTER =
   "text-xs lg:text-sm xl:text-base text-black justify-self-center";
 
-export const VEHICLE_GRID_WRAP = "hidden md:grid gap-x-3 xl:gap-x-4 gap-y-3 items-center";
+export const VEHICLE_GRID_WRAP = "hidden lg:grid gap-x-3 xl:gap-x-4 gap-y-3 items-center";
 
 export const VEHICLE_GRID_INNER = "gap-x-3 xl:gap-x-4 items-center";
 

--- a/app/ui/src/app/edit/formStyles.ts
+++ b/app/ui/src/app/edit/formStyles.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Shared Tailwind class tokens for the delivery edit form. Prefer complete string literals so
  * Tailwind's scanner includes all utilities. Vehicle editing panel constants compose
  * `EDITING_EXISTING_HIGHLIGHT` at module load (still scanned in this file).

--- a/app/ui/src/app/edit/formStyles.ts
+++ b/app/ui/src/app/edit/formStyles.ts
@@ -20,7 +20,7 @@ export const NAVBAR_OUTLINE_PILL =
 export const NAVBAR_SOLID_PILL =
   "h-11 px-6 rounded-full bg-zinc-300 text-black text-base font-normal hover:bg-zinc-400 transition-colors cursor-pointer";
 
-/** Invalid vs valid focus/border G�� desktop inputs (Address desktop + all Vehicle fields). */
+/** Invalid vs valid focus/border desktop inputs (Address desktop + all Vehicle fields). */
 export function fieldBorder(invalid: boolean, mode: "desktop" | "mobile" = "desktop"): string {
   if (mode === "mobile") {
     if (invalid) {
@@ -33,7 +33,7 @@ export function fieldBorder(invalid: boolean, mode: "desktop" | "mobile" = "desk
   }
   return "border-zinc-300 focus:border-zinc-500";
 }
-/** Editing an existing unlocked row G�� same ring, border, and fill on address + vehicle surfaces. */
+/** Editing an existing unlocked row, same ring, border, and fill on address + vehicle surfaces. */
 export const EDITING_EXISTING_HIGHLIGHT =
   "border border-blue-200 bg-blue-50 ring-2 ring-blue-200";
 
@@ -97,7 +97,7 @@ export const VEHICLE_AVAILABLE_SEGMENT_BUTTON =
 export const VEHICLE_AVAILABLE_SEGMENT_READ_ONLY_SPAN =
   "relative z-10 flex-1 min-w-0 text-center text-xs font-medium text-black py-1.5 bg-transparent";
 
-/** Locked summary cells G�� w-full fills fixed-width grid columns and is harmless in fr columns. */
+/** Locked summary cells w-full fills fixed-width grid columns and is harmless in fr columns. */
 export const VEHICLE_LOCKED_CELL =
   "h-11 w-full bg-zinc-300 rounded-md flex items-center px-3 xl:px-4";
 

--- a/app/ui/src/app/edit/formStyles.ts
+++ b/app/ui/src/app/edit/formStyles.ts
@@ -1,4 +1,4 @@
-/**
+ï»¿/**
  * Shared Tailwind class tokens for the delivery edit form. Prefer complete string literals so
  * Tailwind's scanner includes all utilities. Vehicle editing panel constants compose
  * `EDITING_EXISTING_HIGHLIGHT` at module load (still scanned in this file).
@@ -20,7 +20,7 @@ export const NAVBAR_OUTLINE_PILL =
 export const NAVBAR_SOLID_PILL =
   "h-11 px-6 rounded-full bg-zinc-300 text-black text-base font-normal hover:bg-zinc-400 transition-colors cursor-pointer";
 
-/** Invalid vs valid focus/border GÇö desktop inputs (Address desktop + all Vehicle fields). */
+/** Invalid vs valid focus/border Gï¿½ï¿½ desktop inputs (Address desktop + all Vehicle fields). */
 export function fieldBorder(invalid: boolean, mode: "desktop" | "mobile" = "desktop"): string {
   if (mode === "mobile") {
     if (invalid) {
@@ -34,7 +34,7 @@ export function fieldBorder(invalid: boolean, mode: "desktop" | "mobile" = "desk
   return "border-zinc-300 focus:border-zinc-500";
 }
 
-/** Editing an existing unlocked row GÇö same ring, border, and fill on address + vehicle surfaces. */
+/** Editing an existing unlocked row Gï¿½ï¿½ same ring, border, and fill on address + vehicle surfaces. */
 export const EDITING_EXISTING_HIGHLIGHT =
   "border border-blue-200 bg-blue-50 ring-2 ring-blue-200";
 
@@ -95,7 +95,7 @@ export const VEHICLE_AVAILABLE_SEGMENT_BUTTON =
 export const VEHICLE_AVAILABLE_SEGMENT_READ_ONLY_SPAN =
   "relative z-10 flex-1 min-w-0 text-center text-xs font-medium text-black py-1.5 bg-transparent";
 
-/** Locked summary cells GÇö w-full fills fixed-width grid columns and is harmless in fr columns. */
+/** Locked summary cells Gï¿½ï¿½ w-full fills fixed-width grid columns and is harmless in fr columns. */
 export const VEHICLE_LOCKED_CELL =
   "h-11 w-full bg-zinc-300 rounded-md flex items-center px-3 xl:px-4";
 

--- a/app/ui/src/app/edit/formStyles.ts
+++ b/app/ui/src/app/edit/formStyles.ts
@@ -1,4 +1,4 @@
-﻿﻿/**
+﻿/**
  * Shared Tailwind class tokens for the delivery edit form. Prefer complete string literals so
  * Tailwind's scanner includes all utilities. Vehicle editing panel constants compose
  * `EDITING_EXISTING_HIGHLIGHT` at module load (still scanned in this file).

--- a/app/ui/src/app/edit/formStyles.ts
+++ b/app/ui/src/app/edit/formStyles.ts
@@ -19,3 +19,120 @@ export const NAVBAR_OUTLINE_PILL =
 
 export const NAVBAR_SOLID_PILL =
   "h-11 px-6 rounded-full bg-zinc-300 text-black text-base font-normal hover:bg-zinc-400 transition-colors cursor-pointer";
+
+/** Invalid vs valid focus/border GÇö desktop inputs (Address desktop + all Vehicle fields). */
+export function fieldBorder(invalid: boolean, mode: "desktop" | "mobile" = "desktop"): string {
+  if (mode === "mobile") {
+    if (invalid) {
+      return "border-red-500 focus:border-red-500";
+    }
+    return "focus:border-zinc-400";
+  }
+  if (invalid) {
+    return "border-red-500 focus:border-red-500";
+  }
+  return "border-zinc-300 focus:border-zinc-500";
+}
+
+/** Editing an existing unlocked row GÇö same ring, border, and fill on address + vehicle surfaces. */
+export const EDITING_EXISTING_HIGHLIGHT =
+  "border border-blue-200 bg-blue-50 ring-2 ring-blue-200";
+
+/** Composed at module load from EDITING_EXISTING_HIGHLIGHT (Tailwind still scans the template). */
+export const VEHICLE_DESKTOP_EDITING_PANEL =
+  `col-span-full rounded-lg p-2 ${EDITING_EXISTING_HIGHLIGHT}`;
+
+/** Composed at module load from EDITING_EXISTING_HIGHLIGHT (Tailwind still scans the template). */
+export const VEHICLE_MOBILE_EDITING_CARD =
+  `rounded-xl p-4 space-y-3 ${EDITING_EXISTING_HIGHLIGHT}`;
+
+export const MOBILE_FIELD_LABEL = "text-sm text-black block mb-1";
+
+export const ICON_BUTTON_9 =
+  "w-9 h-9 rounded-md border border-zinc-300 flex items-center justify-center text-black hover:bg-zinc-100 transition-colors cursor-pointer";
+
+export const ICON_BUTTON_9_DANGER =
+  "w-9 h-9 rounded-md border border-zinc-300 flex items-center justify-center text-black hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors cursor-pointer disabled:opacity-0 disabled:pointer-events-none";
+
+/** Name/type/measure/departure flex; capacity + Available (No/Yes pill) stay fixed width below xl. */
+export const DESKTOP_VEHICLE_GRID_CLASS =
+  "md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_88px_112px_minmax(0,1fr)_auto] xl:grid-cols-[1fr_1fr_1fr_144px_112px_144px_1fr]";
+
+export const VEHICLE_DESKTOP_INPUT =
+  "h-11 bg-white rounded-md border px-3 xl:px-4 text-sm xl:text-base text-black focus:outline-none min-w-0";
+
+export const VEHICLE_DESKTOP_SELECT =
+  "h-11 w-full bg-white rounded-md border px-3 xl:px-4 text-sm xl:text-base text-black focus:outline-none cursor-pointer select-chevron capitalize min-w-0";
+
+export const VEHICLE_DESKTOP_NUMBER_INPUT =
+  "h-11 w-full min-w-0 bg-white rounded-md border px-3 xl:px-4 text-sm xl:text-base text-black focus:outline-none";
+
+export const VEHICLE_DESKTOP_DEPARTURE_SELECT =
+  "h-11 w-full bg-white rounded-md border px-3 xl:px-4 text-sm xl:text-base text-black focus:outline-none cursor-pointer select-chevron min-w-0";
+
+export const VEHICLE_MOBILE_INPUT =
+  "h-11 w-full rounded-md border px-4 text-base text-black focus:outline-none min-w-0";
+
+export const VEHICLE_MOBILE_SELECT =
+  "h-11 w-full rounded-md border px-4 text-base text-black focus:outline-none cursor-pointer capitalize min-w-0 select-chevron";
+
+/** Segmented No / Yes for vehicle Available: sliding rounded thumb + transparent labels (desktop + mobile). */
+export const VEHICLE_AVAILABLE_SEGMENTED_TRACK =
+  "relative inline-flex w-full min-w-0 max-w-full shrink-0 rounded-full border border-zinc-300 bg-white p-0.5 overflow-hidden";
+
+export const VEHICLE_AVAILABLE_SEGMENT_THUMB =
+  "absolute top-0.5 bottom-0.5 left-0.5 w-[calc(50%-0.125rem)] rounded-full border border-zinc-300 bg-zinc-200 shadow-sm pointer-events-none transition-transform duration-200 ease-out motion-reduce:transition-none";
+
+export const VEHICLE_AVAILABLE_SEGMENT_THUMB_NO = "translate-x-0";
+
+export const VEHICLE_AVAILABLE_SEGMENT_THUMB_YES = "translate-x-full";
+
+export const VEHICLE_AVAILABLE_SEGMENT_ROW = "relative z-10 flex w-full";
+
+export const VEHICLE_AVAILABLE_SEGMENT_BUTTON =
+  "relative z-10 flex-1 min-w-0 text-center text-xs font-medium text-black py-1.5 bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-1 cursor-pointer";
+
+export const VEHICLE_AVAILABLE_SEGMENT_READ_ONLY_SPAN =
+  "relative z-10 flex-1 min-w-0 text-center text-xs font-medium text-black py-1.5 bg-transparent";
+
+/** Locked summary cells GÇö w-full fills fixed-width grid columns and is harmless in fr columns. */
+export const VEHICLE_LOCKED_CELL =
+  "h-11 w-full bg-zinc-300 rounded-md flex items-center px-3 xl:px-4";
+
+export const VEHICLE_CONFIRM_DESKTOP =
+  "h-9 px-3 rounded-md border border-blue-300 bg-blue-100 text-blue-800 text-sm font-medium hover:bg-blue-200 transition-colors cursor-pointer";
+
+export const VEHICLE_MOBILE_CARD = "rounded-xl border border-zinc-200 p-4 space-y-3";
+
+export const VEHICLE_PILL_FULL_DANGER =
+  "w-full h-11 rounded-full border border-zinc-300 text-black text-base font-normal hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors cursor-pointer disabled:opacity-0 disabled:pointer-events-none";
+
+export const VEHICLE_PILL_FULL_PRIMARY =
+  "w-full h-11 rounded-full border border-blue-300 bg-blue-100 text-blue-800 text-base font-medium hover:bg-blue-200 transition-colors cursor-pointer";
+
+export const VEHICLE_PILL_HALF =
+  "flex-1 h-11 rounded-full border border-zinc-300 text-black text-base font-normal hover:bg-zinc-50 transition-colors cursor-pointer";
+
+export const VEHICLE_PILL_HALF_DANGER =
+  "flex-1 h-11 rounded-full border border-zinc-300 text-black text-base font-normal hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors cursor-pointer disabled:opacity-0 disabled:pointer-events-none";
+
+export const VEHICLE_SECTION_TITLE = "text-base font-semibold text-black mb-4";
+
+export const VEHICLE_HEADER_CELL_START =
+  "text-xs lg:text-sm xl:text-base text-black justify-self-start";
+
+export const VEHICLE_HEADER_CELL_CENTER =
+  "text-xs lg:text-sm xl:text-base text-black justify-self-center";
+
+export const VEHICLE_GRID_WRAP = "hidden md:grid gap-x-3 xl:gap-x-4 gap-y-3 items-center";
+
+export const VEHICLE_GRID_INNER = "gap-x-3 xl:gap-x-4 items-center";
+
+export const VEHICLE_ADD_ENABLED =
+  "w-full md:w-auto h-11 px-6 rounded-full border text-base font-normal transition-colors border-zinc-300 text-black hover:bg-zinc-50 cursor-pointer";
+
+export const VEHICLE_ADD_DISABLED =
+  "w-full md:w-auto h-11 px-6 rounded-full border text-base font-normal transition-colors border-zinc-200 text-zinc-400 cursor-not-allowed";
+
+/** Fixed wrapper width for the AvailableSegmented control (desktop + mobile). */
+export const VEHICLE_AVAILABLE_SEGMENT_WRAPPER = "w-[7.5rem] shrink-0";

--- a/app/ui/src/app/edit/formStyles.ts
+++ b/app/ui/src/app/edit/formStyles.ts
@@ -138,3 +138,27 @@ export const VEHICLE_ADD_DISABLED =
 
 /** Fixed wrapper width for the AvailableSegmented control (desktop + mobile). */
 export const VEHICLE_AVAILABLE_SEGMENT_WRAPPER = "w-[7.5rem] shrink-0";
+
+/** Text span inside a mobile locked field cell. */
+export const VEHICLE_MOBILE_LOCKED_TEXT = "text-base text-black truncate";
+
+/** Text span inside a desktop locked field cell. */
+export const VEHICLE_DESKTOP_LOCKED_TEXT = "text-sm xl:text-base text-black truncate";
+
+/** Wrapper div for the AvailableSegmented control in the desktop grid (locked + editing). */
+export const VEHICLE_DESKTOP_AVAILABLE_CELL = "flex items-center justify-center h-11 min-w-0 px-0.5";
+
+/** Action button container in the desktop grid (locked + editing). */
+export const VEHICLE_DESKTOP_ACTION_CELL = "flex items-center gap-1";
+
+/** Row wrapping the Available label and segmented control in mobile cards. */
+export const VEHICLE_MOBILE_AVAILABLE_ROW = "flex items-center justify-between gap-3 pt-1";
+
+/** "Available" label text in mobile cards. */
+export const VEHICLE_MOBILE_AVAILABLE_LABEL = "text-sm text-black";
+
+/** Button row at the bottom of a mobile locked card (Edit + Delete). */
+export const VEHICLE_MOBILE_LOCKED_ACTIONS = "flex gap-2 pt-2";
+
+/** Confirm + Delete column at the bottom of a mobile editing-existing card. */
+export const VEHICLE_MOBILE_EDITING_ACTIONS = "flex flex-col gap-2 pt-2";

--- a/app/ui/src/app/edit/hooks/useVehicles.ts
+++ b/app/ui/src/app/edit/hooks/useVehicles.ts
@@ -13,6 +13,7 @@ export function useVehicles() {
       locked: false,
       editingExisting: false,
       name: "",
+      startLocation: "",
       type: "",
       capacityUnit: "",
       capacity: 0,
@@ -28,6 +29,7 @@ export function useVehicles() {
   const activeVehicleIsValid =
     !!activeVehicle &&
     activeVehicle.name.trim() !== "" &&
+    activeVehicle.startLocation.trim() !== "" &&
     activeVehicle.type !== "" &&
     activeVehicle.capacityUnit !== "" &&
     activeVehicle.capacity > 0 &&
@@ -56,6 +58,7 @@ export function useVehicles() {
       const isValid =
         !!active &&
         active.name.trim() !== "" &&
+        active.startLocation.trim() !== "" &&
         active.type !== "" &&
         active.capacityUnit !== "" &&
         active.capacity > 0 &&
@@ -76,6 +79,7 @@ export function useVehicles() {
           locked: false,
           editingExisting: false,
           name: "",
+          startLocation: "",
           type: "",
           capacityUnit: "",
           capacity: 0,
@@ -108,6 +112,7 @@ export function useVehicles() {
       if (!v) return prev;
       const valid =
         v.name.trim() !== "" &&
+        v.startLocation.trim() !== "" &&
         v.type !== "" &&
         v.capacityUnit !== "" &&
         v.capacity > 0 &&

--- a/app/ui/src/app/edit/hooks/useVehicles.ts
+++ b/app/ui/src/app/edit/hooks/useVehicles.ts
@@ -1,0 +1,136 @@
+/**
+ * Vehicle list state: same lock/edit/confirm pattern as addresses, without pagination.
+ */
+
+import { useState, useCallback } from "react";
+import type { VehicleRow } from "../types/delivery";
+
+export function useVehicles() {
+  // Start with one empty editable row; IDs increase as rows are added.
+  const [vehicles, setVehicles] = useState<VehicleRow[]>([
+    {
+      id: 1,
+      locked: false,
+      editingExisting: false,
+      name: "",
+      type: "",
+      capacityUnit: "",
+      capacity: 0,
+      available: true,
+      departureTime: "",
+    },
+  ]);
+
+  const [vehicleTouched, setVehicleTouched] = useState(false);
+
+  // Unlocked row must be valid before adding another vehicle.
+  const activeVehicle = vehicles.find((v) => !v.locked);
+  const activeVehicleIsValid =
+    !!activeVehicle &&
+    activeVehicle.name.trim() !== "" &&
+    activeVehicle.type !== "" &&
+    activeVehicle.capacityUnit !== "" &&
+    activeVehicle.capacity > 0 &&
+    activeVehicle.departureTime.trim() !== "";
+
+  const allVehiclesLocked = vehicles.length > 0 && vehicles.every((v) => v.locked);
+
+  // Patch a single field on one vehicle row.
+  const updateVehicle = useCallback(<K extends keyof VehicleRow>(
+    id: number,
+    key: K,
+    value: VehicleRow[K]
+  ) => {
+    setVehicles((prev) =>
+      prev.map((v) => (v.id === id ? { ...v, [key]: value } : v))
+    );
+  }, []);
+
+  // Lock the open row if needed, then append a fresh editable vehicle.
+  // All logic runs inside the functional updater so the ID is always computed
+  // from the latest state and the callback never needs to be recreated.
+  const addVehicle = useCallback(() => {
+    setVehicles((prev) => {
+      const active = prev.find((v) => !v.locked);
+      const allLocked = prev.length > 0 && prev.every((v) => v.locked);
+      const isValid =
+        !!active &&
+        active.name.trim() !== "" &&
+        active.type !== "" &&
+        active.capacityUnit !== "" &&
+        active.capacity > 0 &&
+        active.departureTime.trim() !== "";
+
+      if (!allLocked && !isValid) {
+        setVehicleTouched(true);
+        return prev;
+      }
+
+      setVehicleTouched(false);
+      const newId = prev.reduce((max, v) => Math.max(max, v.id), 0) + 1;
+
+      return [
+        ...prev.map((v) => (v.locked ? v : { ...v, locked: true, editingExisting: false })),
+        {
+          id: newId,
+          locked: false,
+          editingExisting: false,
+          name: "",
+          type: "",
+          capacityUnit: "",
+          capacity: 0,
+          available: true,
+          departureTime: "",
+        },
+      ];
+    });
+  }, []);
+
+  // Always keep at least one vehicle in the list.
+  const deleteVehicle = useCallback((id: number) => {
+    setVehicles((prev) => {
+      if (prev.length <= 1) return prev;
+      return prev.filter((v) => v.id !== id);
+    });
+  }, []);
+
+  // Edit mode for a locked row: full-width blue panel with Confirm.
+  const unlockVehicle = useCallback((id: number) => {
+    setVehicles((prev) =>
+      prev.map((v) => (v.id === id ? { ...v, locked: false, editingExisting: true } : v))
+    );
+  }, []);
+
+  // Validate required fields, then collapse the row back to the gray summary cells.
+  const confirmVehicle = useCallback((id: number) => {
+    setVehicles((prev) => {
+      const v = prev.find((x) => x.id === id);
+      if (!v) return prev;
+      const valid =
+        v.name.trim() !== "" &&
+        v.type !== "" &&
+        v.capacityUnit !== "" &&
+        v.capacity > 0 &&
+        v.departureTime.trim() !== "";
+      if (!valid) {
+        setVehicleTouched(true);
+        return prev;
+      }
+      setVehicleTouched(false);
+      return prev.map((x) => (x.id === id ? { ...x, locked: true, editingExisting: false } : x));
+    });
+  }, []);
+
+  // Public API for the vehicle grid.
+  return {
+    vehicles,
+    updateVehicle,
+    addVehicle,
+    deleteVehicle,
+    unlockVehicle,
+    confirmVehicle,
+    vehicleTouched,
+    activeVehicleIsValid,
+    allVehiclesLocked,
+  };
+}

--- a/app/ui/src/app/edit/hooks/useVehicles.ts
+++ b/app/ui/src/app/edit/hooks/useVehicles.ts
@@ -2,11 +2,21 @@
  * Vehicle list state: same lock/edit/confirm pattern as addresses, without pagination.
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import type { VehicleRow } from "../types/delivery";
 
+function isVehicleValid(v: VehicleRow): boolean {
+  return (
+    v.name.trim() !== "" &&
+    (v.startLocation ?? "").trim() !== "" &&
+    v.type !== "" &&
+    v.capacityUnit !== "" &&
+    v.capacity > 0 &&
+    v.departureTime.trim() !== ""
+  );
+}
+
 export function useVehicles() {
-  // Start with one empty editable row; IDs increase as rows are added.
   const [vehicles, setVehicles] = useState<VehicleRow[]>([
     {
       id: 1,
@@ -22,22 +32,17 @@ export function useVehicles() {
     },
   ]);
 
-  const [vehicleTouched, setVehicleTouched] = useState(false);
+  // Always reflects the latest vehicles state without creating stale closures.
+  const vehiclesRef = useRef(vehicles);
+  vehiclesRef.current = vehicles;
 
-  // Unlocked row must be valid before adding another vehicle.
+  // Set of vehicle IDs whose fields should show validation errors.
+  const [touchedIds, setTouchedIds] = useState<Set<number>>(new Set());
+
   const activeVehicle = vehicles.find((v) => !v.locked);
-  const activeVehicleIsValid =
-    !!activeVehicle &&
-    activeVehicle.name.trim() !== "" &&
-    activeVehicle.startLocation.trim() !== "" &&
-    activeVehicle.type !== "" &&
-    activeVehicle.capacityUnit !== "" &&
-    activeVehicle.capacity > 0 &&
-    activeVehicle.departureTime.trim() !== "";
-
+  const activeVehicleIsValid = !!activeVehicle && isVehicleValid(activeVehicle);
   const allVehiclesLocked = vehicles.length > 0 && vehicles.every((v) => v.locked);
 
-  // Patch a single field on one vehicle row.
   const updateVehicle = useCallback(<K extends keyof VehicleRow>(
     id: number,
     key: K,
@@ -48,46 +53,33 @@ export function useVehicles() {
     );
   }, []);
 
-  // Lock the open row if needed, then append a fresh editable vehicle.
-  // All logic runs inside the functional updater so the ID is always computed
-  // from the latest state and the callback never needs to be recreated.
   const addVehicle = useCallback(() => {
-    setVehicles((prev) => {
-      const active = prev.find((v) => !v.locked);
-      const allLocked = prev.length > 0 && prev.every((v) => v.locked);
-      const isValid =
-        !!active &&
-        active.name.trim() !== "" &&
-        active.startLocation.trim() !== "" &&
-        active.type !== "" &&
-        active.capacityUnit !== "" &&
-        active.capacity > 0 &&
-        active.departureTime.trim() !== "";
+    const prev = vehiclesRef.current;
+    const active = prev.find((v) => !v.locked);
+    const allLocked = prev.length > 0 && prev.every((v) => v.locked);
 
-      if (!allLocked && !isValid) {
-        setVehicleTouched(true);
-        return prev;
-      }
+    if (!allLocked && !(active && isVehicleValid(active))) {
+      if (active) setTouchedIds((t) => new Set([...t, active.id]));
+      return;
+    }
 
-      setVehicleTouched(false);
-      const newId = prev.reduce((max, v) => Math.max(max, v.id), 0) + 1;
-
-      return [
-        ...prev.map((v) => (v.locked ? v : { ...v, locked: true, editingExisting: false })),
-        {
-          id: newId,
-          locked: false,
-          editingExisting: false,
-          name: "",
-          startLocation: "",
-          type: "",
-          capacityUnit: "",
-          capacity: 0,
-          available: true,
-          departureTime: "",
-        },
-      ];
-    });
+    setTouchedIds(new Set());
+    const newId = prev.reduce((max, v) => Math.max(max, v.id), 0) + 1;
+    setVehicles([
+      ...prev.map((v) => (v.locked ? v : { ...v, locked: true, editingExisting: false })),
+      {
+        id: newId,
+        locked: false,
+        editingExisting: false,
+        name: "",
+        startLocation: "",
+        type: "",
+        capacityUnit: "",
+        capacity: 0,
+        available: true,
+        departureTime: "",
+      },
+    ]);
   }, []);
 
   // Always keep at least one vehicle in the list.
@@ -96,37 +88,45 @@ export function useVehicles() {
       if (prev.length <= 1) return prev;
       return prev.filter((v) => v.id !== id);
     });
+    setTouchedIds((t) => {
+      const next = new Set(t);
+      next.delete(id);
+      return next;
+    });
   }, []);
 
-  // Edit mode for a locked row: full-width blue panel with Confirm.
+  // Edit mode for a locked row: clear any stale validation state for the row.
   const unlockVehicle = useCallback((id: number) => {
     setVehicles((prev) =>
       prev.map((v) => (v.id === id ? { ...v, locked: false, editingExisting: true } : v))
     );
-  }, []);
-
-  // Validate required fields, then collapse the row back to the gray summary cells.
-  const confirmVehicle = useCallback((id: number) => {
-    setVehicles((prev) => {
-      const v = prev.find((x) => x.id === id);
-      if (!v) return prev;
-      const valid =
-        v.name.trim() !== "" &&
-        v.startLocation.trim() !== "" &&
-        v.type !== "" &&
-        v.capacityUnit !== "" &&
-        v.capacity > 0 &&
-        v.departureTime.trim() !== "";
-      if (!valid) {
-        setVehicleTouched(true);
-        return prev;
-      }
-      setVehicleTouched(false);
-      return prev.map((x) => (x.id === id ? { ...x, locked: true, editingExisting: false } : x));
+    setTouchedIds((t) => {
+      const next = new Set(t);
+      next.delete(id);
+      return next;
     });
   }, []);
 
-  // Public API for the vehicle grid.
+  // Validate required fields; on failure mark only this row, on success lock it.
+  const confirmVehicle = useCallback((id: number) => {
+    const v = vehiclesRef.current.find((x) => x.id === id);
+    if (!v) return;
+
+    if (!isVehicleValid(v)) {
+      setTouchedIds((t) => new Set([...t, id]));
+      return;
+    }
+
+    setTouchedIds((t) => {
+      const next = new Set(t);
+      next.delete(id);
+      return next;
+    });
+    setVehicles((prev) =>
+      prev.map((x) => (x.id === id ? { ...x, locked: true, editingExisting: false } : x))
+    );
+  }, []);
+
   return {
     vehicles,
     updateVehicle,
@@ -134,7 +134,7 @@ export function useVehicles() {
     deleteVehicle,
     unlockVehicle,
     confirmVehicle,
-    vehicleTouched,
+    touchedIds,
     activeVehicleIsValid,
     allVehiclesLocked,
   };

--- a/app/ui/src/app/edit/hooks/useVehicles.ts
+++ b/app/ui/src/app/edit/hooks/useVehicles.ts
@@ -2,7 +2,7 @@
  * Vehicle list state: same lock/edit/confirm pattern as addresses, without pagination.
  */
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import type { VehicleRow } from "../types/delivery";
 
 function isVehicleValid(v: VehicleRow): boolean {
@@ -32,9 +32,11 @@ export function useVehicles() {
     },
   ]);
 
-  // Always reflects the latest vehicles state without creating stale closures.
+  // Latest vehicles for handlers (ref sync must not run during render — react-hooks/refs).
   const vehiclesRef = useRef(vehicles);
-  vehiclesRef.current = vehicles;
+  useEffect(() => {
+    vehiclesRef.current = vehicles;
+  }, [vehicles]);
 
   // Set of vehicle IDs whose fields should show validation errors.
   const [touchedIds, setTouchedIds] = useState<Set<number>>(new Set());

--- a/app/ui/src/app/edit/page.tsx
+++ b/app/ui/src/app/edit/page.tsx
@@ -1,11 +1,23 @@
 "use client";
 
+/**
+ * Delivery edit screen: wires vehicle state into the vehicle section.
+ */
+
 import Navbar from "./components/Navbar";
+import VehicleSection from "./components/VehicleSection";
+import { useVehicles } from "./hooks/useVehicles";
 
 export default function Page() {
+  const vehicleState = useVehicles();
+
   return (
-    <div className="min-h-screen bg-white font-manrope">
+    <div className="min-h-screen bg-white font-sans-manrope">
       <Navbar />
+
+      <main className="px-4 sm:px-6 md:px-8 py-6 md:py-8 space-y-8 md:space-y-10 max-w-[1480px] mx-auto">
+        <VehicleSection {...vehicleState} />
+      </main>
     </div>
   );
 }

--- a/app/ui/src/app/edit/types/delivery.ts
+++ b/app/ui/src/app/edit/types/delivery.ts
@@ -10,6 +10,7 @@ export type VehicleRow = {
   locked: boolean;
   editingExisting: boolean;
   name: string;
+  startLocation: string;
   /** Empty string represents "not yet selected". */
   type: VehicleType | "";
   /** Empty string represents "not yet selected". */

--- a/app/ui/src/app/edit/types/delivery.ts
+++ b/app/ui/src/app/edit/types/delivery.ts
@@ -1,0 +1,20 @@
+/** Vehicle type options. */
+export type VehicleType = "truck" | "car" | "bicycle";
+
+/** Unit of measurement for vehicle capacity. */
+export type CapacityUnit = "units" | "lbs" | "kgs" | "volume";
+
+/** One fleet vehicle row: identity, capacity, availability, and departure time. */
+export type VehicleRow = {
+  id: number;
+  locked: boolean;
+  editingExisting: boolean;
+  name: string;
+  /** Empty string represents "not yet selected". */
+  type: VehicleType | "";
+  /** Empty string represents "not yet selected". */
+  capacityUnit: CapacityUnit | "";
+  capacity: number;
+  available: boolean;
+  departureTime: string;
+};

--- a/app/ui/src/app/edit/utils/deliveryHelpers.ts
+++ b/app/ui/src/app/edit/utils/deliveryHelpers.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared helpers for delivery edit flows (formatting, validation, etc.).
+ * Place cross-cutting utilities here so hooks and components stay thin.
+ */
+
+/** Capitalise the first letter of a string. Safe on empty strings. */
+export function capitalize(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : "";
+}


### PR DESCRIPTION
Closes #44 and #47

## Vehicle Details (Static UI + CRUD)

### Summary
Implements the "Enter vehicle details" section, allowing dispatchers to input and manage the fleet available for the day's routing.

### What's included
- **Grid layout:** Responsive vehicle row grid for desktop, stacked card layout for mobile
- **Fields per row:** Name (text), Type (dropdown), Capacity measure (dropdown), Capacity (number), Available (segmented Yes/No toggle), Departure time (time select)
- **Add:** Clicking the Add button pushes a new empty vehicle object into state, rendering a new editable row
- **Delete:** Clicking the Delete button removes that specific vehicle from state
- **Edit/Confirm flow:** Existing rows lock into a read-only state and can be unlocked for editing, then confirmed back to locked
- **Page:** Updated to render the navbar and the vehicle details section

### Two Seperate Designs
- Mobile version supports smaller devices
- Desktop versions supports larger screen sizes

### Design decisions
- Vehicle rows use a locked/unlocked pattern — locked rows display as read-only grid cells, unlocked rows show editable inputs
- The Available field uses a custom segmented radio group with keyboard arrow key support rather than a plain checkbox
- Shared style constants from `formStyles` are used throughout for consistency
- Time options are sourced from a shared `timeOptions` constant
- Desktop editing of an existing row renders a full-width highlighted panel to visually distinguish it from inline new rows
- Delete is disabled when only one vehicle remains

### PR chain
- PR 1: Navigation header → `main`
- **PR 2: Vehicle details → `feature/navigation-header` (this PR)**
- PR 3: Addresses → `feature/vehicle-details`