### PR TITLE
Draggable Markers (Toggle Action #2) - V3

### DIFF
--- a/app/ui/src/app/components/AddressGeocoder/ResultsDisplay.tsx
+++ b/app/ui/src/app/components/AddressGeocoder/ResultsDisplay.tsx
@@ -1,7 +1,6 @@
 // app/components/AddressGeocoder/ResultsDisplay.tsx
 
 import React from 'react';
-import Link from 'next/link';
 import type { OptimizedResponse } from '@/app/types/geocoding';
 
 interface ResultsDisplayProps {
@@ -15,12 +14,6 @@ export const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ results, onDownl
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-2xl font-bold text-gray-900">✅ Results Ready</h2>
         <div className="flex gap-3">
-          <Link
-            href="/results"
-            className="px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 font-medium"
-          >
-            🗺️ View Route Map
-          </Link>
           <button
             onClick={onDownload}
             className="px-6 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 font-medium"
@@ -68,7 +61,7 @@ export const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ results, onDownl
 
       <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-center">
         <p className="text-green-800 font-medium">
-          ✓ Geocoding complete! Download the JSON or view the route map above.
+          ✓ Geocoding complete! Download the JSON to continue.
         </p>
       </div>
     </div>

--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -89,9 +89,8 @@ function latLngFromMarkerPosition(
 type MapComponentProps = {
   routes: Route[];
   isEditMode: boolean;
-  pendingPinMove?: PendingPinMove | null;
-  onPendingPinMove?: (vehicleId: string, stopId: string, lat: number, lng: number) => void;
-  onUpdateStopCoordinates?: (routeId: string, stopId: string, lat: number, lng: number) => void;
+  pendingPinMove: PendingPinMove | null;
+  onPendingPinMove: (vehicleId: string, stopId: string, lat: number, lng: number) => void;
 };
 
 type AdvancedMarkersProps = {
@@ -211,9 +210,8 @@ function AdvancedMarkers({
 export default function MapComponent({
   routes,
   isEditMode,
-  pendingPinMove = null,
+  pendingPinMove,
   onPendingPinMove,
-  onUpdateStopCoordinates,
 }: MapComponentProps) {
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY ?? "";
   const mapId = process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID || undefined;
@@ -233,17 +231,6 @@ export default function MapComponent({
   );
 
   const onUnmount = useCallback(() => setMap(null), []);
-  const notifyPinMove = useCallback(
-    (vehicleId: string, stopId: string, lat: number, lng: number) => {
-      if (onPendingPinMove) {
-        onPendingPinMove(vehicleId, stopId, lat, lng);
-        return;
-      }
-      onUpdateStopCoordinates?.(vehicleId, stopId, lat, lng);
-    },
-    [onPendingPinMove, onUpdateStopCoordinates]
-  );
-
   useEffect(() => {
     if (!map || typeof google === "undefined") return;
     const handleResize = () => {
@@ -290,7 +277,7 @@ export default function MapComponent({
               routes={routes}
               isEditMode={isEditMode}
               pendingPinMove={pendingPinMove}
-              onPendingPinMove={notifyPinMove}
+              onPendingPinMove={onPendingPinMove}
             />
           )}
           {!mapId &&
@@ -315,7 +302,7 @@ export default function MapComponent({
                         onDragEnd={(e) => {
                           const latLng = e.latLng;
                           if (!latLng) return;
-                          notifyPinMove(
+                          onPendingPinMove(
                             route.vehicleId,
                             stop.id,
                             latLng.lat(),

--- a/app/ui/src/app/results/types.ts
+++ b/app/ui/src/app/results/types.ts
@@ -35,6 +35,10 @@ export interface Route {
   estimatedTimeMinutes?: number; // total estimated time in minutes
 }
 
+<<<<<<< HEAD
+=======
+// Unsaved pin drag in edit mode (single pending draft move)
+>>>>>>> 6d54429c (rebased and fixed merge conflicts)
 export interface PendingPinMove {
   vehicleId: string;
   stopId: string;

--- a/app/ui/src/app/results/types.ts
+++ b/app/ui/src/app/results/types.ts
@@ -35,10 +35,6 @@ export interface Route {
   estimatedTimeMinutes?: number; // total estimated time in minutes
 }
 
-<<<<<<< HEAD
-=======
-// Unsaved pin drag in edit mode (single pending draft move)
->>>>>>> 6d54429c (rebased and fixed merge conflicts)
 export interface PendingPinMove {
   vehicleId: string;
   stopId: string;


### PR DESCRIPTION
## Overview

Advanced markers now follows the same draft pin flow as classic markers. Dragging updates pendingPinMove, Save commits to routes, Cancel or turning edit mode off clears the draft. Pins use saved coordinates unless that stop has a pending drag. Draggable only while edit mode is on. Effect dependencies and cleanup (clear listeners, detach markers) keep markers in sync and avoid duplicate or stale drag handlers.


## Specific Changes

app/ui/src/app/results/components/Map.tsx
- Added latLngFromMarkerPosition helper to read lat/lng from AdvancedMarkerElement.position after drag.
- Introduced AdvancedMarkersProps and pass isEditMode, pendingPinMove, onPendingPinMove from MapComponent into AdvancedMarkers.
- For each advanced pin: compute position from draft vs stop; set gmpDraggable: isEditMode; dragend → onPendingPinMove(vehicleId, stopId, lat, lng).
- Extended useEffect deps with pendingPinMove, isEditMode, onPendingPinMove; cleanup uses clearInstanceListeners and m.map = null; cancelled guard before assigning markersRef.
- Replaced conditional render with multi-line <AdvancedMarkers ... /> when mapId is set.

Closes #7 