### PR TITLE
refactor: deduplicate JSON parsing and solve conversion

### DIFF
--- a/app/api/include/deliveryoptimizer/api/internal/json_utils.hpp
+++ b/app/api/include/deliveryoptimizer/api/internal/json_utils.hpp
@@ -2,27 +2,9 @@
 
 #include <json/json.h>
 
-#include <memory>
-#include <optional>
 #include <string>
 
 namespace deliveryoptimizer::api::internal {
-
-inline std::optional<Json::Value> ParseJsonText(const std::string& text) {
-  Json::CharReaderBuilder builder;
-  builder["collectComments"] = false;
-
-  Json::Value root;
-  JSONCPP_STRING errors;
-  std::unique_ptr<Json::CharReader> reader{builder.newCharReader()};
-  const char* begin = text.data();
-  const char* end = begin + text.size();
-  if (!reader->parse(begin, end, &root, &errors)) {
-    return std::nullopt;
-  }
-
-  return root;
-}
 
 inline std::string RenderJson(const Json::Value& value) {
   Json::StreamWriterBuilder writer_builder;

--- a/app/api/include/deliveryoptimizer/api/solve_execution.hpp
+++ b/app/api/include/deliveryoptimizer/api/solve_execution.hpp
@@ -3,6 +3,7 @@
 #include "deliveryoptimizer/api/observability.hpp"
 #include "deliveryoptimizer/api/optimize_request.hpp"
 #include "deliveryoptimizer/api/solve_coordinator.hpp"
+#include "deliveryoptimizer/api/vroom_runner.hpp"
 
 #include <cstdint>
 #include <json/json.h>
@@ -20,5 +21,7 @@ struct SolveExecutionResult {
 
 [[nodiscard]] SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input,
                                                              const CoordinatedSolveResult& result);
+
+[[nodiscard]] CoordinatedSolveResult ToCoordinatedSolveResult(const VroomRunResult& result);
 
 } // namespace deliveryoptimizer::api

--- a/app/api/src/optimization_job_runtime.cpp
+++ b/app/api/src/optimization_job_runtime.cpp
@@ -1,8 +1,8 @@
 #include "deliveryoptimizer/api/optimization_job_runtime.hpp"
 
-#include "deliveryoptimizer/api/internal/json_utils.hpp"
 #include "deliveryoptimizer/api/optimize_request.hpp"
 #include "deliveryoptimizer/api/solve_execution.hpp"
+#include "deliveryoptimizer/adapters/json_utils.hpp"
 
 #include <drogon/utils/Utilities.h>
 
@@ -13,29 +13,6 @@ namespace {
 
 [[nodiscard]] std::string BuildWorkerIdPrefix() {
   return "opt-worker-" + drogon::utils::getUuid();
-}
-
-[[nodiscard]] deliveryoptimizer::api::CoordinatedSolveResult
-ToCoordinatedSolveResult(const deliveryoptimizer::api::VroomRunResult& result) {
-  switch (result.status) {
-  case deliveryoptimizer::api::VroomRunStatus::kSuccess:
-    return deliveryoptimizer::api::CoordinatedSolveResult{
-        .status = deliveryoptimizer::api::CoordinatedSolveStatus::kSucceeded,
-        .output = result.output,
-    };
-  case deliveryoptimizer::api::VroomRunStatus::kTimedOut:
-    return deliveryoptimizer::api::CoordinatedSolveResult{
-        .status = deliveryoptimizer::api::CoordinatedSolveStatus::kTimedOut,
-        .output = std::nullopt,
-    };
-  case deliveryoptimizer::api::VroomRunStatus::kFailed:
-    break;
-  }
-
-  return deliveryoptimizer::api::CoordinatedSolveResult{
-      .status = deliveryoptimizer::api::CoordinatedSolveStatus::kFailed,
-      .output = std::nullopt,
-  };
 }
 
 } // namespace
@@ -160,7 +137,7 @@ void OptimizationJobRuntime::WorkerLoop(const std::stop_token stop_token, const 
     }
     RefreshObservability();
 
-    const auto parsed_json = internal::ParseJsonText(claimed_job->request_json);
+    const auto parsed_json = deliveryoptimizer::adapters::ParseJsonText(claimed_job->request_json);
     Json::Value issues{Json::arrayValue};
     const auto parsed_request =
         parsed_json.has_value() ? ParseAndValidateOptimizeRequest(*parsed_json, issues) : std::nullopt;

--- a/app/api/src/optimization_job_store.cpp
+++ b/app/api/src/optimization_job_store.cpp
@@ -1,5 +1,6 @@
 #include "deliveryoptimizer/api/optimization_job_store.hpp"
 #include "deliveryoptimizer/api/internal/json_utils.hpp"
+#include "deliveryoptimizer/adapters/json_utils.hpp"
 
 #include <drogon/orm/DbClient.h>
 #include <drogon/orm/Exception.h>
@@ -47,7 +48,7 @@ ReadOptionalOutcome(const drogon::orm::Row& row) {
   if (field.isNull()) {
     return std::nullopt;
   }
-  return deliveryoptimizer::api::internal::ParseJsonText(field.as<std::string>());
+  return deliveryoptimizer::adapters::ParseJsonText(field.as<std::string>());
 }
 
 [[nodiscard]] std::optional<deliveryoptimizer::api::OptimizationJobRecord>

--- a/app/api/src/solve_coordinator.cpp
+++ b/app/api/src/solve_coordinator.cpp
@@ -1,33 +1,12 @@
 #include "deliveryoptimizer/api/solve_coordinator.hpp"
 
+#include "deliveryoptimizer/api/solve_execution.hpp"
+
 #include <algorithm>
 #include <chrono>
 #include <utility>
 
 namespace {
-
-[[nodiscard]] deliveryoptimizer::api::CoordinatedSolveResult
-ToCoordinatedSolveResult(const deliveryoptimizer::api::VroomRunResult& result) {
-  switch (result.status) {
-  case deliveryoptimizer::api::VroomRunStatus::kSuccess:
-    return deliveryoptimizer::api::CoordinatedSolveResult{
-        .status = deliveryoptimizer::api::CoordinatedSolveStatus::kSucceeded,
-        .output = result.output,
-    };
-  case deliveryoptimizer::api::VroomRunStatus::kTimedOut:
-    return deliveryoptimizer::api::CoordinatedSolveResult{
-        .status = deliveryoptimizer::api::CoordinatedSolveStatus::kTimedOut,
-        .output = std::nullopt,
-    };
-  case deliveryoptimizer::api::VroomRunStatus::kFailed:
-    break;
-  }
-
-  return deliveryoptimizer::api::CoordinatedSolveResult{
-      .status = deliveryoptimizer::api::CoordinatedSolveStatus::kFailed,
-      .output = std::nullopt,
-  };
-}
 
 [[nodiscard]] bool HasQueueWaitExpired(const std::chrono::steady_clock::time_point deadline) {
   return std::chrono::steady_clock::now() >= deadline;

--- a/app/api/src/solve_execution.cpp
+++ b/app/api/src/solve_execution.cpp
@@ -2,6 +2,28 @@
 
 namespace deliveryoptimizer::api {
 
+CoordinatedSolveResult ToCoordinatedSolveResult(const VroomRunResult& result) {
+  switch (result.status) {
+  case VroomRunStatus::kSuccess:
+    return CoordinatedSolveResult{
+        .status = CoordinatedSolveStatus::kSucceeded,
+        .output = result.output,
+    };
+  case VroomRunStatus::kTimedOut:
+    return CoordinatedSolveResult{
+        .status = CoordinatedSolveStatus::kTimedOut,
+        .output = std::nullopt,
+    };
+  case VroomRunStatus::kFailed:
+    break;
+  }
+
+  return CoordinatedSolveResult{
+      .status = CoordinatedSolveStatus::kFailed,
+      .output = std::nullopt,
+  };
+}
+
 SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input,
                                                const CoordinatedSolveResult& result) {
   switch (result.status) {

--- a/app/api/src/vroom_runner.cpp
+++ b/app/api/src/vroom_runner.cpp
@@ -1,5 +1,6 @@
 #include "deliveryoptimizer/api/vroom_runner.hpp"
 
+#include "deliveryoptimizer/adapters/json_utils.hpp"
 #include "endpoints/env_utils.hpp"
 
 #include <algorithm>
@@ -196,23 +197,6 @@ private:
   }
 
   return static_cast<int>(parsed);
-}
-
-[[nodiscard]] std::optional<Json::Value> ParseJson(const std::string_view input) {
-  Json::CharReaderBuilder builder;
-  builder["collectComments"] = false;
-
-  Json::Value root;
-  JSONCPP_STRING errors;
-  std::unique_ptr<Json::CharReader> reader{builder.newCharReader()};
-  const char* begin = input.data();
-  const char* end = begin + input.size();
-  const bool parsed = reader->parse(begin, end, &root, &errors);
-  if (!parsed) {
-    return std::nullopt;
-  }
-
-  return root;
 }
 
 [[nodiscard]] bool WritePayloadToFile(const std::string& path, const Json::Value& input_payload) {
@@ -484,7 +468,7 @@ VroomRunResult ProcessVroomRunner::Run(const Json::Value& input_payload) const {
     return VroomRunResult{.status = VroomRunStatus::kFailed, .output = std::nullopt};
   }
 
-  auto parsed = ParseJson(monitor_result.output_text);
+  auto parsed = deliveryoptimizer::adapters::ParseJsonText(monitor_result.output_text);
   if (!parsed.has_value()) {
     return VroomRunResult{.status = VroomRunStatus::kFailed, .output = std::nullopt};
   }

--- a/libs/adapters/CMakeLists.txt
+++ b/libs/adapters/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(deliveryoptimizer::adapters ALIAS deliveryoptimizer_adapters)
 target_sources(
   deliveryoptimizer_adapters
   PRIVATE
+    src/json_utils.cpp
     src/osrm_contract.cpp
     src/routing_facade.cpp
     src/vroom_contract.cpp
@@ -13,6 +14,7 @@ target_sources(
     FILE_SET HEADERS
     BASE_DIRS include
     FILES
+      include/deliveryoptimizer/adapters/json_utils.hpp
       include/deliveryoptimizer/adapters/osrm_contract.hpp
       include/deliveryoptimizer/adapters/routing_facade.hpp
       include/deliveryoptimizer/adapters/vroom_contract.hpp
@@ -24,7 +26,6 @@ target_link_libraries(
   deliveryoptimizer_adapters
   PUBLIC
     deliveryoptimizer::application
-  PRIVATE
     JsonCpp::JsonCpp
 )
 

--- a/libs/adapters/include/deliveryoptimizer/adapters/json_utils.hpp
+++ b/libs/adapters/include/deliveryoptimizer/adapters/json_utils.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <json/json.h>
+
+#include <optional>
+#include <string_view>
+
+namespace deliveryoptimizer::adapters {
+
+[[nodiscard]] std::optional<Json::Value> ParseJsonText(std::string_view text);
+
+} // namespace deliveryoptimizer::adapters

--- a/libs/adapters/src/json_utils.cpp
+++ b/libs/adapters/src/json_utils.cpp
@@ -1,0 +1,23 @@
+#include "deliveryoptimizer/adapters/json_utils.hpp"
+
+#include <memory>
+
+namespace deliveryoptimizer::adapters {
+
+std::optional<Json::Value> ParseJsonText(const std::string_view text) {
+  Json::CharReaderBuilder builder;
+  builder["collectComments"] = false;
+
+  Json::Value root;
+  JSONCPP_STRING errors;
+  std::unique_ptr<Json::CharReader> reader{builder.newCharReader()};
+  const char* begin = text.data();
+  const char* end = begin + text.size();
+  if (!reader->parse(begin, end, &root, &errors)) {
+    return std::nullopt;
+  }
+
+  return root;
+}
+
+} // namespace deliveryoptimizer::adapters

--- a/libs/adapters/src/vroom_contract.cpp
+++ b/libs/adapters/src/vroom_contract.cpp
@@ -1,7 +1,8 @@
 #include "deliveryoptimizer/adapters/vroom_contract.hpp"
 
+#include "deliveryoptimizer/adapters/json_utils.hpp"
+
 #include <json/json.h>
-#include <memory>
 #include <sstream>
 
 namespace deliveryoptimizer::adapters {
@@ -35,23 +36,6 @@ namespace {
   return capacity;
 }
 
-[[nodiscard]] std::optional<Json::Value> ParseJson(const std::string_view input) {
-  Json::CharReaderBuilder builder;
-  builder["collectComments"] = false;
-
-  Json::Value root;
-  JSONCPP_STRING errors;
-  std::unique_ptr<Json::CharReader> reader{builder.newCharReader()};
-  const auto* begin = input.data();
-  const auto* end = begin + input.size();
-  const bool parsed = reader->parse(begin, end, &root, &errors);
-  if (!parsed) {
-    return std::nullopt;
-  }
-
-  return root;
-}
-
 } // namespace
 
 std::string BuildSolvePayload(const std::size_t deliveries, const std::size_t vehicles) {
@@ -83,7 +67,7 @@ std::string BuildSolvePayload(const std::size_t deliveries, const std::size_t ve
 }
 
 std::optional<VroomSolveSummary> ParseSolveSummary(const std::string_view response_json) {
-  const auto root = ParseJson(response_json);
+  const auto root = ParseJsonText(response_json);
   if (!root.has_value()) {
     return std::nullopt;
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(
     "${CMAKE_SOURCE_DIR}/app/api/src/optimize_request.cpp"
     "${CMAKE_SOURCE_DIR}/app/api/src/solve_admission.cpp"
     "${CMAKE_SOURCE_DIR}/app/api/src/solve_coordinator.cpp"
+    "${CMAKE_SOURCE_DIR}/app/api/src/solve_execution.cpp"
     "${CMAKE_SOURCE_DIR}/app/api/src/server_options.cpp"
 )
 target_compile_features(deliveryoptimizer_tests PRIVATE cxx_std_20)


### PR DESCRIPTION
## Summary

- Deduplicates repeated JsonCpp parsing boilerplate into one shared adapters utility instead of keeping copies in API and VROOM contract code.
- Deduplicates VROOM run result to coordinated solve result mapping into `solve_execution` so both sync coordinator and async job runtime share the same conversion path.
- Keeps adapter consumers buildable by exporting JsonCpp through the adapters target because the new public adapter header exposes `Json::Value`.

## Motivation

- The same `Json::CharReaderBuilder` / `newCharReader()` / `parse()` sequence existed in three places, including one inline API header implementation that bloated every including translation unit.
- The same `ToCoordinatedSolveResult` switch existed in both `solve_coordinator.cpp` and `optimization_job_runtime.cpp`, which made future behavior changes easy to apply in one path and miss in the other.
- Centralizing both helpers reduces drift while preserving current runtime behavior.

## Changes

- Adds `deliveryoptimizer/adapters/json_utils.hpp` and `libs/adapters/src/json_utils.cpp` with the single JsonCpp parsing implementation.
- Replaces the parser copies in `app/api/src/vroom_runner.cpp`, `libs/adapters/src/vroom_contract.cpp`, and API job parsing code with `deliveryoptimizer::adapters::ParseJsonText`.
- Removes the inline parser from `app/api/include/deliveryoptimizer/api/internal/json_utils.hpp`, leaving that header responsible for JSON rendering only.
- Moves `ToCoordinatedSolveResult` into `app/api/src/solve_execution.cpp` and declares it in `solve_execution.hpp`.
- Adds `solve_execution.cpp` to the explicit `deliveryoptimizer_tests` API source list so tests link the moved helper.
- Makes `JsonCpp::JsonCpp` public on `deliveryoptimizer_adapters` because the new public adapter header includes `<json/json.h>` and returns `Json::Value`.

## Validation

### Backend

- [x] `nix develop -c cmake --preset conan-release`
- [x] `nix develop -c cmake --build --preset conan-release --target deliveryoptimizer_adapters deliveryoptimizer_api deliveryoptimizer_tests -j4`
- [x] `nix develop -c ctest --test-dir build/build/Release --output-on-failure -R '^(VroomContractTest\.ParseSolveSummary|SolveCoordinatorLifecycleTest\.|SolveCoordinatorTest\.)'`
- [x] `nix develop -c ctest --test-dir build/build/Release --output-on-failure -L unit`

Additional validation:

- [x] `rg -n "CharReaderBuilder|newCharReader\(|reader->parse|\bParseJson\(|ParseJsonText|ToCoordinatedSolveResult" app libs tests/CMakeLists.txt`

That audit shows one remaining parser implementation in `libs/adapters/src/json_utils.cpp`, one remaining `ToCoordinatedSolveResult` definition in `app/api/src/solve_execution.cpp`, and only call sites elsewhere.

### Frontend

- [ ] Not run; this PR changes backend C++ and CMake only.

### Mobile

- [ ] Not run; this PR changes backend C++ and CMake only.

## Risk

- Low runtime risk: the parser and conversion logic were moved without changing their existing branches or return values.
- Moderate build-interface risk was addressed by making `JsonCpp::JsonCpp` public on `deliveryoptimizer_adapters`, because `json_utils.hpp` is part of that target's public header set.
- The main remaining risk is that downstream consumers may prefer not to include JsonCpp in public adapter headers long term; this PR chooses the smallest safe fix for the current public API shape.

## Rollout and Recovery

- Roll out by merging the two refactor commits together so callers never see the removed local helpers without their shared replacements.
- Recover by reverting this PR; no database migrations, environment variables, feature flags, or runtime rollout steps are involved.

## High-Signal PR Checklist

- [x] The summary states the operational outcome, not just file names.
- [x] The motivation explains why this change is needed now.
- [x] The change list separates backend source, build-interface, and test-target work.
- [x] Validation includes exact commands run and the focused audit used to prove deduplication.
- [x] Risks, migrations, feature flags, and rollback steps are called out when relevant.
- [x] Screenshots or request/response examples are included for UI and API behavior changes.

No screenshots or request/response examples are included because this PR is backend implementation deduplication and build metadata only; it does not change product UI or API behavior.
