### PR TITLE
Extract optimize runtime foundation

### DIFF
--- a/app/api/CMakeLists.txt
+++ b/app/api/CMakeLists.txt
@@ -11,9 +11,11 @@ target_sources(
     src/endpoints/optimize_endpoint.cpp
     src/endpoints/osrm_proxy_endpoint.cpp
     src/observability.cpp
+    src/optimize_request.cpp
     src/request_context.cpp
     src/solve_admission.cpp
     src/solve_coordinator.cpp
+    src/solve_execution.cpp
     src/server_options.cpp
     src/vroom_runner.cpp
   PUBLIC
@@ -28,8 +30,10 @@ target_sources(
       include/deliveryoptimizer/api/endpoints/optimize_endpoint.hpp
       include/deliveryoptimizer/api/endpoints/osrm_proxy_endpoint.hpp
       include/deliveryoptimizer/api/observability.hpp
+      include/deliveryoptimizer/api/optimize_request.hpp
       include/deliveryoptimizer/api/solve_admission.hpp
       include/deliveryoptimizer/api/solve_coordinator.hpp
+      include/deliveryoptimizer/api/solve_execution.hpp
       include/deliveryoptimizer/api/server_options.hpp
       include/deliveryoptimizer/api/vroom_runner.hpp
 )

--- a/app/api/include/deliveryoptimizer/api/endpoints/deliveries_optimize_endpoint.hpp
+++ b/app/api/include/deliveryoptimizer/api/endpoints/deliveries_optimize_endpoint.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <memory>
-
 #include "deliveryoptimizer/api/solve_admission.hpp"
+
+#include <memory>
 
 namespace drogon {
 class HttpAppFramework;

--- a/app/api/include/deliveryoptimizer/api/endpoints/health_endpoint.hpp
+++ b/app/api/include/deliveryoptimizer/api/endpoints/health_endpoint.hpp
@@ -1,11 +1,22 @@
 #pragma once
 
+#include <functional>
+#include <memory>
+
+#include <json/json.h>
+
 namespace drogon {
 class HttpAppFramework;
 }
 
 namespace deliveryoptimizer::api {
 
-void RegisterHealthEndpoint(drogon::HttpAppFramework& app);
+class ObservabilityRegistry;
+
+using HealthExtensionProvider = std::function<void(Json::Value& checks, bool& overall_ready)>;
+
+void RegisterHealthEndpoint(drogon::HttpAppFramework& app,
+                            std::shared_ptr<const ObservabilityRegistry> observability = nullptr,
+                            HealthExtensionProvider extension = {});
 
 } // namespace deliveryoptimizer::api

--- a/app/api/include/deliveryoptimizer/api/endpoints/health_endpoint.hpp
+++ b/app/api/include/deliveryoptimizer/api/endpoints/health_endpoint.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
 #include <functional>
-#include <memory>
-
 #include <json/json.h>
+#include <memory>
 
 namespace drogon {
 class HttpAppFramework;

--- a/app/api/include/deliveryoptimizer/api/observability.hpp
+++ b/app/api/include/deliveryoptimizer/api/observability.hpp
@@ -65,12 +65,13 @@ struct ObservabilityOptions {
 };
 
 void EnsureRequestContext(const drogon::HttpRequestPtr& request);
-[[nodiscard]] std::optional<RequestContext> GetRequestContext(const drogon::HttpRequestPtr& request);
+[[nodiscard]] std::optional<RequestContext>
+GetRequestContext(const drogon::HttpRequestPtr& request);
 [[nodiscard]] SolveLifecycle CreateSolveLifecycle(const drogon::HttpRequestPtr& request);
 [[nodiscard]] std::string_view ToOutcomeString(SolveRequestOutcome outcome);
 void FinalizeSolveRequest(const std::shared_ptr<ObservabilityRegistry>& observability,
-                         const std::shared_ptr<SolveLifecycle>& lifecycle,
-                         SolveRequestOutcome outcome, std::uint16_t http_status);
+                          const std::shared_ptr<SolveLifecycle>& lifecycle,
+                          SolveRequestOutcome outcome, std::uint16_t http_status);
 
 class ObservabilityRegistry {
 public:

--- a/app/api/include/deliveryoptimizer/api/optimize_request.hpp
+++ b/app/api/include/deliveryoptimizer/api/optimize_request.hpp
@@ -57,6 +57,6 @@ ParseAndValidateOptimizeRequest(const Json::Value& root, Json::Value& issues);
 [[nodiscard]] Json::Value BuildVroomInput(const OptimizeRequestInput& input);
 
 [[nodiscard]] Json::Value BuildOptimizeSuccessBody(const OptimizeRequestInput& input,
-                                                  const Json::Value& vroom_output);
+                                                   const Json::Value& vroom_output);
 
 } // namespace deliveryoptimizer::api

--- a/app/api/include/deliveryoptimizer/api/optimize_request.hpp
+++ b/app/api/include/deliveryoptimizer/api/optimize_request.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "deliveryoptimizer/api/solve_admission.hpp"
+
+#include <chrono>
+#include <json/json.h>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace deliveryoptimizer::api {
+
+struct Coordinate {
+  double lon;
+  double lat;
+};
+
+struct TimeWindow {
+  std::chrono::sys_seconds start;
+  std::chrono::sys_seconds end;
+};
+
+struct VehicleInput {
+  std::string external_id;
+  int capacity;
+  std::optional<Coordinate> start;
+  std::optional<Coordinate> end;
+  std::optional<TimeWindow> time_window;
+};
+
+struct JobInput {
+  std::string external_id;
+  double lon;
+  double lat;
+  int demand;
+  int service;
+  std::optional<std::vector<TimeWindow>> time_windows;
+};
+
+struct OptimizeRequestInput {
+  double depot_lon;
+  double depot_lat;
+  std::vector<VehicleInput> vehicles;
+  std::vector<JobInput> jobs;
+};
+
+struct ParsedOptimizeRequest {
+  OptimizeRequestInput input;
+  SolveRequestSize size;
+};
+
+[[nodiscard]] std::optional<ParsedOptimizeRequest>
+ParseAndValidateOptimizeRequest(const Json::Value& root, Json::Value& issues);
+
+[[nodiscard]] std::optional<SolveRequestSize> TryParseOptimizeRequestSize(const Json::Value& root);
+
+[[nodiscard]] Json::Value BuildVroomInput(const OptimizeRequestInput& input);
+
+[[nodiscard]] Json::Value BuildOptimizeSuccessBody(const OptimizeRequestInput& input,
+                                                  const Json::Value& vroom_output);
+
+} // namespace deliveryoptimizer::api

--- a/app/api/include/deliveryoptimizer/api/solve_coordinator.hpp
+++ b/app/api/include/deliveryoptimizer/api/solve_coordinator.hpp
@@ -54,9 +54,9 @@ public:
   SolveCoordinator(SolveCoordinator&&) = delete;
   SolveCoordinator& operator=(SolveCoordinator&&) = delete;
 
-  [[nodiscard]] SolveAdmissionStatus CheckAdmission(
-      const SolveRequestSize& request_size,
-      std::shared_ptr<SolveLifecycle> lifecycle = nullptr);
+  [[nodiscard]] SolveAdmissionStatus
+  CheckAdmission(const SolveRequestSize& request_size,
+                 const std::shared_ptr<SolveLifecycle>& lifecycle = nullptr);
 
   [[nodiscard]] SolveAdmissionStatus Submit(const SolveRequestSize& request_size,
                                             PayloadFactory payload_factory,
@@ -78,9 +78,9 @@ private:
   void WorkerLoop();
   void QueueTimerLoop();
   void CompletionLoop();
-  [[nodiscard]] SolveAdmissionStatus CheckAdmissionLocked(
-      const SolveRequestSize& request_size,
-      const std::shared_ptr<SolveLifecycle>& lifecycle);
+  [[nodiscard]] SolveAdmissionStatus
+  CheckAdmissionLocked(const SolveRequestSize& request_size,
+                       const std::shared_ptr<SolveLifecycle>& lifecycle);
 
   SolveAdmissionConfig config_;
   SolveCoordinatorOptions options_;

--- a/app/api/include/deliveryoptimizer/api/solve_execution.hpp
+++ b/app/api/include/deliveryoptimizer/api/solve_execution.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "deliveryoptimizer/api/observability.hpp"
+#include "deliveryoptimizer/api/optimize_request.hpp"
+#include "deliveryoptimizer/api/solve_coordinator.hpp"
+#include "deliveryoptimizer/api/vroom_runner.hpp"
+
+#include <cstdint>
+#include <json/json.h>
+#include <optional>
+#include <string>
+
+namespace deliveryoptimizer::api {
+
+enum class SolveExecutionStatus : std::uint8_t {
+  kSucceeded,
+  kTimedOut,
+  kQueueWaitTimedOut,
+  kFailed,
+};
+
+struct SolveExecutionResult {
+  SolveExecutionStatus status{SolveExecutionStatus::kFailed};
+  SolveRequestOutcome outcome{SolveRequestOutcome::kFailed};
+  std::uint16_t http_status{502U};
+  std::optional<Json::Value> response_body;
+  std::string error_message;
+};
+
+[[nodiscard]] SolveExecutionResult BuildSolveExecutionResult(
+    const OptimizeRequestInput& input, const CoordinatedSolveResult& result);
+
+[[nodiscard]] SolveExecutionResult BuildSolveExecutionResult(
+    const OptimizeRequestInput& input, const VroomRunResult& result);
+
+} // namespace deliveryoptimizer::api

--- a/app/api/include/deliveryoptimizer/api/solve_execution.hpp
+++ b/app/api/include/deliveryoptimizer/api/solve_execution.hpp
@@ -3,7 +3,6 @@
 #include "deliveryoptimizer/api/observability.hpp"
 #include "deliveryoptimizer/api/optimize_request.hpp"
 #include "deliveryoptimizer/api/solve_coordinator.hpp"
-#include "deliveryoptimizer/api/vroom_runner.hpp"
 
 #include <cstdint>
 #include <json/json.h>
@@ -12,15 +11,7 @@
 
 namespace deliveryoptimizer::api {
 
-enum class SolveExecutionStatus : std::uint8_t {
-  kSucceeded,
-  kTimedOut,
-  kQueueWaitTimedOut,
-  kFailed,
-};
-
 struct SolveExecutionResult {
-  SolveExecutionStatus status{SolveExecutionStatus::kFailed};
   SolveRequestOutcome outcome{SolveRequestOutcome::kFailed};
   std::uint16_t http_status{502U};
   std::optional<Json::Value> response_body;
@@ -29,8 +20,5 @@ struct SolveExecutionResult {
 
 [[nodiscard]] SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input,
                                                              const CoordinatedSolveResult& result);
-
-[[nodiscard]] SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input,
-                                                             const VroomRunResult& result);
 
 } // namespace deliveryoptimizer::api

--- a/app/api/include/deliveryoptimizer/api/solve_execution.hpp
+++ b/app/api/include/deliveryoptimizer/api/solve_execution.hpp
@@ -27,10 +27,10 @@ struct SolveExecutionResult {
   std::string error_message;
 };
 
-[[nodiscard]] SolveExecutionResult BuildSolveExecutionResult(
-    const OptimizeRequestInput& input, const CoordinatedSolveResult& result);
+[[nodiscard]] SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input,
+                                                             const CoordinatedSolveResult& result);
 
-[[nodiscard]] SolveExecutionResult BuildSolveExecutionResult(
-    const OptimizeRequestInput& input, const VroomRunResult& result);
+[[nodiscard]] SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input,
+                                                             const VroomRunResult& result);
 
 } // namespace deliveryoptimizer::api

--- a/app/api/src/api_server.cpp
+++ b/app/api/src/api_server.cpp
@@ -94,7 +94,7 @@ int RunApiServer() {
     response->addHeader(std::string{kRequestIdHeader}, context->request_id);
   });
 
-  RegisterHealthEndpoint(app);
+  RegisterHealthEndpoint(app, observability);
   if (options.enable_metrics) {
     RegisterMetricsEndpoint(app, observability);
   }

--- a/app/api/src/api_server.cpp
+++ b/app/api/src/api_server.cpp
@@ -8,9 +8,8 @@
 #include "deliveryoptimizer/api/observability.hpp"
 #include "deliveryoptimizer/api/server_options.hpp"
 
-#include <drogon/drogon.h>
-
 #include <chrono>
