### PR TITLE
Draggable Markers (Toggle Action #2) - V1

### DIFF
--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -11,6 +11,13 @@ const POLYLINE_COLOR = "#2563eb"; // Blue path per route (single mock route)
 
 type MapComponentProps = {
   routes: Route[];
+  isEditMode: boolean; // defining the props that map component receives from parent (page.tsx)
+  onUpdateStopCoordinates: (
+    routeId: string,
+    stopId: string,
+    lat: number,
+    lng: number
+  ) => void;
 };
 
 // Created a helper component (AdvancedMarkers), which creates the pins and attaches them to the map (it receives two things: google map instance and list of routes)
@@ -60,7 +67,11 @@ function AdvancedMarkers({ map, routes }: { map: google.maps.Map | null; routes:
   return null;
 }
 
-export default function MapComponent({ routes }: MapComponentProps) {
+export default function MapComponent({ // Receiving props (routes, isEditMode, onUpdateStopCoordinates) from parent (page.tsx)
+  routes,
+  isEditMode,
+  onUpdateStopCoordinates,
+}: MapComponentProps) {
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY ?? ""; // API key for Google Maps API
   const mapId = process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID || undefined; // mapId is the ID of the map instance, Advanced Markers needs a map id
   const [map, setMap] = useState<google.maps.Map | null>(null); // Creating a state variable to hold the map instance, initially null, but when Google calls the onMapLoad function, we'll call setMap(mapInstance) to save it
@@ -137,6 +148,17 @@ export default function MapComponent({ routes }: MapComponentProps) {
                       key={stop.id}
                       position={{ lat: stop.lat, lng: stop.lng }}
                       title={stop.address}
+                      draggable={isEditMode} // If edit mode is true, the pin is draggable, if false, the pin is not draggable
+                      onDragEnd={(e) => { // Once the user released the pin, e.latlng says where the pin ended, we call onUpdateStopCoordinates in which latlng.lat() and lng() get the new lat/lng coordinates provided by Google maps. (This will then allows page.tsx to update routes, map re-renders with new position, and polyline gets new path from data)
+                        const latLng = e.latLng;
+                        if (!latLng) return;
+                        onUpdateStopCoordinates(
+                          route.vehicleId,
+                          stop.id,
+                          latLng.lat(),
+                          latLng.lng()
+                        );
+                      }}
                     />
                   ))}
               </Fragment>

--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -6,13 +6,13 @@ import { useCallback, useEffect, useRef, useState, Fragment } from "react";
 import { LoadScriptNext, GoogleMap, Marker, Polyline } from "@react-google-maps/api";
 import type { Route } from "../types";
 
-const DAVIS_CENTER = { lat: 38.5449, lng: -121.7405 }; // Map center coordinates for Davis,CA (Google Maps needs as an initial center to position the initial view of the map)
-const POLYLINE_COLOR = "#2563eb"; // Blue path per route (single mock route)
+const DAVIS_CENTER = { lat: 38.5449, lng: -121.7405 }; // Google still wants an initial center before fitBounds runs
+const POLYLINE_COLOR = "#2563eb";
 
 type MapComponentProps = {
   routes: Route[];
-  isEditMode: boolean; // defining the props that map component receives from parent (page.tsx)
-  onUpdateStopCoordinates: (
+  isEditMode: boolean;
+  onUpdateStopCoordinates?: ( // notice this prop is optional, meaning the parent is only notified when a pin finished being dragged if this function (onUpdateStopCoordinates) is passed, if not, the onDragEnd handler does nothing (no parent update)
     routeId: string,
     stopId: string,
     lat: number,
@@ -20,9 +20,9 @@ type MapComponentProps = {
   ) => void;
 };
 
-// Created a helper component (AdvancedMarkers), which creates the pins and attaches them to the map (it receives two things: google map instance and list of routes)
 function AdvancedMarkers({ map, routes }: { map: google.maps.Map | null; routes: Route[] }) {
-  const markersRef = useRef<google.maps.marker.AdvancedMarkerElement[]>([]); // markersRef is a ref that holds an array of the pin objects we'll create
+  // TODO: draggable not yet implemented for AdvancedMarkers (see #84)
+  const markersRef = useRef<google.maps.marker.AdvancedMarkerElement[]>([]);
 
   useEffect(() => {
     if (!map || routes.length === 0) return;
@@ -32,30 +32,28 @@ function AdvancedMarkers({ map, routes }: { map: google.maps.Map | null; routes:
 
     (async () => {
       try {
-        const { AdvancedMarkerElement } = (await google.maps.importLibrary( // We import the library that contains the Advanced Maker Element (class, where each pin on the map is an instance of that class)
-          "marker"
-        )) as google.maps.MarkerLibrary;
+        const { AdvancedMarkerElement } = (await google.maps.importLibrary("marker")) as google.maps.MarkerLibrary;
 
-        if (cancelled) return; // If cancelled is true, meaning the component might've unmounted, we stop and don't create any pins
+        if (cancelled) return;
 
-        routes.forEach((route) => { // For each route, we take its stops and sort them by sequence (visit order). We copy the array first so we don't mutate the original array
+        routes.forEach((route) => {
           const sorted = [...route.stops].sort((a, b) => a.sequence - b.sequence);
           sorted.forEach((stop) => {
-            const m = new AdvancedMarkerElement({ // We create a new instance of the Advanced Marker Element class for each stop, with the map, position, and title
+            const m = new AdvancedMarkerElement({
               map,
               position: { lat: stop.lat, lng: stop.lng },
               title: stop.address,
             });
-            markers.push(m); // We save the array of pins we created into markersRef
+            markers.push(m);
           });
         });
         markersRef.current = markers;
       } catch {
-        // In the event of library failed to load or no mapID, then we catch and the map just won't show any pins
+        // Library / mapId problems, we just won't show pins
       }
     })();
 
-    return () => { // Cleanup function to clean up the pins when the component unmounts
+    return () => {
       cancelled = true;
       markersRef.current.forEach((m: google.maps.marker.AdvancedMarkerElement) => {
         m.map = null;
@@ -67,20 +65,20 @@ function AdvancedMarkers({ map, routes }: { map: google.maps.Map | null; routes:
   return null;
 }
 
-export default function MapComponent({ // Receiving props (routes, isEditMode, onUpdateStopCoordinates) from parent (page.tsx)
+export default function MapComponent({
   routes,
   isEditMode,
   onUpdateStopCoordinates,
 }: MapComponentProps) {
-  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY ?? ""; // API key for Google Maps API
-  const mapId = process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID || undefined; // mapId is the ID of the map instance, Advanced Markers needs a map id
-  const [map, setMap] = useState<google.maps.Map | null>(null); // Creating a state variable to hold the map instance, initially null, but when Google calls the onMapLoad function, we'll call setMap(mapInstance) to save it
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY ?? "";
+  const mapId = process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID || undefined; // AdvancedMarkerElement needs a mapId
+  const [map, setMap] = useState<google.maps.Map | null>(null);
 
-  const onMapLoad = useCallback( // onMapLoad is called when maps finished loading and gives us the map instance
+  const onMapLoad = useCallback(
     (mapInstance: google.maps.Map) => {
-      setMap(mapInstance); // saving map instance in state so AdvancedMarkers can use it
+      setMap(mapInstance);
       if (routes.length === 0) return;
-      const bounds = new google.maps.LatLngBounds(); // Create an empty box (LatLngBounds), then for each stop in every route, we extend that box to include the stop's lat/lng coords
+      const bounds = new google.maps.LatLngBounds();
       routes.forEach((route) => {
         route.stops.forEach((s) => bounds.extend({ lat: s.lat, lng: s.lng }));
       });
@@ -91,7 +89,7 @@ export default function MapComponent({ // Receiving props (routes, isEditMode, o
 
   const onUnmount = useCallback(() => setMap(null), []);
 
-  // When the browser window is resized, tell the map to redraw so it fills the new container size
+  // Map doesn't always follow container size, so we trigger a redraw after window resize
   useEffect(() => {
     if (!map || typeof google === "undefined") return;
     const handleResize = () => {
@@ -109,7 +107,7 @@ export default function MapComponent({ // Receiving props (routes, isEditMode, o
     );
   }
 
-  const mapOptions: google.maps.MapOptions = { // mapOptions is the options for the map, including the center and zoom level
+  const mapOptions: google.maps.MapOptions = {
     center: DAVIS_CENTER,
     zoom: 11,
     ...(mapId ? { mapId } : {}),
@@ -117,22 +115,22 @@ export default function MapComponent({ // Receiving props (routes, isEditMode, o
 
   return (
     <div className="w-full h-full rounded-lg">
-      <LoadScriptNext // small component that loads google maps script, then renders map components inside it
-        googleMapsApiKey={apiKey} // script needs api key
-        mapIds={mapId ? [mapId] : undefined} // advanced markers needs map id
+      <LoadScriptNext
+        googleMapsApiKey={apiKey}
+        mapIds={mapId ? [mapId] : undefined}
         loadingElement={<div className="min-h-[70vh] bg-zinc-100 animate-pulse rounded-lg" />}
       >
-        <GoogleMap // component that draws the map
+        <GoogleMap
           mapContainerStyle={{ width: "100%", height: "100%" }}
           options={mapOptions}
-          onLoad={onMapLoad} // when maps finished loading, google calls this and passes the map instance
+          onLoad={onMapLoad}
           onUnmount={onUnmount}
         >
           {mapId && <AdvancedMarkers map={map} routes={routes} />}
-          {routes.map((route) => { // For each route, we sort the stops by sequence (visit order), then map the stops to an array of lat/lng objects
+          {routes.map((route) => {
             const sorted = [...route.stops].sort((a, b) => a.sequence - b.sequence);
             const path = sorted.map((s) => ({ lat: s.lat, lng: s.lng }));
-            return ( // We draw a polyline for each route, with the stops in the order they're visited
+            return (
               <Fragment key={route.vehicleId}>
                 <Polyline
                   path={path}
@@ -142,17 +140,18 @@ export default function MapComponent({ // Receiving props (routes, isEditMode, o
                     strokeOpacity: 0.9,
                   }}
                 />
-                {!mapId && // Fallback pins when Map ID is not set (devs without NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID still see pins)
+                {/* Classic Marker fallback when mapId is not set (e.g. dev without NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID) */}
+                {!mapId &&
                   sorted.map((stop) => (
                     <Marker
                       key={stop.id}
                       position={{ lat: stop.lat, lng: stop.lng }}
                       title={stop.address}
-                      draggable={isEditMode} // If edit mode is true, the pin is draggable, if false, the pin is not draggable
-                      onDragEnd={(e) => { // Once the user released the pin, e.latlng says where the pin ended, we call onUpdateStopCoordinates in which latlng.lat() and lng() get the new lat/lng coordinates provided by Google maps. (This will then allows page.tsx to update routes, map re-renders with new position, and polyline gets new path from data)
+                      draggable={isEditMode}
+                      onDragEnd={(e) => {
                         const latLng = e.latLng;
                         if (!latLng) return;
-                        onUpdateStopCoordinates(
+                        onUpdateStopCoordinates?.(
                           route.vehicleId,
                           stop.id,
                           latLng.lat(),

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -29,6 +29,23 @@ export default function ResultsPage() {
     );
   }, [setRoutes]);
 
+  const updateStopCoordinates = useCallback( // Created a callback function updateStopCoordinates that the map can call when a pin is dragged to a new location. (New spot is this lat/lng)
+    (routeId: string, stopId: string, lat: number, lng: number) => { // Has 3 parameters: routeId, stopId, and lat/lng (new coordinates)
+      setRoutes((prev) => // Loop through all routes, if the route's id is not the one we're looking for, leave unchanged.
+        prev.map((route) => {
+          if (route.vehicleId !== routeId) return route;
+          return { // Otherwise, create a new copy of that route to avoid editing it in place, and replace stops with a new list where each stop is the same except for the one that matches our stopId. This specific stop is updated with the new lat/lng
+            ...route,
+            stops: route.stops.map((s) =>
+              s.id === stopId ? { ...s, lat, lng } : s
+            ),
+          };
+        })
+      );
+    },
+    [setRoutes]
+  );
+
   return (
     <main className="h-screen flex flex-col overflow-hidden"> {/* Map container switched to h-screen and added overflow hidden so the page is forced to be exactly one screen tall, whereas before the page was allowed to get taller than browser window leading to a long scroll */}
       <header className="flex items-center gap-2 p-4 shrink-0 border-b border-zinc-200 bg-white">
@@ -53,7 +70,11 @@ export default function ResultsPage() {
         {/* Map area still uses flex flex-1 min-h-0 so it takes all space below header, and now also features min-h-0 flex flex-col so it gets a clear height from the flex layout*/}
         <div className="flex-1 min-w-0 min-h-0 flex flex-col">
           <div className="flex-1 min-h-0 w-full overflow-hidden">
-            <MapComponent routes={routes} />
+            <MapComponent // Passing the current list of routes, edit mode state (determine if pins can be dragged yes/no), and the callback function updateStopCoordinates to the Map component (so when user drags a pin, call this function to update stop with new lat/lng)
+              routes={routes}
+              isEditMode={isEditMode}
+              onUpdateStopCoordinates={updateStopCoordinates}
+            />
           </div>
         </div>
       </div>

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -29,12 +29,12 @@ export default function ResultsPage() {
     );
   }, [setRoutes]);
 
-  const updateStopCoordinates = useCallback( // Created a callback function updateStopCoordinates that the map can call when a pin is dragged to a new location. (New spot is this lat/lng)
-    (routeId: string, stopId: string, lat: number, lng: number) => { // Has 3 parameters: routeId, stopId, and lat/lng (new coordinates)
-      setRoutes((prev) => // Loop through all routes, if the route's id is not the one we're looking for, leave unchanged.
+  const updateStopCoordinates = useCallback(
+    (routeId: string, stopId: string, lat: number, lng: number) => {
+      setRoutes((prev) =>
         prev.map((route) => {
           if (route.vehicleId !== routeId) return route;
-          return { // Otherwise, create a new copy of that route to avoid editing it in place, and replace stops with a new list where each stop is the same except for the one that matches our stopId. This specific stop is updated with the new lat/lng
+          return {
             ...route,
             stops: route.stops.map((s) =>
               s.id === stopId ? { ...s, lat, lng } : s


### PR DESCRIPTION
## Overview

Implemented updateStopCoordinates so a dragged pin can update a stop’s lat/lng in that state, and passes isEditMode into the map so pins are draggable only while edit mode is on. Markers and the route line both use routes, so when coordinates change, the map updates on its own. Only the no Map ID <Marker> path is included in this pr, so Advanced Markers are unchanged.

## Specific Changes

app/ui/src/app/results/page.tsx
- Added updateStopCoordinates(routeId, stopId, lat, lng) with useCallback, which finds the matching route and stop and sets lat / lng in routes

- Passed isEditMode and onUpdateStopCoordinates={updateStopCoordinates} into MapComponent so the map can allow dragging and report the new coordinates on drag end

app/ui/src/app/results/components/Map.tsx
- Extended MapComponentProps with isEditMode and onUpdateStopCoordinates

- For the !mapId fallback <Marker>s only: set draggable={isEditMode} and onDragEnd to read latLng from the event and call onUpdateStopCoordinates(route.vehicleId, stop.id, …)

Closes #7 