### PR TITLE
perf(api): reserve metrics render buffer

### DIFF
--- a/app/api/src/observability.cpp
+++ b/app/api/src/observability.cpp
@@ -1,6 +1,7 @@
 #include "deliveryoptimizer/api/observability.hpp"
 
 #include <array>
+#include <cstddef>
 #include <iomanip>
 #include <iostream>
 #include <json/json.h>
@@ -33,6 +34,8 @@ constexpr std::array<HistogramBucket, 12> kHistogramBuckets{{
     {10.0, "10"},
     {30.0, "30"},
 }};
+
+constexpr std::size_t kPrometheusTextInitialCapacity = 16U * 1024U;
 
 [[nodiscard]] double DurationToSeconds(const SteadyClock::duration duration) {
   return std::chrono::duration<double>(duration).count();
@@ -355,7 +358,7 @@ std::string ObservabilityRegistry::RenderPrometheusText() const {
   };
 
   std::string output;
-  output.reserve(4096);
+  output.reserve(kPrometheusTextInitialCapacity);
 
   AppendCounter(output, "deliveryoptimizer_solver_requests_accepted_total",
                 "Count of solver requests accepted into the coordinator queue.",

--- a/tests/api/observability/renders_prometheus_metrics_test.cpp
+++ b/tests/api/observability/renders_prometheus_metrics_test.cpp
@@ -37,6 +37,7 @@ TEST(ObservabilityRegistryTest, RendersPrometheusMetricsWithExpectedFamiliesAndB
 
   const std::string rendered = registry.RenderPrometheusText();
 
+  EXPECT_GT(rendered.size(), 4096U);
   EXPECT_NE(rendered.find("# HELP deliveryoptimizer_solver_requests_accepted_total Count of solver "
                           "requests accepted into the coordinator queue."),
             std::string::npos);


### PR DESCRIPTION
## Summary

- Reserves a realistic initial buffer for Prometheus metrics rendering so normal `/metrics` scrapes do not start from an undersized 4 KiB allocation.
- Adds focused observability regression coverage proving the current rendered metrics payload already exceeds the old reserve size.
- Keeps the Prometheus text output unchanged; this PR is a performance/allocation improvement only.

## Motivation

- `RenderPrometheusText()` emits counters, gauges, and three histogram families with 12 configured buckets each.
- The previous `output.reserve(4096)` no longer matched the rendered payload size, so each scrape could force avoidable `std::string` growth while appending metrics text.
- Prometheus scrapes happen repeatedly, so avoiding predictable allocation churn is worth fixing at the render boundary.

## Changes

- Added `kPrometheusTextInitialCapacity` in `app/api/src/observability.cpp` and increased the initial render buffer to 16 KiB.
- Added `<cstddef>` for the named capacity constant.
- Extended `ObservabilityRegistryTest.RendersPrometheusMetricsWithExpectedFamiliesAndBuckets` to assert the current rendered metrics body is larger than 4096 bytes.
- Removed the earlier brittle capacity assertion after review because returned `std::string::capacity()` is not a portable observable contract.

## Validation

### Backend

- [x] `nix develop -c conan profile detect --force`
- [x] `nix develop -c conan install . --output-folder=build --build=missing -s build_type=Release`
- [x] `nix develop -c cmake --preset conan-release`
- [x] `nix develop -c cmake --build --preset conan-release --target deliveryoptimizer_tests -j4`
- [x] `nix develop -c ctest --preset conan-release --output-on-failure -R 'ObservabilityRegistryTest'`

### CI

- [x] `config` GitHub Actions check passed on PR #147.
- [x] `ui` GitHub Actions check passed on PR #147.

No frontend commands were run locally because this PR only changes backend observability rendering and its C++ unit coverage.

## Risk

- Low behavioral risk: Prometheus metric names, help text, sample values, and endpoint behavior are unchanged.
- The 16 KiB reserve is intentionally conservative for the current metrics surface, but future large metric-family additions may require another capacity adjustment or a computed estimator.
- The regression test proves the old 4 KiB reserve is stale, but does not instrument allocation counts directly to avoid adding a brittle test seam.

## Rollout and Recovery

- Roll out by merging the reserve-size change with the focused regression assertion.
- Recover by reverting this commit; the previous behavior produced identical metrics output but could reintroduce repeated string growth during scrapes.

## High-Signal PR Checklist

- [x] The summary states the operational outcome, not just file names.
- [x] The motivation explains why this change is needed now.
- [x] The change list separates production code and test coverage.
- [x] Validation includes exact commands run and CI status observed.
- [x] Risks and rollback steps are called out.
- [x] Screenshots or request/response examples are included for UI and API behavior changes.

No screenshots or request/response examples are included because this PR does not change UI or Prometheus output semantics; it only changes the internal render buffer reservation.