+#include <drogon/drogon.h>
 #include <type_traits>
 
 namespace {
@@ -50,16 +49,16 @@ int RunApiServer() {
     response->addHeader(std::string{kRequestIdHeader}, GenerateRequestId());
   });
   app.setCustomErrorHandler([default_error_handler](const drogon::HttpStatusCode code) {
-        auto response = InvokeErrorHandler(default_error_handler, code);
-        if (response == nullptr) {
-          return response;
-        }
+    auto response = InvokeErrorHandler(default_error_handler, code);
+    if (response == nullptr) {
+      return response;
+    }
 
-        if (response->getHeader(std::string{kRequestIdHeader}).empty()) {
-          response->addHeader(std::string{kRequestIdHeader}, GenerateRequestId());
-        }
-        return response;
-      });
+    if (response->getHeader(std::string{kRequestIdHeader}).empty()) {
+      response->addHeader(std::string{kRequestIdHeader}, GenerateRequestId());
+    }
+    return response;
+  });
   app.registerSyncAdvice([observability](const drogon::HttpRequestPtr& request) {
     EnsureRequestContext(request);
     if (request != nullptr && request->body().size() > kMaxRequestBodyBytes) {
@@ -79,20 +78,20 @@ int RunApiServer() {
     }
     return drogon::HttpResponsePtr{};
   });
-  app.registerPreSendingAdvice([](const drogon::HttpRequestPtr& request,
-                                  const drogon::HttpResponsePtr& response) {
-    if (request == nullptr || response == nullptr) {
-      return;
-    }
+  app.registerPreSendingAdvice(
+      [](const drogon::HttpRequestPtr& request, const drogon::HttpResponsePtr& response) {
+        if (request == nullptr || response == nullptr) {
+          return;
+        }
 
-    const auto context = GetRequestContext(request);
-    if (!context.has_value()) {
-      return;
-    }
+        const auto context = GetRequestContext(request);
+        if (!context.has_value()) {
+          return;
+        }
 
-    response->removeHeader(std::string{kRequestIdHeader});
-    response->addHeader(std::string{kRequestIdHeader}, context->request_id);
-  });
+        response->removeHeader(std::string{kRequestIdHeader});
+        response->addHeader(std::string{kRequestIdHeader}, context->request_id);
+      });
 
   RegisterHealthEndpoint(app, observability);
   if (options.enable_metrics) {

--- a/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
+++ b/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
@@ -1,620 +1,27 @@
 #include "deliveryoptimizer/api/endpoints/deliveries_optimize_endpoint.hpp"
 
-#include "deliveryoptimizer/api/deliveries_optimize_limits.hpp"
 #include "deliveryoptimizer/api/observability.hpp"
+#include "deliveryoptimizer/api/optimize_request.hpp"
 #include "deliveryoptimizer/api/solve_coordinator.hpp"
+#include "deliveryoptimizer/api/solve_execution.hpp"
 #include "deliveryoptimizer/api/vroom_runner.hpp"
 
-#include <chrono>
-#include <cmath>
 #include <cstdint>
 #include <drogon/drogon.h>
 #include <json/json.h>
-#include <limits>
-#include <map>
 #include <memory>
-#include <optional>
-#include <string>
 #include <string_view>
 #include <trantor/net/EventLoop.h>
 #include <utility>
-#include <vector>
 
 namespace {
 
-constexpr int kDefaultJobServiceSeconds = 300;
-constexpr double kMinLongitude = -180.0;
-constexpr double kMaxLongitude = 180.0;
-constexpr double kMinLatitude = -90.0;
-constexpr double kMaxLatitude = 90.0;
-constexpr std::string_view kCoordinateValidationMessage =
-    "must be an array [lon, lat] with longitude in [-180, 180] and latitude in [-90, 90].";
-constexpr Json::ArrayIndex kMaxOptimizeVehicles =
-    static_cast<Json::ArrayIndex>(deliveryoptimizer::api::kMaxDeliveriesOptimizeVehicles);
-constexpr Json::ArrayIndex kMaxOptimizeJobs =
-    static_cast<Json::ArrayIndex>(deliveryoptimizer::api::kMaxDeliveriesOptimizeJobs);
-
-struct Coordinate {
-  double lon;
-  double lat;
-};
-
-struct TimeWindow {
-  std::chrono::sys_seconds start;
-  std::chrono::sys_seconds end;
-};
-
-struct VehicleInput {
-  std::string external_id;
-  int capacity;
-  std::optional<Coordinate> start;
-  std::optional<Coordinate> end;
-  std::optional<TimeWindow> time_window;
-};
-
-struct JobInput {
-  std::string external_id;
-  double lon;
-  double lat;
-  int demand;
-  int service;
-  std::optional<std::vector<TimeWindow>> time_windows;
-};
-
-struct OptimizeRequestInput {
-  double depot_lon;
-  double depot_lat;
-  std::vector<VehicleInput> vehicles;
-  std::vector<JobInput> jobs;
-};
+using deliveryoptimizer::api::OptimizeRequestInput;
 
 struct CompletedResponse {
   drogon::HttpResponsePtr response;
   deliveryoptimizer::api::SolveRequestOutcome outcome;
 };
-
-void AddValidationIssue(Json::Value& issues, const std::string_view field,
-                        const std::string_view message) {
-  Json::Value issue{Json::objectValue};
-  issue["field"] = std::string{field};
-  issue["message"] = std::string{message};
-  issues.append(issue);
-}
-
-[[nodiscard]] std::string BuildMaxItemsMessage(const Json::ArrayIndex max_items) {
-  return "must contain at most " + std::to_string(static_cast<unsigned long long>(max_items)) +
-         " items.";
-}
-
-[[nodiscard]] std::optional<Coordinate> ParseCoordinate(const Json::Value& value) {
-  if (!value.isArray() || value.size() != 2U || !value[0].isNumeric() || !value[1].isNumeric()) {
-    return std::nullopt;
-  }
-
-  const double lon = value[0].asDouble();
-  const double lat = value[1].asDouble();
-  if (!std::isfinite(lon) || !std::isfinite(lat) || lon < kMinLongitude || lon > kMaxLongitude ||
-      lat < kMinLatitude || lat > kMaxLatitude) {
-    return std::nullopt;
-  }
-
-  return Coordinate{.lon = lon, .lat = lat};
-}
-
-[[nodiscard]] std::optional<int> ParseBoundedInt(const Json::Value& value, const int min_value) {
-  if (value.isInt64()) {
-    const Json::Int64 parsed = value.asInt64();
-    if (parsed < static_cast<Json::Int64>(min_value) ||
-        parsed > static_cast<Json::Int64>(std::numeric_limits<int>::max())) {
-      return std::nullopt;
-    }
-
-    return static_cast<int>(parsed);
-  }
-
-  if (value.isUInt64()) {
-    const Json::UInt64 parsed = value.asUInt64();
-    if (parsed < static_cast<Json::UInt64>(min_value) ||
-        parsed > static_cast<Json::UInt64>(std::numeric_limits<int>::max())) {
-      return std::nullopt;
-    }
-
-    return static_cast<int>(parsed);
-  }
-
-  return std::nullopt;
-}
-
-[[nodiscard]] std::optional<std::chrono::sys_seconds>
-ParseNonNegativeEpochSeconds(const Json::Value& value) {
-  if (value.isInt64()) {
-    const Json::Int64 parsed = value.asInt64();
-    if (parsed < 0) {
-      return std::nullopt;
-    }
-
-    return std::chrono::sys_seconds{std::chrono::seconds{static_cast<std::int64_t>(parsed)}};
-  }
-
-  if (value.isUInt64()) {
-    const Json::UInt64 parsed = value.asUInt64();
-    if (parsed > static_cast<Json::UInt64>(std::numeric_limits<std::int64_t>::max())) {
-      return std::nullopt;
-    }
-
-    return std::chrono::sys_seconds{
-        std::chrono::seconds{static_cast<std::int64_t>(parsed)},
-    };
-  }
-
-  return std::nullopt;
-}
-
-[[nodiscard]] std::optional<TimeWindow> ParseTimeWindow(const Json::Value& value) {
-  if (!value.isArray() || value.size() != 2U) {
-    return std::nullopt;
-  }
-
-  const auto parsed_start = ParseNonNegativeEpochSeconds(value[0]);
-  const auto parsed_end = ParseNonNegativeEpochSeconds(value[1]);
-  if (!parsed_start.has_value() || !parsed_end.has_value() ||
-      parsed_end.value() <= parsed_start.value()) {
-    return std::nullopt;
-  }
-
-  return TimeWindow{
-      .start = parsed_start.value(),
-      .end = parsed_end.value(),
-  };
-}
-
-[[nodiscard]] std::optional<std::vector<TimeWindow>> ParseTimeWindows(const Json::Value& value) {
-  if (!value.isArray() || value.empty()) {
-    return std::nullopt;
-  }
-
-  std::vector<TimeWindow> windows;
-  windows.reserve(value.size());
-  for (Json::ArrayIndex index = 0U; index < value.size(); ++index) {
-    const auto parsed_window = ParseTimeWindow(value[index]);
-    if (!parsed_window.has_value()) {
-      return std::nullopt;
-    }
-    windows.push_back(parsed_window.value());
-  }
-
-  return windows;
-}
-
-[[nodiscard]] std::optional<Json::UInt64> ParsePositiveId(const Json::Value& value) {
-  if (value.isUInt64()) {
-    const Json::UInt64 parsed = value.asUInt64();
-    if (parsed > 0U) {
-      return parsed;
-    }
-    return std::nullopt;
-  }
-
-  if (value.isInt64()) {
-    const Json::Int64 parsed = value.asInt64();
-    if (parsed > 0) {
-      return static_cast<Json::UInt64>(parsed);
-    }
-  }
-
-  return std::nullopt;
-}
-
-[[nodiscard]] std::optional<VehicleInput>
-ParseVehicle(const Json::Value& vehicle, const std::string_view base_field, Json::Value& issues) {
-  if (!vehicle.isObject()) {
-    AddValidationIssue(issues, base_field, "must be an object.");
-    return std::nullopt;
-  }
-
-  const Json::Value& vehicle_id = vehicle["id"];
-  const Json::Value& capacity = vehicle["capacity"];
-  const Json::Value& start = vehicle["start"];
-  const Json::Value& end = vehicle["end"];
-  const Json::Value& time_window = vehicle["time_window"];
-
-  bool valid_vehicle = true;
-  std::string external_id;
-  std::optional<Coordinate> start_coordinate;
-  std::optional<Coordinate> end_coordinate;
-  std::optional<TimeWindow> vehicle_time_window;
-
-  if (!vehicle_id.isString() || vehicle_id.asString().empty()) {
-    AddValidationIssue(issues, std::string{base_field} + ".id", "must be a non-empty string.");
-    valid_vehicle = false;
-  } else {
-    external_id = vehicle_id.asString();
-  }
-
-  const auto parsed_capacity = ParseBoundedInt(capacity, 1);
-  if (!parsed_capacity.has_value()) {
-    AddValidationIssue(issues, std::string{base_field} + ".capacity",
-                       "must be a positive integer.");
-    valid_vehicle = false;
-  }
-
-  if (vehicle.isMember("start")) {
-    start_coordinate = ParseCoordinate(start);
-    if (!start_coordinate.has_value()) {
-      AddValidationIssue(issues, std::string{base_field} + ".start", kCoordinateValidationMessage);
-      valid_vehicle = false;
-    }
-  }
-
-  if (vehicle.isMember("end")) {
-    end_coordinate = ParseCoordinate(end);
-    if (!end_coordinate.has_value()) {
-      AddValidationIssue(issues, std::string{base_field} + ".end", kCoordinateValidationMessage);
-      valid_vehicle = false;
-    }
-  }
-
-  if (vehicle.isMember("time_window")) {
-    vehicle_time_window = ParseTimeWindow(time_window);
-    if (!vehicle_time_window.has_value()) {
-      AddValidationIssue(
-          issues, std::string{base_field} + ".time_window",
-          "must be an array [start, end] with non-negative integer values and end > start.");
-      valid_vehicle = false;
-    }
-  }
-
-  if (!valid_vehicle) {
-    return std::nullopt;
-  }
-
-  return VehicleInput{.external_id = std::move(external_id),
-                      .capacity = parsed_capacity.value(),
-                      .start = start_coordinate,
-                      .end = end_coordinate,
-                      .time_window = vehicle_time_window};
-}
-
-[[nodiscard]] std::optional<JobInput>
-ParseJob(const Json::Value& job, const std::string_view base_field, Json::Value& issues) {
-  if (!job.isObject()) {
-    AddValidationIssue(issues, base_field, "must be an object.");
-    return std::nullopt;
-  }
-
-  const Json::Value& job_id = job["id"];
-  const Json::Value& location = job["location"];
-  const Json::Value& time_windows = job["time_windows"];
-
-  bool valid_job = true;
-  std::string external_id;
-  if (!job_id.isString() || job_id.asString().empty()) {
-    AddValidationIssue(issues, std::string{base_field} + ".id", "must be a non-empty string.");
-    valid_job = false;
-  } else {
-    external_id = job_id.asString();
-  }
-
-  const auto parsed_location = ParseCoordinate(location);
-  if (!parsed_location.has_value()) {
-    AddValidationIssue(issues, std::string{base_field} + ".location", kCoordinateValidationMessage);
-    valid_job = false;
-  }
-
-  int parsed_demand = 1;
-  if (job.isMember("demand")) {
-    const auto parsed_demand_value = ParseBoundedInt(job["demand"], 1);
-    if (!parsed_demand_value.has_value()) {
-      AddValidationIssue(issues, std::string{base_field} + ".demand",
-                         "must be a positive integer.");
-      valid_job = false;
-    } else {
-      parsed_demand = parsed_demand_value.value();
-    }
-  }
-
-  int parsed_service = kDefaultJobServiceSeconds;
-  std::optional<std::vector<TimeWindow>> parsed_time_windows;
-  if (job.isMember("service")) {
-    const auto parsed_service_value = ParseBoundedInt(job["service"], 0);
-    if (!parsed_service_value.has_value()) {
-      AddValidationIssue(issues, std::string{base_field} + ".service",
-                         "must be a non-negative integer.");
-      valid_job = false;
-    } else {
-      parsed_service = parsed_service_value.value();
-    }
-  }
-
-  if (job.isMember("time_windows")) {
-    parsed_time_windows = ParseTimeWindows(time_windows);
-    if (!parsed_time_windows.has_value()) {
-      AddValidationIssue(issues, std::string{base_field} + ".time_windows",
-                         "must be an array of [start, end] pairs with non-negative integer values "
-                         "and end > start.");
-      valid_job = false;
-    }
-  }
-
-  if (!valid_job) {
-    return std::nullopt;
-  }
-
-  return JobInput{.external_id = std::move(external_id),
-                  .lon = parsed_location->lon,
-                  .lat = parsed_location->lat,
-                  .demand = parsed_demand,
-                  .service = parsed_service,
-                  .time_windows = std::move(parsed_time_windows)};
-}
-
-void ParseDepot(const Json::Value& root, OptimizeRequestInput& parsed_input, Json::Value& issues) {
-  const Json::Value& depot = root["depot"];
-  if (!depot.isObject()) {
-    AddValidationIssue(issues, "depot", "is required and must be an object.");
-    return;
-  }
-
-  const auto depot_coordinate = ParseCoordinate(depot["location"]);
-  if (!depot_coordinate.has_value()) {
-    AddValidationIssue(issues, "depot.location", kCoordinateValidationMessage);
-    return;
-  }
-
-  parsed_input.depot_lon = depot_coordinate->lon;
-  parsed_input.depot_lat = depot_coordinate->lat;
-}
-
-void ParseVehicles(const Json::Value& root, OptimizeRequestInput& parsed_input,
-                   Json::Value& issues) {
-  const Json::Value& vehicles = root["vehicles"];
-  if (!vehicles.isArray()) {
-    AddValidationIssue(issues, "vehicles", "is required and must be a non-empty array.");
-    return;
-  }
-
-  if (vehicles.empty()) {
-    AddValidationIssue(issues, "vehicles", "must not be empty.");
-    return;
-  }
-  if (vehicles.size() > kMaxOptimizeVehicles) {
-    AddValidationIssue(issues, "vehicles", BuildMaxItemsMessage(kMaxOptimizeVehicles));
-    return;
-  }
-
-  for (Json::ArrayIndex index = 0U; index < vehicles.size(); ++index) {
-    const std::string base_field = "vehicles[" + std::to_string(index) + "]";
-    const auto parsed_vehicle = ParseVehicle(vehicles[index], base_field, issues);
-    if (parsed_vehicle.has_value()) {
-      parsed_input.vehicles.push_back(parsed_vehicle.value());
-    }
-  }
-}
-
-void ParseJobs(const Json::Value& root, OptimizeRequestInput& parsed_input, Json::Value& issues) {
-  const Json::Value& jobs = root["jobs"];
-  if (!jobs.isArray()) {
-    AddValidationIssue(issues, "jobs", "is required and must be a non-empty array.");
-    return;
-  }
-
-  if (jobs.empty()) {
-    AddValidationIssue(issues, "jobs", "must not be empty.");
-    return;
-  }
-  if (jobs.size() > kMaxOptimizeJobs) {
-    AddValidationIssue(issues, "jobs", BuildMaxItemsMessage(kMaxOptimizeJobs));
-    return;
-  }
-
-  for (Json::ArrayIndex index = 0U; index < jobs.size(); ++index) {
-    const std::string base_field = "jobs[" + std::to_string(index) + "]";
-    const auto parsed_job = ParseJob(jobs[index], base_field, issues);
-    if (parsed_job.has_value()) {
-      parsed_input.jobs.push_back(parsed_job.value());
-    }
-  }
-}
-
-[[nodiscard]] std::optional<OptimizeRequestInput> ParseAndValidateRequest(const Json::Value& root,
-                                                                          Json::Value& issues) {
-  issues = Json::Value{Json::arrayValue};
-  if (!root.isObject()) {
-    AddValidationIssue(issues, "body", "must be a JSON object.");
-    return std::nullopt;
-  }
-
-  OptimizeRequestInput parsed_input{};
-  ParseDepot(root, parsed_input, issues);
-  ParseVehicles(root, parsed_input, issues);
-  ParseJobs(root, parsed_input, issues);
-
-  if (!issues.empty()) {
-    return std::nullopt;
-  }
-
-  return parsed_input;
-}
-
-[[nodiscard]] std::optional<deliveryoptimizer::api::SolveRequestSize>
-TryParseRequestSizeForAdmission(const Json::Value& root) {
-  if (!root.isObject()) {
-    return std::nullopt;
-  }
-
-  const Json::Value& vehicles = root["vehicles"];
-  const Json::Value& jobs = root["jobs"];
-  if (!vehicles.isArray() || !jobs.isArray()) {
-    return std::nullopt;
-  }
-
-  if (vehicles.size() > kMaxOptimizeVehicles || jobs.size() > kMaxOptimizeJobs) {
-    return std::nullopt;
-  }
-
-  return deliveryoptimizer::api::SolveRequestSize{
-      .jobs = static_cast<std::size_t>(jobs.size()),
-      .vehicles = static_cast<std::size_t>(vehicles.size()),
-  };
-}
-
-[[nodiscard]] Json::Value BuildLocation(const double lon, const double lat) {
-  Json::Value location{Json::arrayValue};
-  location.append(lon);
-  location.append(lat);
-  return location;
-}
-
-[[nodiscard]] Json::Value BuildUnitArray(const int value) {
-  Json::Value values{Json::arrayValue};
-  values.append(value);
-  return values;
-}
-
-[[nodiscard]] Json::Value BuildTimeWindowArray(const TimeWindow& time_window) {
-  Json::Value values{Json::arrayValue};
-  values.append(static_cast<Json::Int64>(time_window.start.time_since_epoch().count()));
-  values.append(static_cast<Json::Int64>(time_window.end.time_since_epoch().count()));
-  return values;
-}
-
-[[nodiscard]] Json::Value BuildTimeWindowsArray(const std::vector<TimeWindow>& time_windows) {
-  Json::Value values{Json::arrayValue};
-  for (const auto& time_window : time_windows) {
-    values.append(BuildTimeWindowArray(time_window));
-  }
-  return values;
-}
-
-[[nodiscard]] Json::Value BuildVroomInput(const OptimizeRequestInput& input) {
-  Json::Value payload{Json::objectValue};
-  payload["jobs"] = Json::Value{Json::arrayValue};
-  payload["vehicles"] = Json::Value{Json::arrayValue};
-
-  for (std::size_t index = 0U; index < input.jobs.size(); ++index) {
-    const JobInput& job_input = input.jobs[index];
-    Json::Value job{Json::objectValue};
-    job["id"] = static_cast<Json::UInt64>(index + 1U);
-    job["location"] = BuildLocation(job_input.lon, job_input.lat);
-    job["amount"] = BuildUnitArray(job_input.demand);
-    job["service"] = job_input.service;
-    job["description"] = job_input.external_id;
-    if (job_input.time_windows.has_value()) {
-      job["time_windows"] = BuildTimeWindowsArray(job_input.time_windows.value());
-    }
-    payload["jobs"].append(job);
-  }
-
-  for (std::size_t index = 0U; index < input.vehicles.size(); ++index) {
-    const VehicleInput& vehicle_input = input.vehicles[index];
-    Json::Value vehicle{Json::objectValue};
-    const Coordinate start = vehicle_input.start.value_or(Coordinate{
-        .lon = input.depot_lon,
-        .lat = input.depot_lat,
-    });
-    const Coordinate end = vehicle_input.end.value_or(Coordinate{
-        .lon = input.depot_lon,
-        .lat = input.depot_lat,
-    });
-    vehicle["id"] = static_cast<Json::UInt64>(index + 1U);
-    vehicle["start"] = BuildLocation(start.lon, start.lat);
-    vehicle["end"] = BuildLocation(end.lon, end.lat);
-    vehicle["capacity"] = BuildUnitArray(vehicle_input.capacity);
-    vehicle["description"] = vehicle_input.external_id;
-    if (vehicle_input.time_window.has_value()) {
-      vehicle["time_window"] = BuildTimeWindowArray(vehicle_input.time_window.value());
-    }
-    payload["vehicles"].append(vehicle);
-  }
-
-  return payload;
-}
-
-[[nodiscard]] std::map<Json::UInt64, std::string>
-BuildVehicleExternalIdMap(const OptimizeRequestInput& input) {
-  std::map<Json::UInt64, std::string> vehicle_map;
-  for (std::size_t index = 0U; index < input.vehicles.size(); ++index) {
-    vehicle_map[static_cast<Json::UInt64>(index + 1U)] = input.vehicles[index].external_id;
-  }
-  return vehicle_map;
-}
-
-[[nodiscard]] std::map<Json::UInt64, std::string>
-BuildJobExternalIdMap(const OptimizeRequestInput& input) {
-  std::map<Json::UInt64, std::string> job_map;
-  for (std::size_t index = 0U; index < input.jobs.size(); ++index) {
-    job_map[static_cast<Json::UInt64>(index + 1U)] = input.jobs[index].external_id;
-  }
-  return job_map;
-}
-
-void ApplyExternalIdsToRoutes(Json::Value& routes,
-                              const std::map<Json::UInt64, std::string>& vehicle_map,
-                              const std::map<Json::UInt64, std::string>& job_map) {
-  if (!routes.isArray()) {
-    return;
-  }
-
-  for (Json::ArrayIndex route_index = 0U; route_index < routes.size(); ++route_index) {
-    Json::Value& route = routes[route_index];
-    if (!route.isObject()) {
-      continue;
-    }
-
-    const auto vehicle_id = ParsePositiveId(route["vehicle"]);
-    if (vehicle_id.has_value()) {
-      const auto vehicle_it = vehicle_map.find(*vehicle_id);
-      if (vehicle_it != vehicle_map.end()) {
-        route["vehicle_external_id"] = vehicle_it->second;
-      }
-    }
-
-    Json::Value& steps = route["steps"];
-    if (!steps.isArray()) {
-      continue;
-    }
-
-    for (Json::ArrayIndex step_index = 0U; step_index < steps.size(); ++step_index) {
-      Json::Value& step = steps[step_index];
-      if (!step.isObject()) {
-        continue;
-      }
-      const auto job_id = ParsePositiveId(step["job"]);
-      if (!job_id.has_value()) {
-        continue;
-      }
-
-      const auto job_it = job_map.find(*job_id);
-      if (job_it != job_map.end()) {
-        step["job_external_id"] = job_it->second;
-      }
-    }
-  }
-}
-
-void ApplyExternalIdsToUnassigned(Json::Value& unassigned,
-                                  const std::map<Json::UInt64, std::string>& job_map) {
-  if (!unassigned.isArray()) {
-    return;
-  }
-
-  for (Json::ArrayIndex index = 0U; index < unassigned.size(); ++index) {
-    Json::Value& entry = unassigned[index];
-    if (!entry.isObject()) {
-      continue;
-    }
-
-    const auto job_id = ParsePositiveId(entry["id"]);
-    if (!job_id.has_value()) {
-      continue;
-    }
-
-    const auto job_it = job_map.find(*job_id);
-    if (job_it != job_map.end()) {
-      entry["job_external_id"] = job_it->second;
-    }
-  }
-}
 
 [[nodiscard]] drogon::HttpResponsePtr BuildErrorResponse(const drogon::HttpStatusCode code,
                                                          const std::string_view error_message) {
@@ -634,42 +41,14 @@ void ApplyExternalIdsToUnassigned(Json::Value& unassigned,
   return response;
 }
 
-[[nodiscard]] drogon::HttpResponsePtr BuildSuccessResponse(const OptimizeRequestInput& input,
-                                                           const Json::Value& vroom_output) {
-  Json::Value body{Json::objectValue};
-  body["status"] = "ok";
-
-  const Json::Value& summary = vroom_output["summary"];
-  body["summary"] = summary.isObject() ? summary : Json::Value{Json::objectValue};
-
-  Json::Value routes = vroom_output["routes"];
-  if (!routes.isArray()) {
-    routes = Json::Value{Json::arrayValue};
-  }
-  Json::Value unassigned = vroom_output["unassigned"];
-  if (!unassigned.isArray()) {
-    unassigned = Json::Value{Json::arrayValue};
-  }
-
-  const auto vehicle_map = BuildVehicleExternalIdMap(input);
-  const auto job_map = BuildJobExternalIdMap(input);
-  ApplyExternalIdsToRoutes(routes, vehicle_map, job_map);
-  ApplyExternalIdsToUnassigned(unassigned, job_map);
-  body["routes"] = std::move(routes);
-  body["unassigned"] = std::move(unassigned);
-
-  return drogon::HttpResponse::newHttpJsonResponse(body);
-}
-
 [[nodiscard]] CompletedResponse
 BuildAdmissionRejectionResponse(const deliveryoptimizer::api::SolveAdmissionStatus status) {
   switch (status) {
   case deliveryoptimizer::api::SolveAdmissionStatus::kRejectedTooManyJobs:
   case deliveryoptimizer::api::SolveAdmissionStatus::kRejectedTooManyVehicles:
     return CompletedResponse{
-        .response = BuildErrorResponse(
-            drogon::k503ServiceUnavailable,
-            "Routing optimization is unavailable for requests of this size."),
+        .response = BuildErrorResponse(drogon::k422UnprocessableEntity,
+                                       "Routing optimization is unavailable for requests of this size."),
         .outcome =
             status == deliveryoptimizer::api::SolveAdmissionStatus::kRejectedTooManyJobs
                 ? deliveryoptimizer::api::SolveRequestOutcome::kRejectedTooManyJobs
@@ -692,38 +71,20 @@ BuildAdmissionRejectionResponse(const deliveryoptimizer::api::SolveAdmissionStat
 }
 
 [[nodiscard]] CompletedResponse
-BuildSolveExecutionResponse(const OptimizeRequestInput& input,
-                            const deliveryoptimizer::api::CoordinatedSolveResult& result) {
-  switch (result.status) {
-  case deliveryoptimizer::api::CoordinatedSolveStatus::kSucceeded:
-    if (result.output.has_value()) {
-      return CompletedResponse{
-          .response = BuildSuccessResponse(input, *result.output),
-          .outcome = deliveryoptimizer::api::SolveRequestOutcome::kSucceeded,
-      };
-    }
+BuildSolveExecutionResponse(const deliveryoptimizer::api::SolveExecutionResult& result) {
+  if (result.response_body.has_value()) {
+    auto response = drogon::HttpResponse::newHttpJsonResponse(*result.response_body);
+    response->setStatusCode(static_cast<drogon::HttpStatusCode>(result.http_status));
     return CompletedResponse{
-        .response = BuildErrorResponse(drogon::k502BadGateway, "Routing optimization failed."),
-        .outcome = deliveryoptimizer::api::SolveRequestOutcome::kFailed,
+        .response = response,
+        .outcome = result.outcome,
     };
-  case deliveryoptimizer::api::CoordinatedSolveStatus::kTimedOut:
-    return CompletedResponse{
-        .response = BuildErrorResponse(drogon::k504GatewayTimeout, "Routing optimization timed out."),
-        .outcome = deliveryoptimizer::api::SolveRequestOutcome::kSolveTimedOut,
-    };
-  case deliveryoptimizer::api::CoordinatedSolveStatus::kQueueWaitTimedOut:
-    return CompletedResponse{
-        .response = BuildErrorResponse(drogon::k503ServiceUnavailable,
-                                       "Routing optimization queue wait timed out."),
-        .outcome = deliveryoptimizer::api::SolveRequestOutcome::kQueueWaitTimedOut,
-    };
-  case deliveryoptimizer::api::CoordinatedSolveStatus::kFailed:
-    break;
   }
 
   return CompletedResponse{
-      .response = BuildErrorResponse(drogon::k502BadGateway, "Routing optimization failed."),
-      .outcome = deliveryoptimizer::api::SolveRequestOutcome::kFailed,
+      .response = BuildErrorResponse(static_cast<drogon::HttpStatusCode>(result.http_status),
+                                     result.error_message),
+      .outcome = result.outcome,
   };
 }
 
@@ -747,10 +108,10 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
 
   app.registerHandler(
       "/api/v1/deliveries/optimize",
-      [coordinator =
-           std::move(coordinator),
+      [coordinator = std::move(coordinator),
        observability = std::move(observability)](const drogon::HttpRequestPtr& request,
-                                   std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
+                                                 std::function<void(const drogon::HttpResponsePtr&)>&&
+                                                     callback) {
         auto lifecycle = std::make_shared<SolveLifecycle>(CreateSolveLifecycle(request));
         auto response_callback =
             std::make_shared<std::function<void(const drogon::HttpResponsePtr&)>>(
@@ -767,7 +128,8 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
         const auto respond_with_completion =
             [respond, observability, lifecycle](const CompletedResponse& completed_response) {
               FinalizeSolveRequest(observability, lifecycle, completed_response.outcome,
-                                   static_cast<std::uint16_t>(completed_response.response->getStatusCode()));
+                                   static_cast<std::uint16_t>(
+                                       completed_response.response->getStatusCode()));
               respond(completed_response.response);
             };
 
@@ -781,7 +143,7 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
           return;
         }
 
-        const auto early_request_size = TryParseRequestSizeForAdmission(*parsed_json);
+        const auto early_request_size = TryParseOptimizeRequestSize(*parsed_json);
         if (early_request_size.has_value()) {
           lifecycle->jobs = early_request_size->jobs;
           lifecycle->vehicles = early_request_size->vehicles;
@@ -794,8 +156,8 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
         }
 
         Json::Value issues{Json::arrayValue};
-        auto parsed_input = ParseAndValidateRequest(*parsed_json, issues);
-        if (!parsed_input.has_value()) {
+        auto parsed_request = ParseAndValidateOptimizeRequest(*parsed_json, issues);
+        if (!parsed_request.has_value()) {
           respond_with_completion(CompletedResponse{
               .response = BuildValidationResponse(issues),
               .outcome = SolveRequestOutcome::kValidationFailed,
@@ -803,11 +165,11 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
           return;
         }
 
-        OptimizeRequestInput optimize_request = std::move(parsed_input.value());
         auto optimize_request_ptr =
-            std::make_shared<OptimizeRequestInput>(std::move(optimize_request));
+            std::make_shared<OptimizeRequestInput>(std::move(parsed_request->input));
         lifecycle->jobs = optimize_request_ptr->jobs.size();
         lifecycle->vehicles = optimize_request_ptr->vehicles.size();
+
         const SolveRequestSize request_size{
             .jobs = optimize_request_ptr->jobs.size(),
             .vehicles = optimize_request_ptr->vehicles.size(),
@@ -816,12 +178,12 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
         const SolveAdmissionStatus admission_status = coordinator->Submit(
             request_size, [optimize_request_ptr] { return BuildVroomInput(*optimize_request_ptr); },
             [optimize_request_ptr, respond_with_completion](const CoordinatedSolveResult& result) mutable {
-              respond_with_completion(BuildSolveExecutionResponse(*optimize_request_ptr, result));
+              respond_with_completion(BuildSolveExecutionResponse(
+                  BuildSolveExecutionResult(*optimize_request_ptr, result)));
             },
             lifecycle);
         if (admission_status != SolveAdmissionStatus::kAccepted) {
           respond_with_completion(BuildAdmissionRejectionResponse(admission_status));
-          return;
         }
       },
       {drogon::Post});

--- a/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
+++ b/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
@@ -47,12 +47,12 @@ BuildAdmissionRejectionResponse(const deliveryoptimizer::api::SolveAdmissionStat
   case deliveryoptimizer::api::SolveAdmissionStatus::kRejectedTooManyJobs:
   case deliveryoptimizer::api::SolveAdmissionStatus::kRejectedTooManyVehicles:
     return CompletedResponse{
-        .response = BuildErrorResponse(drogon::k422UnprocessableEntity,
-                                       "Routing optimization is unavailable for requests of this size."),
-        .outcome =
-            status == deliveryoptimizer::api::SolveAdmissionStatus::kRejectedTooManyJobs
-                ? deliveryoptimizer::api::SolveRequestOutcome::kRejectedTooManyJobs
-                : deliveryoptimizer::api::SolveRequestOutcome::kRejectedTooManyVehicles,
+        .response =
+            BuildErrorResponse(drogon::k422UnprocessableEntity,
+                               "Routing optimization is unavailable for requests of this size."),
+        .outcome = status == deliveryoptimizer::api::SolveAdmissionStatus::kRejectedTooManyJobs
+                       ? deliveryoptimizer::api::SolveRequestOutcome::kRejectedTooManyJobs
+                       : deliveryoptimizer::api::SolveRequestOutcome::kRejectedTooManyVehicles,
     };
   case deliveryoptimizer::api::SolveAdmissionStatus::kRejectedQueueFull:
     return CompletedResponse{
@@ -108,10 +108,9 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
 
   app.registerHandler(
       "/api/v1/deliveries/optimize",
-      [coordinator = std::move(coordinator),
-       observability = std::move(observability)](const drogon::HttpRequestPtr& request,
-                                                 std::function<void(const drogon::HttpResponsePtr&)>&&
-                                                     callback) {
+      [coordinator = std::move(coordinator), observability = std::move(observability)](
+          const drogon::HttpRequestPtr& request,
+          std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
         auto lifecycle = std::make_shared<SolveLifecycle>(CreateSolveLifecycle(request));
         auto response_callback =
             std::make_shared<std::function<void(const drogon::HttpResponsePtr&)>>(
@@ -127,9 +126,9 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
         };
         const auto respond_with_completion =
             [respond, observability, lifecycle](const CompletedResponse& completed_response) {
-              FinalizeSolveRequest(observability, lifecycle, completed_response.outcome,
-                                   static_cast<std::uint16_t>(
-                                       completed_response.response->getStatusCode()));
+              FinalizeSolveRequest(
+                  observability, lifecycle, completed_response.outcome,
+                  static_cast<std::uint16_t>(completed_response.response->getStatusCode()));
               respond(completed_response.response);
             };
 
@@ -177,7 +176,8 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
 
         const SolveAdmissionStatus admission_status = coordinator->Submit(
             request_size, [optimize_request_ptr] { return BuildVroomInput(*optimize_request_ptr); },
-            [optimize_request_ptr, respond_with_completion](const CoordinatedSolveResult& result) mutable {
+            [optimize_request_ptr,
+             respond_with_completion](const CoordinatedSolveResult& result) mutable {
               respond_with_completion(BuildSolveExecutionResponse(
                   BuildSolveExecutionResult(*optimize_request_ptr, result)));
             },

--- a/app/api/src/endpoints/health_endpoint.cpp
+++ b/app/api/src/endpoints/health_endpoint.cpp
@@ -1,7 +1,6 @@
 #include "deliveryoptimizer/api/endpoints/health_endpoint.hpp"
 
 #include "deliveryoptimizer/api/observability.hpp"
-
 #include "env_utils.hpp"
 
 #include <chrono>
@@ -170,9 +169,8 @@ void RegisterHealthEndpoint(drogon::HttpAppFramework& app,
 
         osrm_client->sendRequest(
             osrm_probe_request,
-            [osrm_client = std::move(osrm_client), vroom_ready,
-             observability = observability, extension = extension,
-             callback = std::move(callback)](
+            [osrm_client = std::move(osrm_client), vroom_ready, observability = observability,
+             extension = extension, callback = std::move(callback)](
                 const drogon::ReqResult result, const drogon::HttpResponsePtr& response) mutable {
               (void)osrm_client;
               const OsrmProbeResult osrm_probe = EvaluateOsrmProbe(result, response);

--- a/app/api/src/endpoints/health_endpoint.cpp
+++ b/app/api/src/endpoints/health_endpoint.cpp
@@ -1,5 +1,7 @@
 #include "deliveryoptimizer/api/endpoints/health_endpoint.hpp"
 
+#include "deliveryoptimizer/api/observability.hpp"
+
 #include "env_utils.hpp"
 
 #include <chrono>
@@ -76,16 +78,25 @@ struct OsrmProbeResult {
   return OsrmProbeResult{.ready = true, .detail = code_text};
 }
 
-[[nodiscard]] drogon::HttpResponsePtr BuildHealthResponse(const bool vroom_ready,
-                                                          const OsrmProbeResult& osrm_probe) {
+[[nodiscard]] drogon::HttpResponsePtr BuildHealthResponse(
+    const bool vroom_ready, const OsrmProbeResult& osrm_probe,
+    const std::shared_ptr<const deliveryoptimizer::api::ObservabilityRegistry>& observability,
+    const deliveryoptimizer::api::HealthExtensionProvider& extension) {
   Json::Value body{Json::objectValue};
-  const bool overall_ready = vroom_ready && osrm_probe.ready;
-  body["status"] = overall_ready ? "ok" : "degraded";
+  bool overall_ready = vroom_ready && osrm_probe.ready;
 
   Json::Value checks{Json::objectValue};
   checks["vroom_binary"] = vroom_ready ? "ok" : "missing";
   checks["osrm"] = osrm_probe.ready ? "ok" : "down";
   checks["osrm_detail"] = osrm_probe.detail;
+  if (observability != nullptr) {
+    checks["solver_queue_depth"] = static_cast<Json::UInt64>(observability->QueueDepth());
+    checks["solver_inflight"] = static_cast<Json::UInt64>(observability->InflightSolves());
+  }
+  if (extension) {
+    extension(checks, overall_ready);
+  }
+  body["status"] = overall_ready ? "ok" : "degraded";
   body["checks"] = checks;
 
   auto response = drogon::HttpResponse::newHttpJsonResponse(body);
@@ -138,13 +149,17 @@ void CacheOsrmProbe(const OsrmProbeResult& result) {
 
 namespace deliveryoptimizer::api {
 
-void RegisterHealthEndpoint(drogon::HttpAppFramework& app) {
+void RegisterHealthEndpoint(drogon::HttpAppFramework& app,
+                            std::shared_ptr<const ObservabilityRegistry> observability,
+                            HealthExtensionProvider extension) {
   app.registerHandler(
-      "/health", [](const drogon::HttpRequestPtr& /*request*/,
-                    std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
+      "/health", [observability = std::move(observability), extension = std::move(extension)](
+                     const drogon::HttpRequestPtr& /*request*/,
+                     std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
         const bool vroom_ready = IsVroomBinaryReady();
         if (const auto cached_probe = GetCachedOsrmProbe()) {
-          std::move(callback)(BuildHealthResponse(vroom_ready, *cached_probe));
+          std::move(callback)(
+              BuildHealthResponse(vroom_ready, *cached_probe, observability, extension));
           return;
         }
 
@@ -155,12 +170,15 @@ void RegisterHealthEndpoint(drogon::HttpAppFramework& app) {
 
         osrm_client->sendRequest(
             osrm_probe_request,
-            [osrm_client = std::move(osrm_client), vroom_ready, callback = std::move(callback)](
+            [osrm_client = std::move(osrm_client), vroom_ready,
+             observability = observability, extension = extension,
+             callback = std::move(callback)](
                 const drogon::ReqResult result, const drogon::HttpResponsePtr& response) mutable {
               (void)osrm_client;
               const OsrmProbeResult osrm_probe = EvaluateOsrmProbe(result, response);
               CacheOsrmProbe(osrm_probe);
-              std::move(callback)(BuildHealthResponse(vroom_ready, osrm_probe));
+              std::move(callback)(
+                  BuildHealthResponse(vroom_ready, osrm_probe, observability, extension));
             },
             kOsrmProbeTimeoutSeconds);
       });

--- a/app/api/src/endpoints/metrics_endpoint.cpp
+++ b/app/api/src/endpoints/metrics_endpoint.cpp
@@ -3,25 +3,23 @@
 #include "deliveryoptimizer/api/observability.hpp"
 
 #include <drogon/drogon.h>
-
 #include <utility>
 
 namespace deliveryoptimizer::api {
 
 void RegisterMetricsEndpoint(drogon::HttpAppFramework& app,
                              std::shared_ptr<ObservabilityRegistry> observability) {
-  app.registerHandler(
-      "/metrics",
-      [observability = std::move(observability)](const drogon::HttpRequestPtr& /*request*/,
-                                                 std::function<void(const drogon::HttpResponsePtr&)>&&
-                                                     callback) {
-        auto response = drogon::HttpResponse::newHttpResponse();
-        response->setStatusCode(drogon::k200OK);
-        response->setContentTypeString("text/plain; version=0.0.4; charset=utf-8");
-        response->setBody(observability->RenderPrometheusText());
-        std::move(callback)(response);
-      },
-      {drogon::Get});
+  app.registerHandler("/metrics",
+                      [observability = std::move(observability)](
+                          const drogon::HttpRequestPtr& /*request*/,
+                          std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
+                        auto response = drogon::HttpResponse::newHttpResponse();
+                        response->setStatusCode(drogon::k200OK);
+                        response->setContentTypeString("text/plain; version=0.0.4; charset=utf-8");
+                        response->setBody(observability->RenderPrometheusText());
+                        std::move(callback)(response);
+                      },
+                      {drogon::Get});
 }
 
 } // namespace deliveryoptimizer::api

--- a/app/api/src/observability.cpp
+++ b/app/api/src/observability.cpp
@@ -1,10 +1,9 @@
 #include "deliveryoptimizer/api/observability.hpp"
 
-#include <json/json.h>
-
 #include <array>
 #include <iomanip>
 #include <iostream>
+#include <json/json.h>
 #include <limits>
 #include <ostream>
 #include <sstream>
@@ -231,9 +230,8 @@ std::uint64_t ObservabilityRegistry::InflightSolves() const {
 }
 
 void FinalizeSolveRequest(const std::shared_ptr<ObservabilityRegistry>& observability,
-                         const std::shared_ptr<SolveLifecycle>& lifecycle,
-                         const SolveRequestOutcome outcome,
-                         const std::uint16_t http_status) {
+                          const std::shared_ptr<SolveLifecycle>& lifecycle,
+                          const SolveRequestOutcome outcome, const std::uint16_t http_status) {
   if (observability == nullptr || lifecycle == nullptr) {
     return;
   }
@@ -275,8 +273,7 @@ void FinalizeSolveRequest(const std::shared_ptr<ObservabilityRegistry>& observab
     break;
   }
 
-  observability->LogSolveRequest(*lifecycle, outcome,
-                                 http_status);
+  observability->LogSolveRequest(*lifecycle, outcome, http_status);
 }
 
 std::string ObservabilityRegistry::RenderPrometheusText() const {
@@ -382,7 +379,8 @@ void ObservabilityRegistry::LogSolveRequest(const SolveLifecycle& lifecycle,
       static_cast<Json::Int64>(DurationToMilliseconds(lifecycle.queue_wait_duration));
   log_line["solve_duration_ms"] =
       static_cast<Json::Int64>(DurationToMilliseconds(lifecycle.solve_duration));
-  log_line["request_duration_ms"] = static_cast<Json::Int64>(DurationToMilliseconds(request_duration));
+  log_line["request_duration_ms"] =
+      static_cast<Json::Int64>(DurationToMilliseconds(request_duration));
 
   Json::StreamWriterBuilder writer_builder;
   writer_builder["indentation"] = "";

--- a/app/api/src/optimize_request.cpp
+++ b/app/api/src/optimize_request.cpp
@@ -105,6 +105,25 @@ ParseNonNegativeEpochSeconds(const Json::Value& value) {
   return std::nullopt;
 }
 
+[[nodiscard]] std::optional<std::uint64_t> ParsePositiveId(const Json::Value& value) {
+  if (value.isUInt64()) {
+    const Json::UInt64 parsed = value.asUInt64();
+    if (parsed > 0U) {
+      return static_cast<std::uint64_t>(parsed);
+    }
+    return std::nullopt;
+  }
+
+  if (value.isInt64()) {
+    const Json::Int64 parsed = value.asInt64();
+    if (parsed > 0) {
+      return static_cast<std::uint64_t>(parsed);
+    }
+  }
+
+  return std::nullopt;
+}
+
 [[nodiscard]] std::optional<deliveryoptimizer::api::TimeWindow>
 ParseTimeWindow(const Json::Value& value) {
   if (!value.isArray() || value.size() != 2U) {
@@ -413,9 +432,9 @@ void ApplyExternalIdsToRoutes(Json::Value& routes,
     if (!route.isObject()) {
       continue;
     }
-    const auto vehicle_id = route["vehicle"];
-    if (vehicle_id.isUInt64()) {
-      const auto vehicle_it = vehicle_map.find(vehicle_id.asUInt64());
+    const auto vehicle_id = ParsePositiveId(route["vehicle"]);
+    if (vehicle_id.has_value()) {
+      const auto vehicle_it = vehicle_map.find(*vehicle_id);
       if (vehicle_it != vehicle_map.end()) {
         route["vehicle_external_id"] = vehicle_it->second;
       }
@@ -431,12 +450,12 @@ void ApplyExternalIdsToRoutes(Json::Value& routes,
       if (!step.isObject()) {
         continue;
       }
-      const auto job_id = step["job"];
-      if (!job_id.isUInt64()) {
+      const auto job_id = ParsePositiveId(step["job"]);
+      if (!job_id.has_value()) {
         continue;
       }
 
-      const auto job_it = job_map.find(job_id.asUInt64());
+      const auto job_it = job_map.find(*job_id);
       if (job_it != job_map.end()) {
         step["job_external_id"] = job_it->second;
       }
@@ -451,12 +470,12 @@ void ApplyExternalIdsToUnassigned(Json::Value& unassigned,
     if (!job.isObject()) {
       continue;
     }
-    const auto job_id = job["id"];
-    if (!job_id.isUInt64()) {
+    const auto job_id = ParsePositiveId(job["id"]);
+    if (!job_id.has_value()) {
       continue;
     }
 
-    const auto job_it = job_map.find(job_id.asUInt64());
+    const auto job_it = job_map.find(*job_id);
     if (job_it != job_map.end()) {
       job["job_external_id"] = job_it->second;
     }

--- a/app/api/src/optimize_request.cpp
+++ b/app/api/src/optimize_request.cpp
@@ -305,7 +305,8 @@ void ParseDepot(const Json::Value& root, deliveryoptimizer::api::OptimizeRequest
 }
 
 void ParseVehicles(const Json::Value& root,
-                   deliveryoptimizer::api::OptimizeRequestInput& parsed_input, Json::Value& issues) {
+                   deliveryoptimizer::api::OptimizeRequestInput& parsed_input,
+                   Json::Value& issues) {
   const Json::Value& vehicles = root["vehicles"];
   if (!vehicles.isArray()) {
     AddValidationIssue(issues, "vehicles", "is required and must be a non-empty array.");
@@ -369,7 +370,8 @@ void ParseJobs(const Json::Value& root, deliveryoptimizer::api::OptimizeRequestI
   return values;
 }
 
-[[nodiscard]] Json::Value BuildTimeWindowArray(const deliveryoptimizer::api::TimeWindow& time_window) {
+[[nodiscard]] Json::Value
+BuildTimeWindowArray(const deliveryoptimizer::api::TimeWindow& time_window) {
   Json::Value values{Json::arrayValue};
   values.append(static_cast<Json::Int64>(time_window.start.time_since_epoch().count()));
   values.append(static_cast<Json::Int64>(time_window.end.time_since_epoch().count()));
@@ -466,7 +468,7 @@ void ApplyExternalIdsToUnassigned(Json::Value& unassigned,
 namespace deliveryoptimizer::api {
 
 std::optional<ParsedOptimizeRequest> ParseAndValidateOptimizeRequest(const Json::Value& root,
-                                                                    Json::Value& issues) {
+                                                                     Json::Value& issues) {
   issues = Json::Value{Json::arrayValue};
   if (!root.isObject()) {
     AddValidationIssue(issues, "body", "must be a JSON object.");

--- a/app/api/src/optimize_request.cpp
+++ b/app/api/src/optimize_request.cpp
@@ -1,0 +1,578 @@
+#include "deliveryoptimizer/api/optimize_request.hpp"
+
+#include "deliveryoptimizer/api/deliveries_optimize_limits.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr int kDefaultJobServiceSeconds = 300;
+constexpr double kMinLongitude = -180.0;
+constexpr double kMaxLongitude = 180.0;
+constexpr double kMinLatitude = -90.0;
+constexpr double kMaxLatitude = 90.0;
+constexpr std::string_view kCoordinateValidationMessage =
+    "must be an array [lon, lat] with longitude in [-180, 180] and latitude in [-90, 90].";
+constexpr Json::ArrayIndex kMaxOptimizeVehicles =
+    static_cast<Json::ArrayIndex>(deliveryoptimizer::api::kMaxDeliveriesOptimizeVehicles);
+constexpr Json::ArrayIndex kMaxOptimizeJobs =
+    static_cast<Json::ArrayIndex>(deliveryoptimizer::api::kMaxDeliveriesOptimizeJobs);
+
+void AddValidationIssue(Json::Value& issues, const std::string_view field,
+                        const std::string_view message) {
+  Json::Value issue{Json::objectValue};
+  issue["field"] = std::string{field};
+  issue["message"] = std::string{message};
+  issues.append(issue);
+}
+
+[[nodiscard]] std::string BuildMaxItemsMessage(const Json::ArrayIndex max_items) {
+  return "must contain at most " + std::to_string(static_cast<unsigned long long>(max_items)) +
+         " items.";
+}
+
+[[nodiscard]] std::optional<deliveryoptimizer::api::Coordinate>
+ParseCoordinate(const Json::Value& value) {
+  if (!value.isArray() || value.size() != 2U || !value[0].isNumeric() || !value[1].isNumeric()) {
+    return std::nullopt;
+  }
+
+  const double lon = value[0].asDouble();
+  const double lat = value[1].asDouble();
+  if (!std::isfinite(lon) || !std::isfinite(lat) || lon < kMinLongitude || lon > kMaxLongitude ||
+      lat < kMinLatitude || lat > kMaxLatitude) {
+    return std::nullopt;
+  }
+
+  return deliveryoptimizer::api::Coordinate{.lon = lon, .lat = lat};
+}
+
+[[nodiscard]] std::optional<int> ParseBoundedInt(const Json::Value& value, const int min_value) {
+  if (value.isInt64()) {
+    const Json::Int64 parsed = value.asInt64();
+    if (parsed < static_cast<Json::Int64>(min_value) ||
+        parsed > static_cast<Json::Int64>(std::numeric_limits<int>::max())) {
+      return std::nullopt;
+    }
+
+    return static_cast<int>(parsed);
+  }
+
+  if (value.isUInt64()) {
+    const Json::UInt64 parsed = value.asUInt64();
+    if (parsed < static_cast<Json::UInt64>(min_value) ||
+        parsed > static_cast<Json::UInt64>(std::numeric_limits<int>::max())) {
+      return std::nullopt;
+    }
+
+    return static_cast<int>(parsed);
+  }
+
+  return std::nullopt;
+}
+
+[[nodiscard]] std::optional<std::chrono::sys_seconds>
+ParseNonNegativeEpochSeconds(const Json::Value& value) {
+  if (value.isInt64()) {
+    const Json::Int64 parsed = value.asInt64();
+    if (parsed < 0) {
+      return std::nullopt;
+    }
+
+    return std::chrono::sys_seconds{std::chrono::seconds{static_cast<std::int64_t>(parsed)}};
+  }
+
+  if (value.isUInt64()) {
+    const Json::UInt64 parsed = value.asUInt64();
+    if (parsed > static_cast<Json::UInt64>(std::numeric_limits<std::int64_t>::max())) {
+      return std::nullopt;
+    }
+
+    return std::chrono::sys_seconds{
+        std::chrono::seconds{static_cast<std::int64_t>(parsed)},
+    };
+  }
+
+  return std::nullopt;
+}
+
+[[nodiscard]] std::optional<deliveryoptimizer::api::TimeWindow>
+ParseTimeWindow(const Json::Value& value) {
+  if (!value.isArray() || value.size() != 2U) {
+    return std::nullopt;
+  }
+
+  const auto parsed_start = ParseNonNegativeEpochSeconds(value[0]);
+  const auto parsed_end = ParseNonNegativeEpochSeconds(value[1]);
+  if (!parsed_start.has_value() || !parsed_end.has_value() ||
+      parsed_end.value() <= parsed_start.value()) {
+    return std::nullopt;
+  }
+
+  return deliveryoptimizer::api::TimeWindow{
+      .start = parsed_start.value(),
+      .end = parsed_end.value(),
+  };
+}
+
+[[nodiscard]] std::optional<std::vector<deliveryoptimizer::api::TimeWindow>>
+ParseTimeWindows(const Json::Value& value) {
+  if (!value.isArray() || value.empty()) {
+    return std::nullopt;
+  }
+
+  std::vector<deliveryoptimizer::api::TimeWindow> windows;
+  windows.reserve(value.size());
+  for (Json::ArrayIndex index = 0U; index < value.size(); ++index) {
+    const auto parsed_window = ParseTimeWindow(value[index]);
+    if (!parsed_window.has_value()) {
+      return std::nullopt;
+    }
+    windows.push_back(parsed_window.value());
+  }
+
+  return windows;
+}
+
+[[nodiscard]] std::optional<deliveryoptimizer::api::VehicleInput>
+ParseVehicle(const Json::Value& vehicle, const std::string_view base_field, Json::Value& issues) {
+  if (!vehicle.isObject()) {
+    AddValidationIssue(issues, base_field, "must be an object.");
+    return std::nullopt;
+  }
+
+  const Json::Value& vehicle_id = vehicle["id"];
+  const Json::Value& capacity = vehicle["capacity"];
+  const Json::Value& start = vehicle["start"];
+  const Json::Value& end = vehicle["end"];
+  const Json::Value& time_window = vehicle["time_window"];
+
+  bool valid_vehicle = true;
+  std::string external_id;
+  std::optional<deliveryoptimizer::api::Coordinate> start_coordinate;
+  std::optional<deliveryoptimizer::api::Coordinate> end_coordinate;
+  std::optional<deliveryoptimizer::api::TimeWindow> vehicle_time_window;
+
+  if (!vehicle_id.isString() || vehicle_id.asString().empty()) {
+    AddValidationIssue(issues, std::string{base_field} + ".id", "must be a non-empty string.");
+    valid_vehicle = false;
+  } else {
+    external_id = vehicle_id.asString();
+  }
+
+  const auto parsed_capacity = ParseBoundedInt(capacity, 1);
+  if (!parsed_capacity.has_value()) {
+    AddValidationIssue(issues, std::string{base_field} + ".capacity",
+                       "must be a positive integer.");
+    valid_vehicle = false;
+  }
+
+  if (vehicle.isMember("start")) {
+    start_coordinate = ParseCoordinate(start);
+    if (!start_coordinate.has_value()) {
+      AddValidationIssue(issues, std::string{base_field} + ".start", kCoordinateValidationMessage);
+      valid_vehicle = false;
+    }
+  }
+
+  if (vehicle.isMember("end")) {
+    end_coordinate = ParseCoordinate(end);
+    if (!end_coordinate.has_value()) {
+      AddValidationIssue(issues, std::string{base_field} + ".end", kCoordinateValidationMessage);
+      valid_vehicle = false;
+    }
+  }
+
+  if (vehicle.isMember("time_window")) {
+    vehicle_time_window = ParseTimeWindow(time_window);
+    if (!vehicle_time_window.has_value()) {
+      AddValidationIssue(
+          issues, std::string{base_field} + ".time_window",
+          "must be an array [start, end] with non-negative integer values and end > start.");
+      valid_vehicle = false;
+    }
+  }
+
+  if (!valid_vehicle) {
+    return std::nullopt;
+  }
+
+  return deliveryoptimizer::api::VehicleInput{.external_id = std::move(external_id),
+                                              .capacity = parsed_capacity.value(),
+                                              .start = start_coordinate,
+                                              .end = end_coordinate,
+                                              .time_window = vehicle_time_window};
+}
+
+[[nodiscard]] std::optional<deliveryoptimizer::api::JobInput>
+ParseJob(const Json::Value& job, const std::string_view base_field, Json::Value& issues) {
+  if (!job.isObject()) {
+    AddValidationIssue(issues, base_field, "must be an object.");
+    return std::nullopt;
+  }
+
+  const Json::Value& job_id = job["id"];
+  const Json::Value& location = job["location"];
+  const Json::Value& time_windows = job["time_windows"];
+
+  bool valid_job = true;
+  std::string external_id;
+  if (!job_id.isString() || job_id.asString().empty()) {
+    AddValidationIssue(issues, std::string{base_field} + ".id", "must be a non-empty string.");
+    valid_job = false;
+  } else {
+    external_id = job_id.asString();
+  }
+
+  const auto parsed_location = ParseCoordinate(location);
+  if (!parsed_location.has_value()) {
+    AddValidationIssue(issues, std::string{base_field} + ".location", kCoordinateValidationMessage);
+    valid_job = false;
+  }
+
+  int parsed_demand = 1;
+  if (job.isMember("demand")) {
+    const auto parsed_demand_value = ParseBoundedInt(job["demand"], 1);
+    if (!parsed_demand_value.has_value()) {
+      AddValidationIssue(issues, std::string{base_field} + ".demand",
+                         "must be a positive integer.");
+      valid_job = false;
+    } else {
+      parsed_demand = parsed_demand_value.value();
+    }
+  }
+
+  int parsed_service = kDefaultJobServiceSeconds;
+  std::optional<std::vector<deliveryoptimizer::api::TimeWindow>> parsed_time_windows;
+  if (job.isMember("service")) {
+    const auto parsed_service_value = ParseBoundedInt(job["service"], 0);
+    if (!parsed_service_value.has_value()) {
+      AddValidationIssue(issues, std::string{base_field} + ".service",
+                         "must be a non-negative integer.");
+      valid_job = false;
+    } else {
+      parsed_service = parsed_service_value.value();
+    }
+  }
+
+  if (job.isMember("time_windows")) {
+    parsed_time_windows = ParseTimeWindows(time_windows);
+    if (!parsed_time_windows.has_value()) {
+      AddValidationIssue(issues, std::string{base_field} + ".time_windows",
+                         "must be an array of [start, end] pairs with non-negative integer values "
+                         "and end > start.");
+      valid_job = false;
+    }
+  }
+
+  if (!valid_job) {
+    return std::nullopt;
+  }
+
+  return deliveryoptimizer::api::JobInput{.external_id = std::move(external_id),
+                                          .lon = parsed_location->lon,
+                                          .lat = parsed_location->lat,
+                                          .demand = parsed_demand,
+                                          .service = parsed_service,
+                                          .time_windows = std::move(parsed_time_windows)};
+}
+
+void ParseDepot(const Json::Value& root, deliveryoptimizer::api::OptimizeRequestInput& parsed_input,
+                Json::Value& issues) {
+  const Json::Value& depot = root["depot"];
+  if (!depot.isObject()) {
+    AddValidationIssue(issues, "depot", "is required and must be an object.");
+    return;
+  }
+
+  const auto depot_coordinate = ParseCoordinate(depot["location"]);
+  if (!depot_coordinate.has_value()) {
+    AddValidationIssue(issues, "depot.location", kCoordinateValidationMessage);
+    return;
+  }
+
+  parsed_input.depot_lon = depot_coordinate->lon;
+  parsed_input.depot_lat = depot_coordinate->lat;
+}
+
+void ParseVehicles(const Json::Value& root,
+                   deliveryoptimizer::api::OptimizeRequestInput& parsed_input, Json::Value& issues) {
+  const Json::Value& vehicles = root["vehicles"];
+  if (!vehicles.isArray()) {
+    AddValidationIssue(issues, "vehicles", "is required and must be a non-empty array.");
+    return;
+  }
+
+  if (vehicles.empty()) {
+    AddValidationIssue(issues, "vehicles", "must not be empty.");
+    return;
+  }
+  if (vehicles.size() > kMaxOptimizeVehicles) {
+    AddValidationIssue(issues, "vehicles", BuildMaxItemsMessage(kMaxOptimizeVehicles));
+    return;
+  }
+
+  for (Json::ArrayIndex index = 0U; index < vehicles.size(); ++index) {
+    const std::string base_field = "vehicles[" + std::to_string(index) + "]";
+    const auto parsed_vehicle = ParseVehicle(vehicles[index], base_field, issues);
+    if (parsed_vehicle.has_value()) {
+      parsed_input.vehicles.push_back(parsed_vehicle.value());
+    }
+  }
+}
+
+void ParseJobs(const Json::Value& root, deliveryoptimizer::api::OptimizeRequestInput& parsed_input,
+               Json::Value& issues) {
+  const Json::Value& jobs = root["jobs"];
+  if (!jobs.isArray()) {
+    AddValidationIssue(issues, "jobs", "is required and must be a non-empty array.");
+    return;
+  }
+
+  if (jobs.empty()) {
+    AddValidationIssue(issues, "jobs", "must not be empty.");
+    return;
+  }
+  if (jobs.size() > kMaxOptimizeJobs) {
+    AddValidationIssue(issues, "jobs", BuildMaxItemsMessage(kMaxOptimizeJobs));
+    return;
+  }
+
+  for (Json::ArrayIndex index = 0U; index < jobs.size(); ++index) {
+    const std::string base_field = "jobs[" + std::to_string(index) + "]";
+    const auto parsed_job = ParseJob(jobs[index], base_field, issues);
+    if (parsed_job.has_value()) {
+      parsed_input.jobs.push_back(parsed_job.value());
+    }
+  }
+}
+
+[[nodiscard]] Json::Value BuildLocation(const double lon, const double lat) {
+  Json::Value location{Json::arrayValue};
+  location.append(lon);
+  location.append(lat);
+  return location;
+}
+
+[[nodiscard]] Json::Value BuildUnitArray(const int value) {
+  Json::Value values{Json::arrayValue};
+  values.append(value);
+  return values;
+}
+
+[[nodiscard]] Json::Value BuildTimeWindowArray(const deliveryoptimizer::api::TimeWindow& time_window) {
+  Json::Value values{Json::arrayValue};
+  values.append(static_cast<Json::Int64>(time_window.start.time_since_epoch().count()));
+  values.append(static_cast<Json::Int64>(time_window.end.time_since_epoch().count()));
+  return values;
+}
+
+[[nodiscard]] Json::Value
+BuildTimeWindowsArray(const std::vector<deliveryoptimizer::api::TimeWindow>& time_windows) {
+  Json::Value values{Json::arrayValue};
+  for (const auto& time_window : time_windows) {
+    values.append(BuildTimeWindowArray(time_window));
+  }
+  return values;
+}
+
+[[nodiscard]] std::map<std::uint64_t, std::string>
+BuildVehicleExternalIdMap(const deliveryoptimizer::api::OptimizeRequestInput& input) {
+  std::map<std::uint64_t, std::string> vehicle_map;
+  for (std::size_t index = 0U; index < input.vehicles.size(); ++index) {
+    vehicle_map.emplace(static_cast<std::uint64_t>(index + 1U), input.vehicles[index].external_id);
+  }
+  return vehicle_map;
+}
+
+[[nodiscard]] std::map<std::uint64_t, std::string>
+BuildJobExternalIdMap(const deliveryoptimizer::api::OptimizeRequestInput& input) {
+  std::map<std::uint64_t, std::string> job_map;
+  for (std::size_t index = 0U; index < input.jobs.size(); ++index) {
+    job_map.emplace(static_cast<std::uint64_t>(index + 1U), input.jobs[index].external_id);
+  }
+  return job_map;
+}
+
+void ApplyExternalIdsToRoutes(Json::Value& routes,
+                              const std::map<std::uint64_t, std::string>& vehicle_map,
+                              const std::map<std::uint64_t, std::string>& job_map) {
+  for (Json::ArrayIndex route_index = 0U; route_index < routes.size(); ++route_index) {
+    Json::Value& route = routes[route_index];
+    const auto vehicle_id = route["vehicle"];
+    if (vehicle_id.isUInt64()) {
+      const auto vehicle_it = vehicle_map.find(vehicle_id.asUInt64());
+      if (vehicle_it != vehicle_map.end()) {
+        route["vehicle_id"] = vehicle_it->second;
+      }
+    }
+
+    Json::Value& steps = route["steps"];
+    if (!steps.isArray()) {
+      continue;
+    }
+
+    for (Json::ArrayIndex step_index = 0U; step_index < steps.size(); ++step_index) {
+      Json::Value& step = steps[step_index];
+      const auto job_id = step["job"];
+      if (!job_id.isUInt64()) {
+        continue;
+      }
+
+      const auto job_it = job_map.find(job_id.asUInt64());
+      if (job_it != job_map.end()) {
+        step["job_id"] = job_it->second;
+      }
+    }
+  }
+}
+
+void ApplyExternalIdsToUnassigned(Json::Value& unassigned,
+                                  const std::map<std::uint64_t, std::string>& job_map) {
+  for (Json::ArrayIndex index = 0U; index < unassigned.size(); ++index) {
+    Json::Value& job = unassigned[index];
+    const auto job_id = job["id"];
+    if (!job_id.isUInt64()) {
+      continue;
+    }
+
+    const auto job_it = job_map.find(job_id.asUInt64());
+    if (job_it != job_map.end()) {
+      job["job_id"] = job_it->second;
+    }
+  }
+}
+
+} // namespace
+
+namespace deliveryoptimizer::api {
+
+std::optional<ParsedOptimizeRequest> ParseAndValidateOptimizeRequest(const Json::Value& root,
+                                                                    Json::Value& issues) {
+  issues = Json::Value{Json::arrayValue};
+  if (!root.isObject()) {
+    AddValidationIssue(issues, "body", "must be a JSON object.");
+    return std::nullopt;
+  }
+
+  OptimizeRequestInput parsed_input{};
+  ParseDepot(root, parsed_input, issues);
+  ParseVehicles(root, parsed_input, issues);
+  ParseJobs(root, parsed_input, issues);
+
+  if (!issues.empty()) {
+    return std::nullopt;
+  }
+
+  const SolveRequestSize request_size{
+      .jobs = parsed_input.jobs.size(),
+      .vehicles = parsed_input.vehicles.size(),
+  };
+  return ParsedOptimizeRequest{
+      .input = std::move(parsed_input),
+      .size = request_size,
+  };
+}
+
+std::optional<SolveRequestSize> TryParseOptimizeRequestSize(const Json::Value& root) {
+  if (!root.isObject()) {
+    return std::nullopt;
+  }
+
+  const Json::Value& vehicles = root["vehicles"];
+  const Json::Value& jobs = root["jobs"];
+  if (!vehicles.isArray() || !jobs.isArray()) {
+    return std::nullopt;
+  }
+
+  if (vehicles.size() > kMaxOptimizeVehicles || jobs.size() > kMaxOptimizeJobs) {
+    return std::nullopt;
+  }
+
+  return SolveRequestSize{
+      .jobs = static_cast<std::size_t>(jobs.size()),
+      .vehicles = static_cast<std::size_t>(vehicles.size()),
+  };
+}
+
+Json::Value BuildVroomInput(const OptimizeRequestInput& input) {
+  Json::Value payload{Json::objectValue};
+  payload["jobs"] = Json::Value{Json::arrayValue};
+  payload["vehicles"] = Json::Value{Json::arrayValue};
+
+  for (std::size_t index = 0U; index < input.jobs.size(); ++index) {
+    const JobInput& job_input = input.jobs[index];
+    Json::Value job{Json::objectValue};
+    job["id"] = static_cast<Json::UInt64>(index + 1U);
+    job["location"] = BuildLocation(job_input.lon, job_input.lat);
+    job["amount"] = BuildUnitArray(job_input.demand);
+    job["service"] = job_input.service;
+    job["description"] = job_input.external_id;
+    if (job_input.time_windows.has_value()) {
+      job["time_windows"] = BuildTimeWindowsArray(job_input.time_windows.value());
+    }
+    payload["jobs"].append(job);
+  }
+
+  for (std::size_t index = 0U; index < input.vehicles.size(); ++index) {
+    const VehicleInput& vehicle_input = input.vehicles[index];
+    Json::Value vehicle{Json::objectValue};
+    const Coordinate start = vehicle_input.start.value_or(Coordinate{
+        .lon = input.depot_lon,
+        .lat = input.depot_lat,
+    });
+    const Coordinate end = vehicle_input.end.value_or(Coordinate{
+        .lon = input.depot_lon,
+        .lat = input.depot_lat,
+    });
+    vehicle["id"] = static_cast<Json::UInt64>(index + 1U);
+    vehicle["start"] = BuildLocation(start.lon, start.lat);
+    vehicle["end"] = BuildLocation(end.lon, end.lat);
+    vehicle["capacity"] = BuildUnitArray(vehicle_input.capacity);
+    vehicle["description"] = vehicle_input.external_id;
+    if (vehicle_input.time_window.has_value()) {
+      vehicle["time_window"] = BuildTimeWindowArray(vehicle_input.time_window.value());
+    }
+    payload["vehicles"].append(vehicle);
+  }
+
+  return payload;
+}
+
+Json::Value BuildOptimizeSuccessBody(const OptimizeRequestInput& input,
+                                     const Json::Value& vroom_output) {
+  Json::Value body{Json::objectValue};
+  body["status"] = "ok";
+
+  const Json::Value& summary = vroom_output["summary"];
+  body["summary"] = summary.isObject() ? summary : Json::Value{Json::objectValue};
+
+  Json::Value routes = vroom_output["routes"];
+  if (!routes.isArray()) {
+    routes = Json::Value{Json::arrayValue};
+  }
+  Json::Value unassigned = vroom_output["unassigned"];
+  if (!unassigned.isArray()) {
+    unassigned = Json::Value{Json::arrayValue};
+  }
+
+  const auto vehicle_map = BuildVehicleExternalIdMap(input);
+  const auto job_map = BuildJobExternalIdMap(input);
+  ApplyExternalIdsToRoutes(routes, vehicle_map, job_map);
+  ApplyExternalIdsToUnassigned(unassigned, job_map);
+  body["routes"] = std::move(routes);
+  body["unassigned"] = std::move(unassigned);
+
+  return body;
+}
+
+} // namespace deliveryoptimizer::api

--- a/app/api/src/optimize_request.cpp
+++ b/app/api/src/optimize_request.cpp
@@ -412,7 +412,7 @@ void ApplyExternalIdsToRoutes(Json::Value& routes,
     if (vehicle_id.isUInt64()) {
       const auto vehicle_it = vehicle_map.find(vehicle_id.asUInt64());
       if (vehicle_it != vehicle_map.end()) {
-        route["vehicle_id"] = vehicle_it->second;
+        route["vehicle_external_id"] = vehicle_it->second;
       }
     }
 
@@ -430,7 +430,7 @@ void ApplyExternalIdsToRoutes(Json::Value& routes,
 
       const auto job_it = job_map.find(job_id.asUInt64());
       if (job_it != job_map.end()) {
-        step["job_id"] = job_it->second;
+        step["job_external_id"] = job_it->second;
       }
     }
   }
@@ -447,7 +447,7 @@ void ApplyExternalIdsToUnassigned(Json::Value& unassigned,
 
     const auto job_it = job_map.find(job_id.asUInt64());
     if (job_it != job_map.end()) {
-      job["job_id"] = job_it->second;
+      job["job_external_id"] = job_it->second;
     }
   }
 }

--- a/app/api/src/optimize_request.cpp
+++ b/app/api/src/optimize_request.cpp
@@ -408,6 +408,9 @@ void ApplyExternalIdsToRoutes(Json::Value& routes,
                               const std::map<std::uint64_t, std::string>& job_map) {
   for (Json::ArrayIndex route_index = 0U; route_index < routes.size(); ++route_index) {
     Json::Value& route = routes[route_index];
+    if (!route.isObject()) {
+      continue;
+    }
     const auto vehicle_id = route["vehicle"];
     if (vehicle_id.isUInt64()) {
       const auto vehicle_it = vehicle_map.find(vehicle_id.asUInt64());
@@ -423,6 +426,9 @@ void ApplyExternalIdsToRoutes(Json::Value& routes,
 
     for (Json::ArrayIndex step_index = 0U; step_index < steps.size(); ++step_index) {
       Json::Value& step = steps[step_index];
+      if (!step.isObject()) {
+        continue;
+      }
       const auto job_id = step["job"];
       if (!job_id.isUInt64()) {
         continue;
@@ -440,6 +446,9 @@ void ApplyExternalIdsToUnassigned(Json::Value& unassigned,
                                   const std::map<std::uint64_t, std::string>& job_map) {
   for (Json::ArrayIndex index = 0U; index < unassigned.size(); ++index) {
     Json::Value& job = unassigned[index];
+    if (!job.isObject()) {
+      continue;
+    }
     const auto job_id = job["id"];
     if (!job_id.isUInt64()) {
       continue;

--- a/app/api/src/request_context.cpp
+++ b/app/api/src/request_context.cpp
@@ -1,9 +1,8 @@
 #include "deliveryoptimizer/api/observability.hpp"
 
+#include <chrono>
 #include <drogon/HttpRequest.h>
 #include <drogon/utils/Utilities.h>
-
-#include <chrono>
 #include <string>
 #include <utility>
 

--- a/app/api/src/server_options.cpp
+++ b/app/api/src/server_options.cpp
@@ -183,10 +183,9 @@ template <typename Integer>
   const std::size_t timeout_ms = ResolveNonNegativeSizeOption(
       kSolverQueueWaitMsEnv, static_cast<std::size_t>(kDefaultSolverQueueWaitMs),
       "solver queue wait timeout (ms)");
-  const auto max_queue_wait_timeout =
-      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::duration::max());
-  const std::uint64_t max_timeout_ms =
-      static_cast<std::uint64_t>(max_queue_wait_timeout.count());
+  const auto max_queue_wait_timeout = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::duration::max());
+  const std::uint64_t max_timeout_ms = static_cast<std::uint64_t>(max_queue_wait_timeout.count());
   if (static_cast<std::uint64_t>(timeout_ms) > max_timeout_ms) {
     std::cerr << "Capping " << kSolverQueueWaitMsEnv << "='" << timeout_ms << "' to "
               << max_timeout_ms << " because larger solver queue wait timeout (ms) values "

--- a/app/api/src/solve_coordinator.cpp
+++ b/app/api/src/solve_coordinator.cpp
@@ -40,11 +40,11 @@ ToCoordinatedSolveResult(const deliveryoptimizer::api::VroomRunResult& result) {
   return accepted_solves < config.max_concurrency;
 }
 
-[[nodiscard]] std::chrono::steady_clock::time_point ResolveDeadline(
-    const std::chrono::steady_clock::time_point queued_at,
-    const std::chrono::milliseconds queue_wait) {
-  const auto max_queue_wait =
-      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::duration::max());
+[[nodiscard]] std::chrono::steady_clock::time_point
+ResolveDeadline(const std::chrono::steady_clock::time_point queued_at,
+                const std::chrono::milliseconds queue_wait) {
+  const auto max_queue_wait = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::duration::max());
   const auto clamped_queue_wait = std::min(queue_wait, max_queue_wait);
   const auto queue_wait_duration =
       std::chrono::duration_cast<std::chrono::steady_clock::duration>(clamped_queue_wait);
@@ -77,9 +77,7 @@ SolveCoordinator::SolveCoordinator(SolveAdmissionConfig config,
                                    std::shared_ptr<const VroomRunner> runner,
                                    SolveCoordinatorOptions options,
                                    std::shared_ptr<ObservabilityRegistry> observability)
-    : config_(config),
-      options_(options),
-      runner_(std::move(runner)),
+    : config_(config), options_(options), runner_(std::move(runner)),
       observability_(std::move(observability)) {
   if (observability_ == nullptr) {
     observability_ = std::make_shared<ObservabilityRegistry>(ObservabilityOptions{
@@ -142,8 +140,9 @@ SolveCoordinator::~SolveCoordinator() {
   completion_workers_.clear();
 }
 
-SolveAdmissionStatus SolveCoordinator::CheckAdmission(const SolveRequestSize& request_size,
-                                                      std::shared_ptr<SolveLifecycle> lifecycle) {
+SolveAdmissionStatus
+SolveCoordinator::CheckAdmission(const SolveRequestSize& request_size,
+                                 const std::shared_ptr<SolveLifecycle>& lifecycle) {
   std::lock_guard<std::mutex> lock(mutex_);
   return CheckAdmissionLocked(request_size, lifecycle);
 }
@@ -192,9 +191,9 @@ void SolveCoordinator::EnqueueCompletion(CompletionTask task) {
   completion_condition_.notify_one();
 }
 
-SolveAdmissionStatus SolveCoordinator::CheckAdmissionLocked(
-    const SolveRequestSize& request_size,
-    const std::shared_ptr<SolveLifecycle>& lifecycle) {
+SolveAdmissionStatus
+SolveCoordinator::CheckAdmissionLocked(const SolveRequestSize& request_size,
+                                       const std::shared_ptr<SolveLifecycle>& lifecycle) {
   UpdateLifecycleState(lifecycle, queue_.size(), active_solves_);
   if (shutting_down_) {
     return SolveAdmissionStatus::kRejectedQueueFull;
@@ -307,7 +306,8 @@ void SolveCoordinator::QueueTimerLoop() {
       }
 
       auto expired_request_it = find_earliest_deadline();
-      if (expired_request_it == queue_.end() || !HasQueueWaitExpired(expired_request_it->deadline)) {
+      if (expired_request_it == queue_.end() ||
+          !HasQueueWaitExpired(expired_request_it->deadline)) {
         continue;
       }
 

--- a/app/api/src/solve_execution.cpp
+++ b/app/api/src/solve_execution.cpp
@@ -2,8 +2,8 @@
 
 namespace {
 
-[[nodiscard]] deliveryoptimizer::api::CoordinatedSolveResult ToCoordinatedSolveResult(
-    const deliveryoptimizer::api::VroomRunResult& result) {
+[[nodiscard]] deliveryoptimizer::api::CoordinatedSolveResult
+ToCoordinatedSolveResult(const deliveryoptimizer::api::VroomRunResult& result) {
   switch (result.status) {
   case deliveryoptimizer::api::VroomRunStatus::kSuccess:
     return deliveryoptimizer::api::CoordinatedSolveResult{

--- a/app/api/src/solve_execution.cpp
+++ b/app/api/src/solve_execution.cpp
@@ -1,0 +1,86 @@
+#include "deliveryoptimizer/api/solve_execution.hpp"
+
+namespace {
+
+[[nodiscard]] deliveryoptimizer::api::CoordinatedSolveResult ToCoordinatedSolveResult(
+    const deliveryoptimizer::api::VroomRunResult& result) {
+  switch (result.status) {
+  case deliveryoptimizer::api::VroomRunStatus::kSuccess:
+    return deliveryoptimizer::api::CoordinatedSolveResult{
+        .status = deliveryoptimizer::api::CoordinatedSolveStatus::kSucceeded,
+        .output = result.output,
+    };
+  case deliveryoptimizer::api::VroomRunStatus::kTimedOut:
+    return deliveryoptimizer::api::CoordinatedSolveResult{
+        .status = deliveryoptimizer::api::CoordinatedSolveStatus::kTimedOut,
+        .output = std::nullopt,
+    };
+  case deliveryoptimizer::api::VroomRunStatus::kFailed:
+    break;
+  }
+
+  return deliveryoptimizer::api::CoordinatedSolveResult{
+      .status = deliveryoptimizer::api::CoordinatedSolveStatus::kFailed,
+      .output = std::nullopt,
+  };
+}
+
+} // namespace
+
+namespace deliveryoptimizer::api {
+
+SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input,
+                                               const CoordinatedSolveResult& result) {
+  switch (result.status) {
+  case CoordinatedSolveStatus::kSucceeded:
+    if (result.output.has_value()) {
+      return SolveExecutionResult{
+          .status = SolveExecutionStatus::kSucceeded,
+          .outcome = SolveRequestOutcome::kSucceeded,
+          .http_status = 200U,
+          .response_body = BuildOptimizeSuccessBody(input, *result.output),
+          .error_message = {},
+      };
+    }
+    return SolveExecutionResult{
+        .status = SolveExecutionStatus::kFailed,
+        .outcome = SolveRequestOutcome::kFailed,
+        .http_status = 502U,
+        .response_body = std::nullopt,
+        .error_message = "Routing optimization failed.",
+    };
+  case CoordinatedSolveStatus::kTimedOut:
+    return SolveExecutionResult{
+        .status = SolveExecutionStatus::kTimedOut,
+        .outcome = SolveRequestOutcome::kSolveTimedOut,
+        .http_status = 504U,
+        .response_body = std::nullopt,
+        .error_message = "Routing optimization timed out.",
+    };
+  case CoordinatedSolveStatus::kQueueWaitTimedOut:
+    return SolveExecutionResult{
+        .status = SolveExecutionStatus::kQueueWaitTimedOut,
+        .outcome = SolveRequestOutcome::kQueueWaitTimedOut,
+        .http_status = 503U,
+        .response_body = std::nullopt,
+        .error_message = "Routing optimization queue wait timed out.",
+    };
+  case CoordinatedSolveStatus::kFailed:
+    break;
+  }
+
+  return SolveExecutionResult{
+      .status = SolveExecutionStatus::kFailed,
+      .outcome = SolveRequestOutcome::kFailed,
+      .http_status = 502U,
+      .response_body = std::nullopt,
+      .error_message = "Routing optimization failed.",
+  };
+}
+
+SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input,
+                                               const VroomRunResult& result) {
+  return BuildSolveExecutionResult(input, ToCoordinatedSolveResult(result));
+}
+
+} // namespace deliveryoptimizer::api

--- a/app/api/src/solve_execution.cpp
+++ b/app/api/src/solve_execution.cpp
@@ -1,32 +1,5 @@
 #include "deliveryoptimizer/api/solve_execution.hpp"
 
-namespace {
-
-[[nodiscard]] deliveryoptimizer::api::CoordinatedSolveResult
-ToCoordinatedSolveResult(const deliveryoptimizer::api::VroomRunResult& result) {
-  switch (result.status) {
-  case deliveryoptimizer::api::VroomRunStatus::kSuccess:
-    return deliveryoptimizer::api::CoordinatedSolveResult{
-        .status = deliveryoptimizer::api::CoordinatedSolveStatus::kSucceeded,
-        .output = result.output,
-    };
-  case deliveryoptimizer::api::VroomRunStatus::kTimedOut:
-    return deliveryoptimizer::api::CoordinatedSolveResult{
-        .status = deliveryoptimizer::api::CoordinatedSolveStatus::kTimedOut,
-        .output = std::nullopt,
-    };
-  case deliveryoptimizer::api::VroomRunStatus::kFailed:
-    break;
-  }
-
-  return deliveryoptimizer::api::CoordinatedSolveResult{
-      .status = deliveryoptimizer::api::CoordinatedSolveStatus::kFailed,
-      .output = std::nullopt,
-  };
-}
-
-} // namespace
-
 namespace deliveryoptimizer::api {
 
 SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input,
@@ -35,7 +8,6 @@ SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input
   case CoordinatedSolveStatus::kSucceeded:
     if (result.output.has_value()) {
       return SolveExecutionResult{
-          .status = SolveExecutionStatus::kSucceeded,
           .outcome = SolveRequestOutcome::kSucceeded,
           .http_status = 200U,
           .response_body = BuildOptimizeSuccessBody(input, *result.output),
@@ -43,7 +15,6 @@ SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input
       };
     }
     return SolveExecutionResult{
-        .status = SolveExecutionStatus::kFailed,
         .outcome = SolveRequestOutcome::kFailed,
         .http_status = 502U,
         .response_body = std::nullopt,
@@ -51,7 +22,6 @@ SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input
     };
   case CoordinatedSolveStatus::kTimedOut:
     return SolveExecutionResult{
-        .status = SolveExecutionStatus::kTimedOut,
         .outcome = SolveRequestOutcome::kSolveTimedOut,
         .http_status = 504U,
         .response_body = std::nullopt,
@@ -59,7 +29,6 @@ SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input
     };
   case CoordinatedSolveStatus::kQueueWaitTimedOut:
     return SolveExecutionResult{
-        .status = SolveExecutionStatus::kQueueWaitTimedOut,
         .outcome = SolveRequestOutcome::kQueueWaitTimedOut,
         .http_status = 503U,
         .response_body = std::nullopt,
@@ -70,17 +39,11 @@ SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input
   }
 
   return SolveExecutionResult{
-      .status = SolveExecutionStatus::kFailed,
       .outcome = SolveRequestOutcome::kFailed,
       .http_status = 502U,
       .response_body = std::nullopt,
       .error_message = "Routing optimization failed.",
   };
-}
-
-SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input,
-                                               const VroomRunResult& result) {
-  return BuildSolveExecutionResult(input, ToCoordinatedSolveResult(result));
 }
 
 } // namespace deliveryoptimizer::api

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs/f8573b9c935cfaa162dd62cc9e75ae2db86f85df";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       systems = [
         "aarch64-darwin"
@@ -13,14 +14,20 @@
         "aarch64-linux"
         "x86_64-linux"
       ];
-      forAllSystems = f:
-        nixpkgs.lib.genAttrs systems (system:
-          f (import nixpkgs {
-            inherit system;
-          }));
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f (
+            import nixpkgs {
+              inherit system;
+            }
+          )
+        );
     in
     {
-      devShells = forAllSystems (pkgs:
+      devShells = forAllSystems (
+        pkgs:
         let
           # On this pinned nixpkgs rev, pkgs.llvmPackages resolves to LLVM 21.1.8.
           llvm = pkgs.llvmPackages;
@@ -68,7 +75,8 @@
               echo "Next step: conan profile detect --force && cmake --preset conan-release"
             '';
           };
-        });
+        }
+      );
 
       formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
     };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(
   deliveryoptimizer_tests
   PRIVATE
     "${CMAKE_SOURCE_DIR}/app/api/src/observability.cpp"
+    "${CMAKE_SOURCE_DIR}/app/api/src/optimize_request.cpp"
     "${CMAKE_SOURCE_DIR}/app/api/src/solve_admission.cpp"
     "${CMAKE_SOURCE_DIR}/app/api/src/solve_coordinator.cpp"
     "${CMAKE_SOURCE_DIR}/app/api/src/server_options.cpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -390,6 +390,16 @@ deliveryoptimizer_set_local_http_test_port(
   38100
 )
 deliveryoptimizer_add_local_http_test(
+  DeliveryOptimizerApiRegressionTest.DeliveriesOptimizeIgnoresMalformedVroomRouteEntries
+  deliveries_optimize_ignores_malformed_vroom_route_entries_test.sh
+  30
+  "${DELIVERYOPTIMIZER_LOCAL_API_REGRESSION_LABELS}"
+)
+deliveryoptimizer_set_local_http_test_port(
+  DeliveryOptimizerApiRegressionTest.DeliveriesOptimizeIgnoresMalformedVroomRouteEntries
+  38300
+)
+deliveryoptimizer_add_local_http_test(
   DeliveryOptimizerApiRegressionTest.DeliveriesOptimizeAcceptsSmallSyncSolve
   deliveries_optimize_accepts_small_sync_solve_test.sh
   30

--- a/tests/api/observability/renders_prometheus_metrics_test.cpp
+++ b/tests/api/observability/renders_prometheus_metrics_test.cpp
@@ -36,14 +36,15 @@ TEST(ObservabilityRegistryTest, RendersPrometheusMetricsWithExpectedFamiliesAndB
 
   const std::string rendered = registry.RenderPrometheusText();
 
-  EXPECT_NE(
-      rendered.find("# HELP deliveryoptimizer_solver_requests_accepted_total Count of solver requests accepted into the coordinator queue."),
-      std::string::npos);
+  EXPECT_NE(rendered.find("# HELP deliveryoptimizer_solver_requests_accepted_total Count of solver "
+                          "requests accepted into the coordinator queue."),
+            std::string::npos);
   EXPECT_NE(rendered.find("deliveryoptimizer_solver_requests_accepted_total 1"), std::string::npos);
   EXPECT_NE(rendered.find("deliveryoptimizer_solver_requests_succeeded_total 1"),
             std::string::npos);
   EXPECT_NE(rendered.find("deliveryoptimizer_solver_requests_rejected_total 1"), std::string::npos);
-  EXPECT_NE(rendered.find("deliveryoptimizer_solver_requests_timed_out_total 1"), std::string::npos);
+  EXPECT_NE(rendered.find("deliveryoptimizer_solver_requests_timed_out_total 1"),
+            std::string::npos);
   EXPECT_NE(rendered.find("deliveryoptimizer_solver_requests_failed_total 1"), std::string::npos);
   EXPECT_NE(rendered.find("deliveryoptimizer_request_tracker_write_failures_total 0"),
             std::string::npos);
@@ -118,6 +119,5 @@ TEST(ObservabilityRegistryTest, FinalizeClientErrorsIncrementRejectedCounter) {
 
   const std::string rendered = observability->RenderPrometheusText();
 
-  EXPECT_NE(rendered.find("deliveryoptimizer_solver_requests_rejected_total 3"),
-            std::string::npos);
+  EXPECT_NE(rendered.find("deliveryoptimizer_solver_requests_rejected_total 3"), std::string::npos);
 }

--- a/tests/api/optimize_request/build_optimize_success_body_preserves_signed_ids_test.cpp
+++ b/tests/api/optimize_request/build_optimize_success_body_preserves_signed_ids_test.cpp
@@ -1,0 +1,78 @@
+#include "deliveryoptimizer/api/optimize_request.hpp"
+
+#include <gtest/gtest.h>
+#include <json/json.h>
+
+namespace {
+
+TEST(OptimizeRequestTest, BuildOptimizeSuccessBodyPreservesExternalIdsForSignedPositiveIds) {
+  const deliveryoptimizer::api::OptimizeRequestInput input{
+      .depot_lon = 7.4236,
+      .depot_lat = 43.7384,
+      .vehicles =
+          {
+              deliveryoptimizer::api::VehicleInput{
+                  .external_id = "van-1",
+                  .capacity = 8,
+                  .start = std::nullopt,
+                  .end = std::nullopt,
+                  .time_window = std::nullopt,
+              },
+          },
+      .jobs =
+          {
+              deliveryoptimizer::api::JobInput{
+                  .external_id = "order-1",
+                  .lon = 7.4212,
+                  .lat = 43.7308,
+                  .demand = 1,
+                  .service = 180,
+                  .time_windows = std::nullopt,
+              },
+              deliveryoptimizer::api::JobInput{
+                  .external_id = "order-2",
+                  .lon = 7.4261,
+                  .lat = 43.7412,
+                  .demand = 1,
+                  .service = 120,
+                  .time_windows = std::nullopt,
+              },
+          },
+  };
+
+  Json::Value vroom_output{Json::objectValue};
+  vroom_output["summary"] = Json::Value{Json::objectValue};
+  vroom_output["summary"]["routes"] = 1;
+  vroom_output["summary"]["unassigned"] = 1;
+
+  Json::Value route{Json::objectValue};
+  route["vehicle"] = Json::Int64{1};
+  route["steps"] = Json::Value{Json::arrayValue};
+  Json::Value step{Json::objectValue};
+  step["type"] = "job";
+  step["job"] = Json::Int64{1};
+  route["steps"].append(step);
+
+  vroom_output["routes"] = Json::Value{Json::arrayValue};
+  vroom_output["routes"].append(route);
+
+  Json::Value unassigned_entry{Json::objectValue};
+  unassigned_entry["id"] = Json::Int64{2};
+  vroom_output["unassigned"] = Json::Value{Json::arrayValue};
+  vroom_output["unassigned"].append(unassigned_entry);
+
+  const Json::Value body = deliveryoptimizer::api::BuildOptimizeSuccessBody(input, vroom_output);
+
+  ASSERT_TRUE(body["routes"].isArray());
+  ASSERT_EQ(body["routes"].size(), 1U);
+  EXPECT_EQ(body["routes"][0]["vehicle_external_id"].asString(), "van-1");
+  ASSERT_TRUE(body["routes"][0]["steps"].isArray());
+  ASSERT_EQ(body["routes"][0]["steps"].size(), 1U);
+  EXPECT_EQ(body["routes"][0]["steps"][0]["job_external_id"].asString(), "order-1");
+
+  ASSERT_TRUE(body["unassigned"].isArray());
+  ASSERT_EQ(body["unassigned"].size(), 1U);
+  EXPECT_EQ(body["unassigned"][0]["job_external_id"].asString(), "order-2");
+}
+
+} // namespace

--- a/tests/api/solve_coordinator/records_lifecycle_metrics_test.cpp
+++ b/tests/api/solve_coordinator/records_lifecycle_metrics_test.cpp
@@ -76,8 +76,8 @@ public:
   };
 }
 
-[[nodiscard]] std::shared_ptr<deliveryoptimizer::api::SolveLifecycle> BuildLifecycle(
-    const std::string& request_id) {
+[[nodiscard]] std::shared_ptr<deliveryoptimizer::api::SolveLifecycle>
+BuildLifecycle(const std::string& request_id) {
   auto lifecycle = std::make_shared<deliveryoptimizer::api::SolveLifecycle>();
   lifecycle->request_id = request_id;
   lifecycle->method = "POST";
@@ -91,25 +91,23 @@ public:
 TEST(SolveCoordinatorLifecycleTest, RecordsLifecycleAndGaugeTransitionsForSuccessfulSolve) {
   auto runner = std::make_shared<BlockingRunner>();
   auto observability = std::make_shared<deliveryoptimizer::api::ObservabilityRegistry>();
-  deliveryoptimizer::api::SolveCoordinator coordinator(BuildConfig(), runner, {},
-                                                       observability);
+  deliveryoptimizer::api::SolveCoordinator coordinator(BuildConfig(), runner, {}, observability);
 
   auto lifecycle = BuildLifecycle("req-success");
   std::promise<deliveryoptimizer::api::CoordinatedSolveResult> result_promise;
   auto result_future = result_promise.get_future();
 
-  ASSERT_EQ(
-      coordinator.Submit(
-          deliveryoptimizer::api::SolveRequestSize{
-              .jobs = 1U,
-              .vehicles = 1U,
-          },
-          [] { return Json::Value{Json::objectValue}; },
-          [&result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
-            result_promise.set_value(result);
-          },
-          lifecycle),
-      deliveryoptimizer::api::SolveAdmissionStatus::kAccepted);
+  ASSERT_EQ(coordinator.Submit(
+                deliveryoptimizer::api::SolveRequestSize{
+                    .jobs = 1U,
+                    .vehicles = 1U,
+                },
+                [] { return Json::Value{Json::objectValue}; },
+                [&result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
+                  result_promise.set_value(result);
+                },
+                lifecycle),
+            deliveryoptimizer::api::SolveAdmissionStatus::kAccepted);
 
   runner->WaitUntilStarted();
 
@@ -133,31 +131,29 @@ TEST(SolveCoordinatorLifecycleTest, RecordsLifecycleAndGaugeTransitionsForSucces
 TEST(SolveCoordinatorLifecycleTest, RecordsAcceptedBeforeCompletionCallbackRuns) {
   auto runner = std::make_shared<ImmediateRunner>();
   auto observability = std::make_shared<deliveryoptimizer::api::ObservabilityRegistry>();
-  deliveryoptimizer::api::SolveCoordinator coordinator(BuildConfig(), runner, {},
-                                                       observability);
+  deliveryoptimizer::api::SolveCoordinator coordinator(BuildConfig(), runner, {}, observability);
 
   auto lifecycle = BuildLifecycle("req-accepted-metric");
   std::promise<std::string> metrics_promise;
   auto metrics_future = metrics_promise.get_future();
 
-  ASSERT_EQ(
-      coordinator.Submit(
-          deliveryoptimizer::api::SolveRequestSize{
-              .jobs = 1U,
-              .vehicles = 1U,
-          },
-          [] { return Json::Value{Json::objectValue}; },
-          [&metrics_promise,
-           observability](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
-            EXPECT_EQ(result.status, deliveryoptimizer::api::CoordinatedSolveStatus::kSucceeded);
-            metrics_promise.set_value(observability->RenderPrometheusText());
-          },
-          lifecycle),
-      deliveryoptimizer::api::SolveAdmissionStatus::kAccepted);
+  ASSERT_EQ(coordinator.Submit(
+                deliveryoptimizer::api::SolveRequestSize{
+                    .jobs = 1U,
+                    .vehicles = 1U,
+                },
+                [] { return Json::Value{Json::objectValue}; },
+                [&metrics_promise,
+                 observability](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
+                  EXPECT_EQ(result.status,
+                            deliveryoptimizer::api::CoordinatedSolveStatus::kSucceeded);
+                  metrics_promise.set_value(observability->RenderPrometheusText());
+                },
+                lifecycle),
+            deliveryoptimizer::api::SolveAdmissionStatus::kAccepted);
 
   const std::string rendered = metrics_future.get();
-  EXPECT_NE(rendered.find("deliveryoptimizer_solver_requests_accepted_total 1"),
-            std::string::npos);
+  EXPECT_NE(rendered.find("deliveryoptimizer_solver_requests_accepted_total 1"), std::string::npos);
 }
 
 TEST(SolveCoordinatorLifecycleTest, RecordsQueuedTimeoutAndQueueGaugeTransitions) {

--- a/tests/api/solve_coordinator/submit_defers_payload_factory_test.cpp
+++ b/tests/api/solve_coordinator/submit_defers_payload_factory_test.cpp
@@ -402,17 +402,16 @@ TEST(SolveCoordinatorTest, DestructorWaitsForInFlightSolveToFinish) {
   std::promise<deliveryoptimizer::api::CoordinatedSolveResult> result_promise;
   auto result_future = result_promise.get_future();
 
-  ASSERT_EQ(
-      coordinator->Submit(
-          deliveryoptimizer::api::SolveRequestSize{
-              .jobs = 1U,
-              .vehicles = 1U,
-          },
-          [] { return Json::Value{Json::objectValue}; },
-          [&result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
-            result_promise.set_value(result);
-          }),
-      deliveryoptimizer::api::SolveAdmissionStatus::kAccepted);
+  ASSERT_EQ(coordinator->Submit(
+                deliveryoptimizer::api::SolveRequestSize{
+                    .jobs = 1U,
+                    .vehicles = 1U,
+                },
+                [] { return Json::Value{Json::objectValue}; },
+                [&result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
+                  result_promise.set_value(result);
+                }),
+            deliveryoptimizer::api::SolveAdmissionStatus::kAccepted);
 
   runner->WaitUntilStarted();
 
@@ -421,8 +420,7 @@ TEST(SolveCoordinatorTest, DestructorWaitsForInFlightSolveToFinish) {
 
   runner->Release();
 
-  EXPECT_EQ(result_future.get().status,
-            deliveryoptimizer::api::CoordinatedSolveStatus::kSucceeded);
+  EXPECT_EQ(result_future.get().status, deliveryoptimizer::api::CoordinatedSolveStatus::kSucceeded);
   EXPECT_EQ(destroy_future.wait_for(std::chrono::seconds{1}), std::future_status::ready);
   destroy_future.get();
 }

--- a/tests/integration/http_server/deliveries_optimize_ignores_malformed_vroom_route_entries_test.sh
+++ b/tests/integration/http_server/deliveries_optimize_ignores_malformed_vroom_route_entries_test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/http_server/http_server_helpers.sh
+source "${script_dir}/http_server_helpers.sh"
+
+http_server_init 38300 "$@"
+response_file="${work_dir}/response.json"
+payload_file="${work_dir}/payload.json"
+stub_bin="${work_dir}/vroom-stub.sh"
+
+cat >"${stub_bin}" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+cat >"${output}" <<'JSON'
+{
+  "summary": { "routes": 1, "unassigned": 1 },
+  "routes": [
+    "bad-route",
+    {
+      "vehicle": 1,
+      "steps": [
+        "bad-step",
+        { "type": "job", "job": 1 }
+      ]
+    }
+  ],
+  "unassigned": [
+    "bad-entry",
+    { "id": 2 }
+  ]
+}
+JSON
+SH
+chmod +x "${stub_bin}"
+
+http_server_start VROOM_BIN="${stub_bin}"
+http_server_wait_until_ready
+
+cat >"${payload_file}" <<'JSON'
+{
+  "depot": { "location": [7.4236, 43.7384] },
+  "vehicles": [
+    { "id": "van-1", "capacity": 8 }
+  ],
+  "jobs": [
+    { "id": "order-1", "location": [7.4212, 43.7308], "demand": 1, "service": 180 },
+    { "id": "order-2", "location": [7.4261, 43.7412], "demand": 1, "service": 120 }
+  ]
+}
+JSON
+
+http_code="$("${curl_bin}" -sS -o "${response_file}" -w "%{http_code}" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  --data-binary "@${payload_file}" \
+  "$(http_server_url /api/v1/deliveries/optimize)")"
+
+if [[ "${http_code}" != "200" ]]; then
+  echo "expected HTTP 200 from deliveries optimize, got ${http_code}" >&2
+  cat "${response_file}" >&2 || true
+  cat "${log_file}" >&2 || true
+  exit 1
+fi
+
+for key in status summary routes unassigned; do
+  if ! grep -Eq '"'"${key}"'"[[:space:]]*:' "${response_file}"; then
+    echo "optimize response missing key ${key}" >&2
+    cat "${response_file}" >&2 || true
+    exit 1
+  fi
+done
+
+if ! grep -Eq '"vehicle_external_id"[[:space:]]*:[[:space:]]*"van-1"' "${response_file}"; then
+  echo "expected optimize response to include vehicle_external_id for valid route entries" >&2
+  cat "${response_file}" >&2 || true
+  exit 1
+fi
+
+if ! grep -Eq '"job_external_id"[[:space:]]*:[[:space:]]*"order-1"' "${response_file}"; then
+  echo "expected optimize response to include job_external_id for valid routed job entries" >&2
+  cat "${response_file}" >&2 || true
+  exit 1
+fi
+
+if ! grep -Eq '"job_external_id"[[:space:]]*:[[:space:]]*"order-2"' "${response_file}"; then
+  echo "expected optimize response to include job_external_id for valid unassigned entries" >&2
+  cat "${response_file}" >&2 || true
+  exit 1
+fi

--- a/tests/integration/http_server/deliveries_optimize_rejects_over_threshold_sync_solve_test.sh
+++ b/tests/integration/http_server/deliveries_optimize_rejects_over_threshold_sync_solve_test.sh
@@ -51,8 +51,8 @@ http_code="$("${curl_bin}" -sS -D "${response_headers_file}" -o "${response_file
   --data-binary "@${payload_file}" \
   "$(http_server_url /api/v1/deliveries/optimize)")"
 
-if [[ "${http_code}" != "503" ]]; then
-  echo "expected HTTP 503 for an over-threshold solve before deep validation, got ${http_code}" >&2
+if [[ "${http_code}" != "422" ]]; then
+  echo "expected HTTP 422 for an over-threshold solve before deep validation, got ${http_code}" >&2
   cat "${response_file}" >&2 || true
   exit 1
 fi


### PR DESCRIPTION
## Summary
- extract optimize request parsing and solve execution into dedicated backend runtime units
- preserve optimize external IDs and ignore malformed VROOM route entries with regression coverage
- clean up Nix and backend C++ formatting/tooling warnings on the branch

## Why
- the optimize runtime logic was still coupled to endpoint glue, which made follow-up backend changes harder to isolate
- optimize response mapping could drop external IDs, and malformed VROOM route entries needed to be tolerated without breaking the response path
- the branch had formatting drift plus a remaining clang-tidy warning in the coordinator surface

## Impact
- backend runtime behavior is split into clearer request and execution layers for follow-up work
- optimize responses keep stable external IDs and handle malformed route entries more defensively
- the branch is clean for the repo's Nix formatter and backend clang-format/clang-tidy warning checks

## Validation
- `nix fmt -- --check flake.nix`
- `nix develop -c bash -lc 'set -euo pipefail; files=$(mktemp); rg --files -g "*.cpp" -g "*.hpp" app libs tests > "$files"; xargs clang-format --dry-run --Werror < "$files"'`
- `nix develop -c bash -lc 'set -euo pipefail; tmpbase=/tmp/deliveryoptimizer-nix-tooling; rm -rf "$tmpbase"; mkdir -p "$tmpbase/build"; cmake -S . -B "$tmpbase/build" -G Ninja -DCMAKE_TOOLCHAIN_FILE="$PWD/build/build/Release/generators/conan_toolchain.cmake" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DDELIVERYOPTIMIZER_ENABLE_TESTS=OFF; tmp=$(mktemp); files=$tmp.files; rg --files -g "*.cpp" app libs > "$files"; clang-tidy -quiet $(cat "$files") -p /tmp/deliveryoptimizer-nix-tooling/build > "$tmp" 2>&1; test "$(grep -Ec ": (warning|error):" "$tmp" || true)" = "0"; rm -rf "$tmpbase"'`
