### PR TITLE
HI-FI: Match Results Top Bar

### DIFF
--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -166,7 +166,7 @@ export default function ResultsPage() {
               <button
                 type="button"
                 onClick={savePendingPinMove}
-                className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
+                className="rounded-full bg-amber-500 px-3 py-1 text-xs font-medium text-white hover:bg-amber-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-amber-500"
               >
                 Save
               </button>

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -122,49 +122,58 @@ export default function ResultsPage() {
         </div>
       )}{" "}
       {/* Map container switched to h-screen and added overflow hidden so the page is forced to be exactly one screen tall, whereas before the page was allowed to get taller than browser window leading to a long scroll */}
-      <header className="flex items-center gap-2 p-4 shrink-0 border-b border-zinc-200 bg-white">
-        <button
-          type="button"
-          onClick={() => setIsSidebarOpen((prev) => !prev)}
-          className="flex h-10 w-10 items-center justify-center rounded-lg border border-zinc-200 bg-white text-zinc-700 hover:bg-zinc-50"
-          aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
-        >
-          <svg
-            className="h-5 w-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden
+      <header className="flex items-center justify-between gap-3 p-4 shrink-0 border-b border-zinc-200 bg-white">
+        <div className="flex items-center gap-3 min-w-0">
+          <button
+            type="button"
+            onClick={() => setIsSidebarOpen((prev) => !prev)}
+            className="flex h-9 w-9 items-center justify-center rounded-lg border border-zinc-200 bg-white text-zinc-700 hover:bg-zinc-50"
+            aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M4 6h16M4 12h16M4 18h16"
-            />
-          </svg>
-        </button>
-        <h1 className="text-2xl font-semibold text-zinc-800">
-          Results – Route map
-        </h1>
-        {pendingPinMove != null && (
-          <div className="ml-auto flex items-center gap-2">
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            </svg>
+          </button>
+          <p className="truncate text-sm font-semibold tracking-wide text-zinc-800 uppercase">
+            Delivery Optimizer
+          </p>
+        </div>
+
+        <div className="ml-auto flex items-center gap-2">
+          {pendingPinMove != null && (
             <button
               type="button"
               onClick={cancelPendingPinMove}
-              className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50"
+              className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
             >
               Cancel
             </button>
-            <button
-              type="button"
-              onClick={savePendingPinMove}
-              className="rounded-md bg-amber-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-600"
-            >
-              Save
-            </button>
-          </div>
-        )}
+          )}
+          <button
+            type="button"
+            onClick={savePendingPinMove}
+            className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            className="rounded-full bg-emerald-500 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-600"
+          >
+            Export
+          </button>
+        </div>
       </header>
       <div className="flex flex-1 min-h-0">
         <div

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -145,31 +145,39 @@ export default function ResultsPage() {
               />
             </svg>
           </button>
-          <p className="truncate text-sm font-semibold tracking-wide text-zinc-800 uppercase">
-            Delivery Optimizer
-          </p>
+          <div className="min-w-0">
+            <span className="block truncate text-sm font-semibold tracking-wide text-zinc-800 uppercase">
+              Delivery Optimizer
+            </span>
+            <h1 className="sr-only">Results</h1>
+          </div>
         </div>
 
         <div className="ml-auto flex items-center gap-2">
           {pendingPinMove != null && (
-            <button
-              type="button"
-              onClick={cancelPendingPinMove}
-              className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
-            >
-              Cancel
-            </button>
+            <>
+              <button
+                type="button"
+                onClick={cancelPendingPinMove}
+                className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={savePendingPinMove}
+                className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
+              >
+                Save
+              </button>
+            </>
           )}
           <button
             type="button"
-            onClick={savePendingPinMove}
-            className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
-          >
-            Save
-          </button>
-          <button
-            type="button"
-            className="rounded-full bg-emerald-500 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-600"
+            disabled
+            aria-disabled="true"
+            title="Export coming soon"
+            className="rounded-full bg-emerald-500 px-3 py-1 text-xs font-medium text-white opacity-50 cursor-not-allowed"
           >
             Export
           </button>


### PR DESCRIPTION
## Summary

Updates the Results page top bar to match the hi-fi design: compact app label, screen-reader page heading, and pill-style Save/Export controls aligned with the edit flow.

## Motivation

The Results header still used the older large title layout. Matching the hi-fi top bar keeps navigation and actions consistent across edit and results before export and further sidebar work land in follow-up PRs.

## Changes

### Frontend

- `app/ui/src/app/results/page.tsx`: Replaced the legacy header with a compact "Delivery Optimizer" label, `sr-only` "Results" heading, sidebar toggle, and pill Save/Cancel (only when a pin move is pending) plus disabled Export placeholder until the export modal PR ships.

## Validation

### Frontend

- [x] `npm --prefix app/ui run lint`
- [x] `npm --prefix app/ui run format:check`
- [x] `npm --prefix app/ui run typecheck`
- [x] `npm --prefix app/ui run test`
- [x] `npm --prefix app/ui run build`

Manual: Loaded `/results` in dev; confirmed top bar layout, Save/Cancel appear after dragging a stop in edit mode, Export shows disabled with tooltip.

## Risk

Low. UI-only header change on Results; Save behavior unchanged (only shown when a pending pin move exists). Export is explicitly disabled.

## Rollout and Recovery

Ship with normal UI deploy. Revert this PR to restore the previous Results header if needed; no data or API changes.
