### PR TITLE
fix(api): validate OSRM proxy path shape

### DIFF
--- a/app/api/src/endpoints/osrm_proxy_endpoint.cpp
+++ b/app/api/src/endpoints/osrm_proxy_endpoint.cpp
@@ -2,6 +2,8 @@
 
 #include "env_utils.hpp"
 
+#include <array>
+#include <cctype>
 #include <drogon/drogon.h>
 #include <string>
 #include <string_view>
@@ -10,6 +12,11 @@
 namespace {
 
 constexpr std::string_view kDefaultOsrmBaseUrl = "http://127.0.0.1:5001";
+
+[[nodiscard]] bool IsAllowedService(const std::string_view service_name) {
+  return service_name == "nearest" || service_name == "route" || service_name == "table" ||
+         service_name == "match";
+}
 
 [[nodiscard]] std::string_view ResolveServiceName(const std::string_view path_suffix) {
   const auto separator = path_suffix.find('/');
@@ -20,9 +27,52 @@ constexpr std::string_view kDefaultOsrmBaseUrl = "http://127.0.0.1:5001";
   return path_suffix.substr(0, separator);
 }
 
-[[nodiscard]] bool IsAllowedService(const std::string_view service_name) {
-  return service_name == "nearest" || service_name == "route" || service_name == "table" ||
-         service_name == "match";
+[[nodiscard]] bool HasEncodedPathSeparatorOrDot(const std::string_view value) {
+  for (std::size_t index = 0; index + 2U < value.size(); ++index) {
+    if (value[index] != '%') {
+      continue;
+    }
+
+    const auto first = static_cast<unsigned char>(value[index + 1U]);
+    const auto second = static_cast<unsigned char>(value[index + 2U]);
+    const char hex_first = static_cast<char>(std::tolower(first));
+    const char hex_second = static_cast<char>(std::tolower(second));
+    if ((hex_first == '2' && (hex_second == 'e' || hex_second == 'f')) ||
+        (hex_first == '5' && hex_second == 'c')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+[[nodiscard]] bool IsSafeOsrmPathSuffix(const std::string_view path_suffix) {
+  std::array<std::string_view, 4> segments{};
+  std::size_t segment_count = 0U;
+  std::size_t segment_start = 0U;
+
+  while (segment_start <= path_suffix.size()) {
+    const auto separator = path_suffix.find('/', segment_start);
+    const auto segment_end = separator == std::string_view::npos ? path_suffix.size() : separator;
+    const auto segment = path_suffix.substr(segment_start, segment_end - segment_start);
+
+    if (segment.empty() || segment == "." || segment == ".." ||
+        segment.find('\\') != std::string_view::npos || HasEncodedPathSeparatorOrDot(segment)) {
+      return false;
+    }
+    if (segment_count >= segments.size()) {
+      return false;
+    }
+    segments[segment_count] = segment;
+    ++segment_count;
+
+    if (separator == std::string_view::npos) {
+      break;
+    }
+    segment_start = separator + 1U;
+  }
+
+  return segment_count == segments.size() && IsAllowedService(segments[0]) && segments[1] == "v1";
 }
 
 } // namespace
@@ -43,6 +93,15 @@ void RegisterOsrmProxyEndpoint(drogon::HttpAppFramework& app) {
         if (!IsAllowedService(service_name)) {
           Json::Value body;
           body["error"] = "OSRM service not allowed.";
+          auto response = drogon::HttpResponse::newHttpJsonResponse(body);
+          response->setStatusCode(drogon::k403Forbidden);
+          std::move(callback)(response);
+          return;
+        }
+
+        if (!IsSafeOsrmPathSuffix(path_suffix)) {
+          Json::Value body;
+          body["error"] = "OSRM path not allowed.";
           auto response = drogon::HttpResponse::newHttpJsonResponse(body);
           response->setStatusCode(drogon::k403Forbidden);
           std::move(callback)(response);

--- a/tests/integration/http_server/osrm_proxy_forwards_allowed_service_with_query_test.sh
+++ b/tests/integration/http_server/osrm_proxy_forwards_allowed_service_with_query_test.sh
@@ -108,3 +108,35 @@ if [[ "${recorded_path}" != "${upstream_path}" && "${recorded_path}" != "${encod
   cat "${stub_log_file}" >&2 || true
   exit 1
 fi
+
+rm -f "${request_path_file}"
+traversal_response_file="${work_dir}/traversal-response.json"
+traversal_http_code="$("${curl_bin}" --path-as-is -sS -o "${traversal_response_file}" -w "%{http_code}" \
+  "$(http_server_url /api/v1/osrm/table/v1/driving/../../../admin/dangerous?annotations=duration)")"
+
+if [[ "${traversal_http_code}" != "403" ]]; then
+  echo "expected HTTP 403 for traversal-shaped OSRM proxy path, got ${traversal_http_code}" >&2
+  cat "${traversal_response_file}" >&2 || true
+  exit 1
+fi
+
+if [[ -f "${request_path_file}" ]]; then
+  echo "traversal-shaped OSRM proxy path reached upstream as '$(cat "${request_path_file}")'" >&2
+  cat "${stub_log_file}" >&2 || true
+  exit 1
+fi
+
+encoded_traversal_http_code="$("${curl_bin}" --path-as-is -sS -o "${traversal_response_file}" -w "%{http_code}" \
+  "$(http_server_url /api/v1/osrm/table/v1/driving/%2e%2e/%2e%2e/admin/dangerous?annotations=duration)")"
+
+if [[ "${encoded_traversal_http_code}" != "403" ]]; then
+  echo "expected HTTP 403 for encoded traversal-shaped OSRM proxy path, got ${encoded_traversal_http_code}" >&2
+  cat "${traversal_response_file}" >&2 || true
+  exit 1
+fi
+
+if [[ -f "${request_path_file}" ]]; then
+  echo "encoded traversal-shaped OSRM proxy path reached upstream as '$(cat "${request_path_file}")'" >&2
+  cat "${stub_log_file}" >&2 || true
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Tightens OSRM proxy forwarding so allowlisted services must also match the expected `/service/v1/profile/resource` OSRM request shape.
- Blocks traversal-shaped proxy paths, including literal and percent-encoded dot/slash/backslash segments, before any upstream OSRM request is created.
- Adds local API regression coverage that proves valid OSRM forwarding still works and traversal-shaped requests are rejected without reaching the OSRM stub.

## Motivation

- The previous proxy gate only checked the first path segment against `nearest`, `route`, `table`, or `match`.
- A request such as `/api/v1/osrm/table/v1/driving/../../../admin/dangerous?annotations=duration` could pass the service-name gate and leave the API to forward an unintended upstream path.
- OSRM is an internal routing dependency; the public API should expose only the narrow routing surface the backend intends to support, not a broad path passthrough.

## Changes

### Backend

- Keeps the existing OSRM service allowlist for `nearest`, `route`, `table`, and `match`.
- Adds path-shape validation requiring exactly four non-empty segments: `service`, `v1`, `profile`, and route resource.
- Rejects unsafe path segments before forwarding:
  - empty segments
  - `.` and `..`
  - backslashes
  - encoded dot, slash, and backslash forms such as `%2e`, `%2f`, and `%5c`
- Preserves the existing disallowed-service `403` response for unknown service names.

### Tests

- Extends the existing OSRM proxy local integration test to keep the positive forwarding assertion for `/nearest/v1/driving/...`.
- Adds negative assertions for literal traversal and encoded traversal paths.
- Verifies rejected traversal-shaped requests do not create a new request record in the upstream OSRM stub.

## Validation

### Backend

- [x] `nix develop -c clang-format --dry-run --Werror app/api/src/endpoints/osrm_proxy_endpoint.cpp`
- [x] `nix develop -c cmake --build --preset conan-release --target deliveryoptimizer_api -j4`
- [x] `nix develop -c ctest --preset conan-release --output-on-failure -R '^DeliveryOptimizerApiContractTest\.OsrmProxy(ForwardsAllowedServiceWithQuery|RejectsDisallowedService)$'`

Additional validation:

- [x] `git diff --check`

Not verified:

- [ ] Full CTest suite was not run because this is a narrow API proxy validation change with focused local API coverage.
- [ ] Docker/e2e OSRM tests were not run because the changed behavior is covered with the local HTTP server plus OSRM stub contract test.

## API Behavior Examples

Allowed request still forwards to OSRM:

```http
GET /api/v1/osrm/nearest/v1/driving/-122.4194,37.7749?number=1&generate_hints=false
```

Traversal-shaped request is rejected by the API before upstream forwarding:

```http
GET /api/v1/osrm/table/v1/driving/../../../admin/dangerous?annotations=duration
HTTP/1.1 403 Forbidden
```

Encoded traversal-shaped request is also rejected before upstream forwarding:

```http
GET /api/v1/osrm/table/v1/driving/%2e%2e/%2e%2e/admin/dangerous?annotations=duration
HTTP/1.1 403 Forbidden
```

## Risk

- The proxy is now intentionally narrower: OSRM endpoints outside `/service/v1/profile/resource` will receive `403` even if the first service segment is allowlisted.
- If the product later needs additional OSRM path shapes, those should be added explicitly with tests instead of reopening broad passthrough behavior.
- Query parameters are still forwarded after path validation; this PR addresses the path traversal/passthrough issue without changing OSRM option handling.

## Rollout and Recovery

- Roll out by merging the API validation and regression test together so the narrower proxy contract is enforced and covered.
- Recover by reverting this commit if a valid production OSRM request shape is unexpectedly blocked, then reintroduce that shape through an explicit allowlist and regression test.

## High-Signal PR Checklist

- [x] The summary states the operational outcome, not just file names.
- [x] The motivation explains why this change is needed now.
- [x] The change list separates backend and test work.
- [x] Validation includes exact commands run and checks intentionally skipped.
- [x] Risks and rollback steps are called out.
- [x] API behavior examples are included for the changed request handling.

No screenshots are included because this PR changes backend API request validation only; it does not change product UI.
