### PR TITLE
Route Distance from Google Directions

### DIFF
--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -11,8 +11,8 @@ const POLYLINE_COLOR = "#2563eb";
 
 const ROUTE_POLYLINE_OPTIONS: google.maps.PolylineOptions = {
   strokeColor: POLYLINE_COLOR,
-  strokeWeight: 5,
-  strokeOpacity: 0.9,
+  strokeWeight: 4,
+  strokeOpacity: 0.75,
 };
 
 function buildRoutePath(
@@ -42,25 +42,68 @@ function RoutePolylinesOverlay({
   const polylinesRef = useRef<google.maps.Polyline[]>([]);
 
   useEffect(() => {
-    if (!map) return;
+    if (!map || typeof google === "undefined") return;
 
     polylinesRef.current.forEach((p) => {
       p.setMap(null);
     });
     polylinesRef.current = [];
 
-    routes.forEach((route) => {
-      const path = buildRoutePath(route, pendingPinMove);
-      if (path.length < 2) return;
-      const poly = new google.maps.Polyline({
+    let cancelled = false;
+    const directionsService = new google.maps.DirectionsService();
+
+    const drawFallback = (route: Route) => {
+      const fallbackPath = buildRoutePath(route, pendingPinMove);
+      if (fallbackPath.length < 2) return;
+      const fallbackPoly = new google.maps.Polyline({
         map,
-        path,
+        path: fallbackPath,
         ...ROUTE_POLYLINE_OPTIONS,
       });
-      polylinesRef.current.push(poly);
-    });
+      polylinesRef.current.push(fallbackPoly);
+    };
+
+    (async () => {
+      for (const route of routes) {
+        const path = buildRoutePath(route, pendingPinMove);
+        if (path.length < 2) continue;
+        const origin = path[0];
+        const destination = path[path.length - 1];
+        if (!origin || !destination) continue;
+
+        const waypoints = path.slice(1, -1).map((location) => ({ location, stopover: true }));
+
+        try {
+          const result = await directionsService.route({
+            origin,
+            destination,
+            waypoints,
+            optimizeWaypoints: false,
+            travelMode: google.maps.TravelMode.DRIVING,
+          });
+          if (cancelled) return;
+
+          const roadPath = result.routes[0]?.overview_path;
+          if (!roadPath || roadPath.length < 2) {
+            drawFallback(route);
+            continue;
+          }
+
+          const roadPoly = new google.maps.Polyline({
+            map,
+            path: roadPath,
+            ...ROUTE_POLYLINE_OPTIONS,
+          });
+          polylinesRef.current.push(roadPoly);
+        } catch {
+          if (cancelled) return;
+          drawFallback(route);
+        }
+      }
+    })();
 
     return () => {
+      cancelled = true;
       polylinesRef.current.forEach((p) => {
         p.setMap(null);
       });

--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -34,9 +34,11 @@ function buildRoutePath(
 function RoutePolylinesOverlay({
   routes,
   pendingPinMove,
+  onRouteDistanceUpdate,
 }: {
   routes: Route[];
   pendingPinMove: PendingPinMove | null;
+  onRouteDistanceUpdate?: (vehicleId: string, distanceMi: number) => void;
 }) {
   const map = useGoogleMap();
   const polylinesRef = useRef<google.maps.Polyline[]>([]);
@@ -50,7 +52,7 @@ function RoutePolylinesOverlay({
     polylinesRef.current = [];
 
     let cancelled = false;
-    const directionsService = new google.maps.DirectionsService();
+    const directionsService = new google.maps.DirectionsService(); // DirectionsService is used to get the route data from Google Maps Directions API (no need for API key, since we're calling the API from the browser)
 
     const drawFallback = (route: Route) => {
       const fallbackPath = buildRoutePath(route, pendingPinMove);
@@ -89,6 +91,15 @@ function RoutePolylinesOverlay({
             continue;
           }
 
+          const totalMeters = (result.routes[0]?.legs ?? []).reduce(
+            (sum, leg) => sum + (leg.distance?.value ?? 0),
+            0
+          );
+          if (totalMeters > 0 && onRouteDistanceUpdate) {
+            const distanceMi = Number((totalMeters / 1609.344).toFixed(1));
+            onRouteDistanceUpdate(route.vehicleId, distanceMi);
+          }
+
           const roadPoly = new google.maps.Polyline({
             map,
             path: roadPath,
@@ -109,7 +120,7 @@ function RoutePolylinesOverlay({
       });
       polylinesRef.current = [];
     };
-  }, [map, routes, pendingPinMove]);
+  }, [map, routes, pendingPinMove, onRouteDistanceUpdate]);
 
   return null;
 }
@@ -134,6 +145,7 @@ type MapComponentProps = {
   isEditMode: boolean;
   pendingPinMove: PendingPinMove | null;
   onPendingPinMove: (vehicleId: string, stopId: string, lat: number, lng: number) => void;
+  onRouteDistanceUpdate?: (vehicleId: string, distanceMi: number) => void;
 };
 
 type AdvancedMarkersProps = {
@@ -255,6 +267,7 @@ export default function MapComponent({
   isEditMode,
   pendingPinMove,
   onPendingPinMove,
+  onRouteDistanceUpdate,
 }: MapComponentProps) {
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY ?? "";
   const mapId = process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID || undefined;
@@ -313,7 +326,11 @@ export default function MapComponent({
           onLoad={onMapLoad}
           onUnmount={onUnmount}
         >
-          <RoutePolylinesOverlay routes={routes} pendingPinMove={pendingPinMove} />
+          <RoutePolylinesOverlay
+            routes={routes}
+            pendingPinMove={pendingPinMove}
+            onRouteDistanceUpdate={onRouteDistanceUpdate}
+          />
           {mapId && (
             <AdvancedMarkers
               map={map}

--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -15,6 +15,23 @@ const ROUTE_POLYLINE_OPTIONS: google.maps.PolylineOptions = {
   strokeOpacity: 0.75,
 };
 
+const directionsCache = new Map<string, google.maps.LatLng[]>();
+// Cap cache size so one long session does not grow memory without bound
+const MAX_DIRECTIONS_CACHE_SIZE = 100;
+
+function rememberDirectionsPath(cacheKey: string, roadPath: google.maps.LatLng[]) {
+  directionsCache.set(cacheKey, roadPath);
+  while (directionsCache.size > MAX_DIRECTIONS_CACHE_SIZE) {
+    const firstKey = directionsCache.keys().next().value;
+    if (firstKey === undefined) break;
+    directionsCache.delete(firstKey);
+  }
+}
+
+function routeCacheKey(path: google.maps.LatLngLiteral[]): string {
+  return path.map((p) => `${p.lat.toFixed(6)},${p.lng.toFixed(6)}`).join("|");
+}
+
 function buildRoutePath(
   route: Route,
   pendingPinMove: PendingPinMove | null
@@ -52,7 +69,6 @@ function RoutePolylinesOverlay({
     polylinesRef.current = [];
 
     let cancelled = false;
-    // Same browser session as the Maps JS script — billing still uses your Maps key, not a second secret.
     const directionsService = new google.maps.DirectionsService();
 
     const drawFallback = (route: Route) => {
@@ -75,9 +91,21 @@ function RoutePolylinesOverlay({
         const destination = path[path.length - 1]!;
 
         const waypoints = path.slice(1, -1).map((location) => ({ location, stopover: true }));
-        // Google limits intermediate waypoints to 25; past that we skip Directions and use straight segments.
         if (waypoints.length > 25) {
           drawFallback(route);
+          return;
+        }
+
+        const cacheKey = routeCacheKey(path);
+        const cachedRoadPath = directionsCache.get(cacheKey);
+        if (cachedRoadPath && cachedRoadPath.length >= 2) {
+          if (cancelled) return;
+          const cachedPoly = new google.maps.Polyline({
+            map,
+            path: cachedRoadPath,
+            ...ROUTE_POLYLINE_OPTIONS,
+          });
+          polylinesRef.current.push(cachedPoly);
           return;
         }
 
@@ -101,10 +129,14 @@ function RoutePolylinesOverlay({
             (sum, leg) => sum + (leg.distance?.value ?? 0),
             0
           );
+          if (cancelled) return;
           if (totalMeters > 0 && onRouteDistanceUpdate) {
             const distanceMi = Number((totalMeters / 1609.344).toFixed(1));
             onRouteDistanceUpdate(route.vehicleId, distanceMi);
           }
+          if (cancelled) return;
+
+          rememberDirectionsPath(cacheKey, roadPath);
           if (cancelled) return;
 
           const roadPoly = new google.maps.Polyline({
@@ -113,7 +145,8 @@ function RoutePolylinesOverlay({
             ...ROUTE_POLYLINE_OPTIONS,
           });
           polylinesRef.current.push(roadPoly);
-        } catch {
+        } catch (err) {
+          console.warn("[Map] DirectionsService failed, falling back to straight line:", err);
           drawFallback(route);
         }
       })

--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -52,9 +52,11 @@ function RoutePolylinesOverlay({
     polylinesRef.current = [];
 
     let cancelled = false;
-    const directionsService = new google.maps.DirectionsService(); // DirectionsService is used to get the route data from Google Maps Directions API (no need for API key, since we're calling the API from the browser)
+    // Same browser session as the Maps JS script — billing still uses your Maps key, not a second secret.
+    const directionsService = new google.maps.DirectionsService();
 
     const drawFallback = (route: Route) => {
+      if (cancelled) return;
       const fallbackPath = buildRoutePath(route, pendingPinMove);
       if (fallbackPath.length < 2) return;
       const fallbackPoly = new google.maps.Polyline({
@@ -65,15 +67,19 @@ function RoutePolylinesOverlay({
       polylinesRef.current.push(fallbackPoly);
     };
 
-    (async () => {
-      for (const route of routes) {
+    void Promise.allSettled(
+      routes.map(async (route) => {
         const path = buildRoutePath(route, pendingPinMove);
-        if (path.length < 2) continue;
-        const origin = path[0];
-        const destination = path[path.length - 1];
-        if (!origin || !destination) continue;
+        if (path.length < 2) return;
+        const origin = path[0]!;
+        const destination = path[path.length - 1]!;
 
         const waypoints = path.slice(1, -1).map((location) => ({ location, stopover: true }));
+        // Google limits intermediate waypoints to 25; past that we skip Directions and use straight segments.
+        if (waypoints.length > 25) {
+          drawFallback(route);
+          return;
+        }
 
         try {
           const result = await directionsService.route({
@@ -88,7 +94,7 @@ function RoutePolylinesOverlay({
           const roadPath = result.routes[0]?.overview_path;
           if (!roadPath || roadPath.length < 2) {
             drawFallback(route);
-            continue;
+            return;
           }
 
           const totalMeters = (result.routes[0]?.legs ?? []).reduce(
@@ -99,6 +105,7 @@ function RoutePolylinesOverlay({
             const distanceMi = Number((totalMeters / 1609.344).toFixed(1));
             onRouteDistanceUpdate(route.vehicleId, distanceMi);
           }
+          if (cancelled) return;
 
           const roadPoly = new google.maps.Polyline({
             map,
@@ -107,11 +114,10 @@ function RoutePolylinesOverlay({
           });
           polylinesRef.current.push(roadPoly);
         } catch {
-          if (cancelled) return;
           drawFallback(route);
         }
-      }
-    })();
+      })
+    );
 
     return () => {
       cancelled = true;

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -40,6 +40,14 @@ export default function ResultsPage() {
     );
   }, [setRoutes]);
 
+  const handleRouteDistanceUpdate = useCallback((vehicleId: string, distanceMi: number) => {
+    setRoutes((prev) =>
+      prev.map((route) =>
+        route.vehicleId === vehicleId ? { ...route, distanceMi } : route
+      )
+    );
+  }, []);
+
   const handleEditModeChange = useCallback((value: boolean) => {
     setIsEditMode(value);
     if (!value) setPendingPinMove(null);
@@ -137,6 +145,7 @@ export default function ResultsPage() {
               isEditMode={isEditMode}
               pendingPinMove={pendingPinMove}
               onPendingPinMove={handlePendingPinMove}
+              onRouteDistanceUpdate={handleRouteDistanceUpdate}
             />
           </div>
         </div>

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -51,6 +51,14 @@ export default function ResultsPage() {
     );
   }, [setRoutes]);
 
+  const handleRouteDistanceUpdate = useCallback((vehicleId: string, distanceMi: number) => {
+    setRoutes((prev) =>
+      prev.map((route) =>
+        route.vehicleId === vehicleId ? { ...route, distanceMi } : route
+      )
+    );
+  }, []);
+
   const handleEditModeChange = useCallback((value: boolean) => {
     setIsEditMode(value);
     if (!value) setPendingPinMove(null);
@@ -148,6 +156,7 @@ export default function ResultsPage() {
               isEditMode={isEditMode}
               pendingPinMove={pendingPinMove}
               onPendingPinMove={handlePendingPinMove}
+              onRouteDistanceUpdate={handleRouteDistanceUpdate}
             />
           </div>
         </div>

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -52,11 +52,14 @@ export default function ResultsPage() {
   }, [setRoutes]);
 
   const handleRouteDistanceUpdate = useCallback((vehicleId: string, distanceMi: number) => {
-    setRoutes((prev) =>
-      prev.map((route) =>
-        route.vehicleId === vehicleId ? { ...route, distanceMi } : route
-      )
-    );
+    setRoutes((prev) => {
+      const next = prev.map((route) =>
+        route.vehicleId === vehicleId && route.distanceMi !== distanceMi
+          ? { ...route, distanceMi }
+          : route
+      );
+      return next.every((r, i) => r === prev[i]) ? prev : next;
+    });
   }, []);
 
   const handleEditModeChange = useCallback((value: boolean) => {


### PR DESCRIPTION
## Overview
This PR updates route distance to come from Google Directions road data instead of static/mock values.
It intentionally builds on the previous “routes on roads” PR, so I understand this branch will need to be rebased after that PR merges.

---

## Specific Changes
app/ui/src/app/results/components/Map.tsx
- After each successful Directions response, sums legs[].distance.value (meters).
- Converts meters to miles (1 decimal).
- Sends distance up through onRouteDistanceUpdate(vehicleId, distanceMi).

app/ui/src/app/results/page.tsx
- Adds handleRouteDistanceUpdate.
- Updates matching route’s distanceMi in state.
- Passes callback into MapComponent.