### PR TITLE
HI-FI: Edit Mode Layout and Banner Styling

### DIFF
--- a/app/ui/src/app/edit/components/layout/sidebar/SidebarResultsButton.tsx
+++ b/app/ui/src/app/edit/components/layout/sidebar/SidebarResultsButton.tsx
@@ -1,7 +1,15 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { readHasOptimizeResults } from "../../../utils/hasOptimizeResults";
 import {
+  SIDEBAR_NAV_ITEM_ACTIVE,
   SIDEBAR_NAV_ITEM_DISABLED,
+  SIDEBAR_NAV_ITEM_INACTIVE,
+  SIDEBAR_NAV_LABEL_ACTIVE,
   SIDEBAR_NAV_LABEL_INACTIVE,
+  SIDEBAR_NAV_PILL_ACTIVE,
   SIDEBAR_NAV_PILL_INACTIVE,
 } from "@/app/edit/formStyles.v2";
 
@@ -12,26 +20,48 @@ const SIDEBAR_RESULTS_ICON = (
     height="24"
     viewBox="0 0 24 24"
     fill="none"
+    aria-hidden
   >
     <path
       d="M4.35 20.7C4.01667 20.8333 3.70833 20.7958 3.425 20.5875C3.14167 20.3792 3 20.1 3 19.75V5.75C3 5.53333 3.0625 5.34167 3.1875 5.175C3.3125 5.00833 3.48333 4.88333 3.7 4.8L9 3L15 5.1L19.65 3.3C19.9833 3.16667 20.2917 3.20417 20.575 3.4125C20.8583 3.62083 21 3.9 21 4.25V12.675C20.75 12.2917 20.4542 11.9417 20.1125 11.625C19.7708 11.3083 19.4 11.0333 19 10.8V5.7L16 6.85V10C15.65 10 15.3083 10.0292 14.975 10.0875C14.6417 10.1458 14.3167 10.2333 14 10.35V6.85L10 5.45V18.525L4.35 20.7ZM5 18.3L8 17.15V5.45L5 6.45V18.3ZM17.4125 17.5C17.7875 17.1667 17.9833 16.6667 18 16C18.0167 15.4333 17.8292 14.9583 17.4375 14.575C17.0458 14.1917 16.5667 14 16 14C15.4333 14 14.9583 14.1917 14.575 14.575C14.1917 14.9583 14 15.4333 14 16C14 16.5667 14.1917 17.0417 14.575 17.425C14.9583 17.8083 15.4333 18 16 18C16.5667 18 17.0375 17.8333 17.4125 17.5ZM16 20C14.9 20 13.9583 19.6083 13.175 18.825C12.3917 18.0417 12 17.1 12 16C12 14.9 12.3917 13.9583 13.175 13.175C13.9583 12.3917 14.9 12 16 12C17.1 12 18.0417 12.3917 18.825 13.175C19.6083 13.9583 20 14.9 20 16C20 16.3833 19.9542 16.7458 19.8625 17.0875C19.7708 17.4292 19.6333 17.75 19.45 18.05L22 20.6L20.6 22L18.05 19.45C17.75 19.6333 17.4292 19.7708 17.0875 19.8625C16.7458 19.9542 16.3833 20 16 20Z"
-      fill="var(--edit-text-primary)"
+      fill="currentColor"
     />
   </svg>
 );
 
 export default function SidebarResultsButton() {
+  const pathname = usePathname();
+  const isResultsPage = pathname === "/results";
+  const hasStoredRoutes = !isResultsPage && readHasOptimizeResults();
+
+  if (isResultsPage) {
+    return (
+      <span className={SIDEBAR_NAV_ITEM_ACTIVE} aria-current="page">
+        <span
+          className={`${SIDEBAR_NAV_PILL_ACTIVE} text-[var(--edit-foreground)]`}
+        >
+          {SIDEBAR_RESULTS_ICON}
+        </span>
+        <span className={SIDEBAR_NAV_LABEL_ACTIVE}>Results</span>
+      </span>
+    );
+  }
+
+  if (hasStoredRoutes) {
+    return (
+      <Link href="/results" className={SIDEBAR_NAV_ITEM_INACTIVE}>
+        <span className={SIDEBAR_NAV_PILL_INACTIVE}>
+          {SIDEBAR_RESULTS_ICON}
+        </span>
+        <span className={SIDEBAR_NAV_LABEL_INACTIVE}>Results</span>
+      </Link>
+    );
+  }
+
   return (
-    <Link
-      href="#"
-      className={SIDEBAR_NAV_ITEM_DISABLED}
-      aria-disabled="true"
-      tabIndex={-1}
-    >
-      {" "}
-      {/* TODO: add results page link when at least one route exists */}
+    <span className={SIDEBAR_NAV_ITEM_DISABLED} aria-disabled="true">
       <span className={SIDEBAR_NAV_PILL_INACTIVE}>{SIDEBAR_RESULTS_ICON}</span>
       <span className={SIDEBAR_NAV_LABEL_INACTIVE}>Results</span>
-    </Link>
+    </span>
   );
 }

--- a/app/ui/src/app/edit/utils/hasOptimizeResults.ts
+++ b/app/ui/src/app/edit/utils/hasOptimizeResults.ts
@@ -1,0 +1,16 @@
+import type { Route } from "@/app/results/types";
+
+/** True when sessionStorage has at least one route ready for /results. */
+export function readHasOptimizeResults(): boolean {
+  if (typeof window === "undefined") return false;
+
+  const stored = sessionStorage.getItem("optimizeResults");
+  if (!stored) return false;
+
+  try {
+    const parsed = JSON.parse(stored) as Route[];
+    return Array.isArray(parsed) && parsed.length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -20,6 +20,43 @@ import type { PendingPinMove, Route } from "../types";
 import { routeColorHex } from "../utils/routeColors";
 
 const DAVIS_CENTER = { lat: 38.5449, lng: -121.7405 };
+const MARKER_ICON_WIDTH = 28;
+const MARKER_ICON_HEIGHT = 40;
+
+let markerScaledSize: google.maps.Size | undefined;
+
+function getMarkerScaledSize(): google.maps.Size | undefined {
+  if (typeof google === "undefined") return undefined;
+  markerScaledSize ??= new google.maps.Size(
+    MARKER_ICON_WIDTH,
+    MARKER_ICON_HEIGHT,
+  );
+  return markerScaledSize;
+}
+
+// fillColor is always a route palette hex from routeColorHex, never user input.
+function markerSvgDataUrl(fillColor: string): string {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${MARKER_ICON_WIDTH}" height="${MARKER_ICON_HEIGHT}" viewBox="0 0 28 40"><path d="M14 1C7.373 1 2 6.373 2 13c0 9.246 12 24 12 24s12-14.754 12-24C26 6.373 20.627 1 14 1z" fill="${fillColor}" stroke="#ffffff" stroke-width="2"/><circle cx="14" cy="13" r="4.25" fill="#ffffff"/></svg>`;
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+}
+
+function createRoutePinElement(fillColor: string): HTMLElement {
+  const wrapper = document.createElement("div");
+  wrapper.style.width = `${MARKER_ICON_WIDTH}px`;
+  wrapper.style.height = `${MARKER_ICON_HEIGHT}px`;
+  // Advanced marker anchor is the content center; shift so the SVG tip sits on the stop.
+  wrapper.style.transform = "translate(-50%, -50%)";
+
+  const img = document.createElement("img");
+  img.src = markerSvgDataUrl(fillColor);
+  img.width = MARKER_ICON_WIDTH;
+  img.height = MARKER_ICON_HEIGHT;
+  img.style.display = "block";
+  img.draggable = false;
+  img.alt = "";
+  wrapper.appendChild(img);
+  return wrapper;
+}
 
 function routePolylineOptions(
   strokeColor: string,
@@ -307,7 +344,8 @@ function AdvancedMarkers({
 
         if (cancelled) return;
 
-        routes.forEach((route) => {
+        routes.forEach((route, routeIndex) => {
+          const accentColor = routeColorHex(routeIndex);
           const sorted = [...route.stops].sort(
             (a, b) => a.sequence - b.sequence,
           );
@@ -319,6 +357,7 @@ function AdvancedMarkers({
               position,
               title: stop.address,
               gmpDraggable: isEditMode,
+              content: createRoutePinElement(accentColor),
             });
 
             m.addListener("dragend", () => {
@@ -466,7 +505,10 @@ export default function MapComponent({
             />
           )}
           {!mapId &&
-            routes.map((route) => {
+            routes.map((route, routeIndex) => {
+              const accentColor = routeColorHex(routeIndex);
+              const iconUrl = markerSvgDataUrl(accentColor);
+              const scaledSize = getMarkerScaledSize();
               const sorted = [...route.stops].sort(
                 (a, b) => a.sequence - b.sequence,
               );
@@ -485,6 +527,18 @@ export default function MapComponent({
                         key={stop.id}
                         position={position}
                         title={stop.address}
+                        icon={
+                          scaledSize
+                            ? {
+                                url: iconUrl,
+                                scaledSize,
+                                anchor: new google.maps.Point(
+                                  MARKER_ICON_WIDTH / 2,
+                                  MARKER_ICON_HEIGHT,
+                                ),
+                              }
+                            : { url: iconUrl }
+                        }
                         draggable={isEditMode}
                         onDragEnd={(e) => {
                           const latLng = e.latLng;

--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -44,8 +44,8 @@ function createRoutePinElement(fillColor: string): HTMLElement {
   const wrapper = document.createElement("div");
   wrapper.style.width = `${MARKER_ICON_WIDTH}px`;
   wrapper.style.height = `${MARKER_ICON_HEIGHT}px`;
-  // Advanced marker anchor is the content center; shift so the SVG tip sits on the stop.
-  wrapper.style.transform = "translate(-50%, -50%)";
+  // Anchor bottom-center of the pin on the stop (tip is at y=40 in the SVG).
+  wrapper.style.transform = "translate(-50%, -100%)";
 
   const img = document.createElement("img");
   img.src = markerSvgDataUrl(fillColor);

--- a/app/ui/src/app/results/components/Sidebar.tsx
+++ b/app/ui/src/app/results/components/Sidebar.tsx
@@ -12,19 +12,12 @@ type SidebarProps = {
   onUpdateStopNote: (routeId: string, stopId: string, note: string) => void;
 };
 
-export default function Sidebar({
-  routes,
-  isEditMode,
-  onEditModeChange,
-  onUpdateStopNote,
-}: SidebarProps) {
-  const [expandedRouteIds, setExpandedRouteIds] = useState<Set<string>>(
-    () => new Set(),
-  );
+export default function Sidebar({ routes, isEditMode, onEditModeChange, onUpdateStopNote }: SidebarProps) {
+  const [expandedRouteIds, setExpandedRouteIds] = useState<Set<string>>(() => new Set());
 
   const totalStops = useMemo(
     () => routes.reduce((sum, r) => sum + r.stops.length, 0),
-    [routes],
+    [routes]
   );
 
   function toggleExpanded(routeId: string) {
@@ -48,50 +41,38 @@ export default function Sidebar({
     <aside
       className={`w-full h-full flex flex-col overflow-hidden border-r-2 bg-white p-4 ${isEditMode ? "border-amber-500" : "border-zinc-200"}`}
     >
-      {isEditMode && (
-        <p className="mb-2 text-xs font-medium text-amber-700 bg-amber-50 rounded px-2 py-1">
-          Edit Mode Active
-        </p>
-      )}
-      <div className="flex shrink-0 items-center justify-between gap-2 mb-4">
-        <span className="text-sm font-medium text-zinc-700">Edit mode</span>
+      <div className="flex shrink-0 items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-zinc-800">Optimized Routes</h2>
+          <p className="mt-1 text-xs text-zinc-500">
+            {routes.length} route{routes.length === 1 ? "" : "s"} with {totalStops} total stop
+            {totalStops === 1 ? "" : "s"}
+          </p>
+        </div>
         <button
           type="button"
-          role="switch"
-          aria-checked={isEditMode}
           onClick={() => onEditModeChange(!isEditMode)}
-          className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-amber-500 ${isEditMode ? "border-amber-500 bg-amber-500" : "border-zinc-200 bg-zinc-100"}`}
+          className="h-9 shrink-0 rounded-[80px] border border-zinc-900 bg-white px-4 text-sm font-semibold text-zinc-900 hover:bg-zinc-50"
         >
-          <span
-            className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow ring-0 transition-transform ${isEditMode ? "translate-x-5" : "translate-x-0.5"}`}
-          />
+          {isEditMode ? "Done" : "Edit"}
         </button>
       </div>
-      <h2 className="shrink-0 text-lg font-semibold text-zinc-800">
-        Optimized Routes
-      </h2>
-      <p className="mt-1 shrink-0 text-xs text-zinc-500">
-        {routes.length} route{routes.length === 1 ? "" : "s"} with {totalStops}{" "}
-        total stop
-        {totalStops === 1 ? "" : "s"}
-      </p>
-      <div className="flex-1 min-h-0 overflow-y-auto mt-3">
+      <div className="mt-3 flex-1 min-h-0 flex flex-col">
+        <div className="flex-1 min-h-0 overflow-y-auto">
         {routes.length === 0 ? (
           <p className="text-sm text-zinc-500">No routes yet</p>
         ) : (
           <ul className="space-y-3 pb-2">
             {routes.map((route, idx) => {
               const isExpanded = expandedRouteIds.has(route.vehicleId);
-              const sortedStops = [...route.stops].sort(
-                (a, b) => a.sequence - b.sequence,
-              );
+              const sortedStops = [...route.stops].sort((a, b) => a.sequence - b.sequence);
               const accent = routeColorHex(idx);
 
               return (
                 <li
                   key={route.vehicleId}
-                  className="rounded-xl border border-zinc-200 bg-zinc-50 shadow-sm overflow-hidden"
-                  style={{ boxShadow: `inset 4px 0 0 ${accent}` }}
+                  className="rounded-xl border border-zinc-200 border-l-4 bg-zinc-50 shadow-sm overflow-hidden"
+                  style={{ borderLeftColor: accent }}
                 >
                   <button
                     type="button"
@@ -102,15 +83,12 @@ export default function Sidebar({
                     <div className="min-w-0 flex-1">
                       <div className="flex items-start gap-2 min-w-0">
                         <span
-                          className="mt-0.5 h-5 w-5 shrink-0 rounded-md"
+                          className="mt-0.5 h-8 w-8 shrink-0 rounded-md"
                           style={{ backgroundColor: accent }}
                           aria-hidden
                         />
                         <div className="min-w-0">
-                          <div
-                            className="text-sm font-semibold"
-                            style={{ color: accent }}
-                          >
+                          <div className="text-sm font-semibold" style={{ color: accent }}>
                             Route {idx + 1}
                           </div>
                           <div className="text-xs text-zinc-500">
@@ -120,37 +98,20 @@ export default function Sidebar({
                       </div>
                       <div className="mt-2 grid grid-cols-3 gap-2">
                         <div className="rounded-lg bg-white px-2 py-1.5 shadow-sm min-w-0 text-center">
-                          <div className="text-[9px] uppercase tracking-wide text-zinc-500">
-                            STOPS
-                          </div>
-                          <div className="text-sm font-semibold text-zinc-800">
-                            {sortedStops.length}
-                          </div>
+                          <div className="text-[9px] uppercase tracking-wide text-zinc-500">STOPS</div>
+                          <div className="text-sm font-semibold text-zinc-800">{sortedStops.length}</div>
                         </div>
                         <div className="rounded-lg bg-white px-2 py-1.5 shadow-sm min-w-0 text-center">
-                          <div className="text-[9px] uppercase tracking-wide text-zinc-500">
-                            DISTANCE
-                          </div>
-                          <div className="text-sm font-semibold text-zinc-800 tabular-nums">
-                            {route.distanceMi != null
-                              ? `${route.distanceMi}mi`
-                              : "—"}
-                          </div>
+                          <div className="text-[9px] uppercase tracking-wide text-zinc-500">DISTANCE</div>
+                          <div className="text-sm font-semibold text-zinc-800 tabular-nums">{route.distanceMi != null ? `${route.distanceMi}mi` : "—"}</div>
                         </div>
                         <div className="rounded-lg bg-white px-2 py-1.5 shadow-sm min-w-0 text-center">
-                          <div className="text-[9px] uppercase tracking-wide text-zinc-500">
-                            EST. TIME
-                          </div>
-                          <div className="text-sm font-semibold text-zinc-800 tabular-nums">
-                            {formatEstTime(route.estimatedTimeMinutes)}
-                          </div>
+                          <div className="text-[9px] uppercase tracking-wide text-zinc-500">EST. TIME</div>
+                          <div className="text-sm font-semibold text-zinc-800 tabular-nums">{formatEstTime(route.estimatedTimeMinutes)}</div>
                         </div>
                       </div>
                       <p className="mt-2 text-xs text-zinc-600">
-                        <span className="font-medium text-zinc-700">
-                          Driver:
-                        </span>{" "}
-                        {route.driverName}
+                        <span className="font-medium text-zinc-700">Driver:</span> {route.driverName}
                       </p>
                     </div>
 
@@ -179,9 +140,7 @@ export default function Sidebar({
                               stop={stop}
                               accentColor={accent}
                               isEditMode={isEditMode}
-                              onSaveNote={(note) =>
-                                onUpdateStopNote(route.vehicleId, stop.id, note)
-                              }
+                              onSaveNote={(note) => onUpdateStopNote(route.vehicleId, stop.id, note)}
                             />
                           </li>
                         ))}
@@ -193,6 +152,12 @@ export default function Sidebar({
             })}
           </ul>
         )}
+        </div>
+        <div className="shrink-0 pt-4 text-zinc-700">
+          <p className="text-3xl leading-none font-semibold text-[#0E5B63]">b²</p>
+          <p className="mt-1 text-[12px] leading-5 font-medium text-zinc-800">Built with ❤️ for Humanity.</p>
+          <p className="text-[12px] leading-5 font-medium text-zinc-800">The Benevolent Bandwidth Foundation</p>
+        </div>
       </div>
     </aside>
   );

--- a/app/ui/src/app/results/components/Sidebar.tsx
+++ b/app/ui/src/app/results/components/Sidebar.tsx
@@ -12,12 +12,19 @@ type SidebarProps = {
   onUpdateStopNote: (routeId: string, stopId: string, note: string) => void;
 };
 
-export default function Sidebar({ routes, isEditMode, onEditModeChange, onUpdateStopNote }: SidebarProps) {
-  const [expandedRouteIds, setExpandedRouteIds] = useState<Set<string>>(() => new Set());
+export default function Sidebar({
+  routes,
+  isEditMode,
+  onEditModeChange,
+  onUpdateStopNote,
+}: SidebarProps) {
+  const [expandedRouteIds, setExpandedRouteIds] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   const totalStops = useMemo(
     () => routes.reduce((sum, r) => sum + r.stops.length, 0),
-    [routes]
+    [routes],
   );
 
   function toggleExpanded(routeId: string) {
@@ -38,14 +45,15 @@ export default function Sidebar({ routes, isEditMode, onEditModeChange, onUpdate
   }
 
   return (
-    <aside
-      className="w-full h-full flex flex-col overflow-hidden border-r-2 border-zinc-200 bg-white p-4"
-    >
+    <aside className="w-full h-full flex flex-col overflow-hidden border-r-2 border-zinc-200 bg-white p-4">
       <div className="flex shrink-0 items-start justify-between gap-3">
         <div>
-          <h2 className="text-lg font-semibold text-zinc-800 whitespace-nowrap">Optimized Routes</h2>
+          <h2 className="text-lg font-semibold text-zinc-800 whitespace-nowrap">
+            Optimized Routes
+          </h2>
           <p className="mt-1 text-xs text-zinc-500">
-            {routes.length} route{routes.length === 1 ? "" : "s"} with {totalStops} total stop
+            {routes.length} route{routes.length === 1 ? "" : "s"} with{" "}
+            {totalStops} total stop
             {totalStops === 1 ? "" : "s"}
           </p>
         </div>
@@ -63,106 +71,142 @@ export default function Sidebar({ routes, isEditMode, onEditModeChange, onUpdate
       </div>
       <div className="mt-3 flex-1 min-h-0 flex flex-col">
         <div className="flex-1 min-h-0 overflow-y-auto">
-        {routes.length === 0 ? (
-          <p className="text-sm text-zinc-500">No routes yet</p>
-        ) : (
-          <ul className="space-y-3 pb-2">
-            {routes.map((route, idx) => {
-              const isExpanded = expandedRouteIds.has(route.vehicleId);
-              const sortedStops = [...route.stops].sort((a, b) => a.sequence - b.sequence);
-              const accent = routeColorHex(idx);
+          {routes.length === 0 ? (
+            <p className="text-sm text-zinc-500">No routes yet</p>
+          ) : (
+            <ul className="space-y-3 pb-2">
+              {routes.map((route, idx) => {
+                const isExpanded = expandedRouteIds.has(route.vehicleId);
+                const sortedStops = [...route.stops].sort(
+                  (a, b) => a.sequence - b.sequence,
+                );
+                const accent = routeColorHex(idx);
 
-              return (
-                <li
-                  key={route.vehicleId}
-                  className={`rounded-xl border border-l-4 shadow-sm overflow-hidden ${
-                    isEditMode ? "border-[#6CCBBE] bg-white" : "border-zinc-200 bg-zinc-50"
-                  }`}
-                  style={{ borderLeftColor: accent }}
-                >
-                  <button
-                    type="button"
-                    onClick={() => toggleExpanded(route.vehicleId)}
-                    className="w-full p-3 flex items-center justify-between gap-3 text-left hover:bg-zinc-100/80 transition-colors"
-                    aria-expanded={isExpanded}
+                return (
+                  <li
+                    key={route.vehicleId}
+                    className={`rounded-xl border border-l-4 shadow-sm overflow-hidden ${
+                      isEditMode
+                        ? "border-[#6CCBBE] bg-white"
+                        : "border-zinc-200 bg-zinc-50"
+                    }`}
+                    style={{ borderLeftColor: accent }}
                   >
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-start gap-2 min-w-0">
-                        <span
-                          className="mt-0.5 h-8 w-8 shrink-0 rounded-md"
-                          style={{ backgroundColor: accent }}
-                          aria-hidden
-                        />
-                        <div className="min-w-0">
-                          <div className="text-sm font-semibold" style={{ color: accent }}>
-                            Route {idx + 1}
-                          </div>
-                          <div className="text-xs text-zinc-500">
-                            {route.vehicleType ?? "Vehicle"} {route.vehicleId}
-                          </div>
-                        </div>
-                      </div>
-                      <div className="mt-2 grid grid-cols-3 gap-2">
-                        <div className="rounded-lg bg-white px-2 py-1.5 shadow-sm min-w-0 text-center">
-                          <div className="text-[9px] uppercase tracking-wide text-zinc-500">STOPS</div>
-                          <div className="text-sm font-semibold text-zinc-800">{sortedStops.length}</div>
-                        </div>
-                        <div className="rounded-lg bg-white px-2 py-1.5 shadow-sm min-w-0 text-center">
-                          <div className="text-[9px] uppercase tracking-wide text-zinc-500">DISTANCE</div>
-                          <div className="text-sm font-semibold text-zinc-800 tabular-nums">{route.distanceMi != null ? `${route.distanceMi}mi` : "—"}</div>
-                        </div>
-                        <div className="rounded-lg bg-white px-2 py-1.5 shadow-sm min-w-0 text-center">
-                          <div className="text-[9px] uppercase tracking-wide text-zinc-500">EST. TIME</div>
-                          <div className="text-sm font-semibold text-zinc-800 tabular-nums">{formatEstTime(route.estimatedTimeMinutes)}</div>
-                        </div>
-                      </div>
-                      <p className="mt-2 text-xs text-zinc-600">
-                        <span className="font-medium text-zinc-700">Driver:</span> {route.driverName}
-                      </p>
-                    </div>
-
-                    <svg
-                      className={`h-4 w-4 shrink-0 text-zinc-500 transition-transform ${
-                        isExpanded ? "rotate-90" : "rotate-0"
-                      }`}
-                      viewBox="0 0 20 20"
-                      fill="currentColor"
-                      aria-hidden
+                    <button
+                      type="button"
+                      onClick={() => toggleExpanded(route.vehicleId)}
+                      className="w-full p-3 flex items-center justify-between gap-3 text-left hover:bg-zinc-100/80 transition-colors"
+                      aria-expanded={isExpanded}
                     >
-                      <path
-                        fillRule="evenodd"
-                        d="M7.21 14.77a.75.75 0 0 1 .02-1.06L10.94 10 7.23 6.29a.75.75 0 1 1 1.06-1.06l4.24 4.24c.3.3.3.77 0 1.06l-4.24 4.24a.75.75 0 0 1-1.06 0Z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </button>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-start gap-2 min-w-0">
+                          <span
+                            className="mt-0.5 h-8 w-8 shrink-0 rounded-md"
+                            style={{ backgroundColor: accent }}
+                            aria-hidden
+                          />
+                          <div className="min-w-0">
+                            <div
+                              className="text-sm font-semibold"
+                              style={{ color: accent }}
+                            >
+                              Route {idx + 1}
+                            </div>
+                            <div className="text-xs text-zinc-500">
+                              {route.vehicleType ?? "Vehicle"} {route.vehicleId}
+                            </div>
+                          </div>
+                        </div>
+                        <div className="mt-2 grid grid-cols-3 gap-2">
+                          <div className="rounded-lg bg-white px-2 py-1.5 shadow-sm min-w-0 text-center">
+                            <div className="text-[9px] uppercase tracking-wide text-zinc-500">
+                              STOPS
+                            </div>
+                            <div className="text-sm font-semibold text-zinc-800">
+                              {sortedStops.length}
+                            </div>
+                          </div>
+                          <div className="rounded-lg bg-white px-2 py-1.5 shadow-sm min-w-0 text-center">
+                            <div className="text-[9px] uppercase tracking-wide text-zinc-500">
+                              DISTANCE
+                            </div>
+                            <div className="text-sm font-semibold text-zinc-800 tabular-nums">
+                              {route.distanceMi != null
+                                ? `${route.distanceMi}mi`
+                                : "—"}
+                            </div>
+                          </div>
+                          <div className="rounded-lg bg-white px-2 py-1.5 shadow-sm min-w-0 text-center">
+                            <div className="text-[9px] uppercase tracking-wide text-zinc-500">
+                              EST. TIME
+                            </div>
+                            <div className="text-sm font-semibold text-zinc-800 tabular-nums">
+                              {formatEstTime(route.estimatedTimeMinutes)}
+                            </div>
+                          </div>
+                        </div>
+                        <p className="mt-2 text-xs text-zinc-600">
+                          <span className="font-medium text-zinc-700">
+                            Driver:
+                          </span>{" "}
+                          {route.driverName}
+                        </p>
+                      </div>
 
-                  {isExpanded && (
-                    <div className="border-t border-zinc-200 bg-zinc-100/50 p-3">
-                      <ul className="space-y-2">
-                        {sortedStops.map((stop) => (
-                          <li key={stop.id}>
-                            <EditableStopItem
-                              stop={stop}
-                              accentColor={accent}
-                              isEditMode={isEditMode}
-                              onSaveNote={(note) => onUpdateStopNote(route.vehicleId, stop.id, note)}
-                            />
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        )}
+                      <svg
+                        className={`h-4 w-4 shrink-0 text-zinc-500 transition-transform ${
+                          isExpanded ? "rotate-90" : "rotate-0"
+                        }`}
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        aria-hidden
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M7.21 14.77a.75.75 0 0 1 .02-1.06L10.94 10 7.23 6.29a.75.75 0 1 1 1.06-1.06l4.24 4.24c.3.3.3.77 0 1.06l-4.24 4.24a.75.75 0 0 1-1.06 0Z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    </button>
+
+                    {isExpanded && (
+                      <div className="border-t border-zinc-200 bg-zinc-100/50 p-3">
+                        <ul className="space-y-2">
+                          {sortedStops.map((stop) => (
+                            <li key={stop.id}>
+                              <EditableStopItem
+                                stop={stop}
+                                accentColor={accent}
+                                isEditMode={isEditMode}
+                                onSaveNote={(note) =>
+                                  onUpdateStopNote(
+                                    route.vehicleId,
+                                    stop.id,
+                                    note,
+                                  )
+                                }
+                              />
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
         </div>
         <div className="shrink-0 pt-4 text-zinc-700">
-          <p className="text-3xl leading-none font-semibold text-[#0E5B63]">b²</p>
-          <p className="mt-1 text-[12px] leading-5 font-medium text-zinc-800">Built with ❤️ for Humanity.</p>
-          <p className="text-[12px] leading-5 font-medium text-zinc-800">The Benevolent Bandwidth Foundation</p>
+          <p className="text-3xl leading-none font-semibold text-[#0E5B63]">
+            b²
+          </p>
+          <p className="mt-1 text-[12px] leading-5 font-medium text-zinc-800">
+            Built with ❤️ for Humanity.
+          </p>
+          <p className="text-[12px] leading-5 font-medium text-zinc-800">
+            The Benevolent Bandwidth Foundation
+          </p>
         </div>
       </div>
     </aside>

--- a/app/ui/src/app/results/components/Sidebar.tsx
+++ b/app/ui/src/app/results/components/Sidebar.tsx
@@ -39,11 +39,11 @@ export default function Sidebar({ routes, isEditMode, onEditModeChange, onUpdate
 
   return (
     <aside
-      className={`w-full h-full flex flex-col overflow-hidden border-r-2 bg-white p-4 ${isEditMode ? "border-amber-500" : "border-zinc-200"}`}
+      className="w-full h-full flex flex-col overflow-hidden border-r-2 border-zinc-200 bg-white p-4"
     >
       <div className="flex shrink-0 items-start justify-between gap-3">
         <div>
-          <h2 className="text-lg font-semibold text-zinc-800">Optimized Routes</h2>
+          <h2 className="text-lg font-semibold text-zinc-800 whitespace-nowrap">Optimized Routes</h2>
           <p className="mt-1 text-xs text-zinc-500">
             {routes.length} route{routes.length === 1 ? "" : "s"} with {totalStops} total stop
             {totalStops === 1 ? "" : "s"}
@@ -52,9 +52,13 @@ export default function Sidebar({ routes, isEditMode, onEditModeChange, onUpdate
         <button
           type="button"
           onClick={() => onEditModeChange(!isEditMode)}
-          className="h-9 shrink-0 rounded-[80px] border border-zinc-900 bg-white px-4 text-sm font-semibold text-zinc-900 hover:bg-zinc-50"
+          className={`h-9 shrink-0 rounded-[80px] px-5 text-sm font-semibold transition-colors ${
+            isEditMode
+              ? "border border-[#7BCFC2] bg-[#7BCFC2] text-[#1C1B1F] hover:bg-[#6dc5b7]"
+              : "border border-zinc-900 bg-white text-zinc-900 hover:bg-zinc-50"
+          }`}
         >
-          {isEditMode ? "Done" : "Edit"}
+          {isEditMode ? "Save edits" : "Edit"}
         </button>
       </div>
       <div className="mt-3 flex-1 min-h-0 flex flex-col">
@@ -71,7 +75,9 @@ export default function Sidebar({ routes, isEditMode, onEditModeChange, onUpdate
               return (
                 <li
                   key={route.vehicleId}
-                  className="rounded-xl border border-zinc-200 border-l-4 bg-zinc-50 shadow-sm overflow-hidden"
+                  className={`rounded-xl border border-l-4 shadow-sm overflow-hidden ${
+                    isEditMode ? "border-[#6CCBBE] bg-white" : "border-zinc-200 bg-zinc-50"
+                  }`}
                   style={{ borderLeftColor: accent }}
                 >
                   <button

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -136,21 +136,23 @@ export default function ResultsPage() {
 
         <div className="ml-auto flex items-center gap-2">
           {pendingPinMove != null && (
-            <button
-              type="button"
-              onClick={cancelPendingPinMove}
-              className="h-9 px-6 rounded-[80px] border border-[var(--edit-foreground)] font-medium text-[14px] leading-5 text-[var(--edit-foreground)] whitespace-nowrap hover:bg-black/5 transition-colors"
-            >
-              Cancel
-            </button>
+            <>
+              <button
+                type="button"
+                onClick={cancelPendingPinMove}
+                className="h-9 px-6 rounded-[80px] border border-[var(--edit-foreground)] font-medium text-[14px] leading-5 text-[var(--edit-foreground)] whitespace-nowrap hover:bg-black/5 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={savePendingPinMove}
+                className="h-9 px-6 rounded-[80px] border border-[var(--edit-foreground)] font-medium text-[14px] leading-5 text-[var(--edit-foreground)] whitespace-nowrap hover:bg-black/5 transition-colors"
+              >
+                Save
+              </button>
+            </>
           )}
-          <button
-            type="button"
-            onClick={savePendingPinMove}
-            className="h-9 px-6 rounded-[80px] border border-[var(--edit-foreground)] font-medium text-[14px] leading-5 text-[var(--edit-foreground)] whitespace-nowrap hover:bg-black/5 transition-colors"
-          >
-            Save
-          </button>
           <button
             type="button"
             className="h-9 px-6 rounded-[80px] bg-[var(--edit-teal-500)] font-medium text-[14px] leading-5 text-[var(--edit-foreground)] whitespace-nowrap hover:opacity-90 transition-opacity"

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -166,7 +166,7 @@ export default function ResultsPage() {
         </EditSidebar>
 
         <div
-          className={`shrink-0 h-full overflow-hidden transition-[width] duration-300 ease-in-out ${isSidebarOpen ? "w-72" : "w-0"}`}
+          className={`shrink-0 h-full overflow-hidden transition-[width] duration-300 ease-in-out ${isSidebarOpen ? "w-[26rem]" : "w-0"}`}
         >
           <Sidebar
             routes={routes}
@@ -176,7 +176,12 @@ export default function ResultsPage() {
           />
         </div>
         <div className="flex-1 min-w-0 min-h-0 flex flex-col">
-          <div className="flex-1 min-h-0 w-full overflow-hidden">
+          <div className="relative flex-1 min-h-0 w-full overflow-hidden">
+            {isEditMode && (
+              <div className="pointer-events-none absolute left-1/2 top-4 z-10 -translate-x-1/2 rounded-[80px] bg-[#7BCFC2] px-4 py-2 text-sm font-medium text-[#1C1B1F] shadow-sm">
+                You are now in editing mode
+              </div>
+            )}
             <MapComponent
               routes={routes}
               isEditMode={isEditMode}

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -41,7 +41,7 @@ export default function ResultsPage() {
     }
   }, [initialRoutes.length]);
 
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const isSidebarOpen = true;
   const [isEditMode, setIsEditMode] = useState(false);
   const [pendingPinMove, setPendingPinMove] = useState<PendingPinMove | null>(
     null,

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -147,7 +147,7 @@ export default function ResultsPage() {
               <button
                 type="button"
                 onClick={savePendingPinMove}
-                className="h-9 px-6 rounded-[80px] border border-[var(--edit-foreground)] font-medium text-[14px] leading-5 text-[var(--edit-foreground)] whitespace-nowrap hover:bg-black/5 transition-colors"
+                className="h-9 px-6 rounded-[80px] bg-amber-500 font-medium text-[14px] leading-5 text-white whitespace-nowrap hover:bg-amber-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-amber-500"
               >
                 Save
               </button>
@@ -155,7 +155,10 @@ export default function ResultsPage() {
           )}
           <button
             type="button"
-            className="h-9 px-6 rounded-[80px] bg-[var(--edit-teal-500)] font-medium text-[14px] leading-5 text-[var(--edit-foreground)] whitespace-nowrap hover:opacity-90 transition-opacity"
+            disabled
+            aria-disabled="true"
+            title="Export coming soon"
+            className="h-9 px-6 rounded-[80px] bg-[var(--edit-teal-500)] font-medium text-[14px] leading-5 text-[var(--edit-foreground)] whitespace-nowrap opacity-50 cursor-not-allowed"
           >
             Export
           </button>

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -3,6 +3,11 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { NAVBAR_V2_LOGO, NAVBAR_V2_ROOT } from "../edit/formStyles.v2";
+import styles from "../edit/edit.module.css";
+import EditSidebar from "../edit/components/layout/sidebar/Sidebar";
+import SidebarEditButton from "../edit/components/layout/sidebar/SidebarEditButton";
+import SidebarResultsButton from "../edit/components/layout/sidebar/SidebarResultsButton";
 import MapComponent from "./components/Map";
 import Sidebar from "./components/Sidebar";
 import type { PendingPinMove, Route } from "./types";
@@ -107,7 +112,9 @@ export default function ResultsPage() {
   const cancelPendingPinMove = useCallback(() => setPendingPinMove(null), []);
 
   return (
-    <main className="h-screen flex flex-col overflow-hidden">
+    <main
+      className={`h-screen flex flex-col overflow-hidden font-sans-manrope ${styles.root}`}
+    >
       {error && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
           <div className="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm w-80 space-y-4">
@@ -122,62 +129,42 @@ export default function ResultsPage() {
         </div>
       )}{" "}
       {/* Map container switched to h-screen and added overflow hidden so the page is forced to be exactly one screen tall, whereas before the page was allowed to get taller than browser window leading to a long scroll */}
-      <header className="flex items-center justify-between gap-3 p-4 shrink-0 border-b border-zinc-200 bg-white">
+      <header className={`${NAVBAR_V2_ROOT} shrink-0 border-b border-zinc-200`}>
         <div className="flex items-center gap-3 min-w-0">
-          <button
-            type="button"
-            onClick={() => setIsSidebarOpen((prev) => !prev)}
-            className="flex h-9 w-9 items-center justify-center rounded-lg border border-zinc-200 bg-white text-zinc-700 hover:bg-zinc-50"
-            aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
-          >
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 6h16M4 12h16M4 18h16"
-              />
-            </svg>
-          </button>
-          <p className="truncate text-sm font-semibold tracking-wide text-zinc-800 uppercase">
-            Delivery Optimizer
-          </p>
+          <p className={NAVBAR_V2_LOGO}>DELIVERY OPTIMIZER</p>
         </div>
 
         <div className="ml-auto flex items-center gap-2">
           {pendingPinMove != null && (
-            <>
-              <button
-                type="button"
-                onClick={cancelPendingPinMove}
-                className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={savePendingPinMove}
-                className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
-              >
-                Save
-              </button>
-            </>
+            <button
+              type="button"
+              onClick={cancelPendingPinMove}
+              className="h-9 px-6 rounded-[80px] border border-[var(--edit-foreground)] font-medium text-[14px] leading-5 text-[var(--edit-foreground)] whitespace-nowrap hover:bg-black/5 transition-colors"
+            >
+              Cancel
+            </button>
           )}
           <button
             type="button"
-            className="rounded-full bg-emerald-500 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-600"
+            onClick={savePendingPinMove}
+            className="h-9 px-6 rounded-[80px] border border-[var(--edit-foreground)] font-medium text-[14px] leading-5 text-[var(--edit-foreground)] whitespace-nowrap hover:bg-black/5 transition-colors"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            className="h-9 px-6 rounded-[80px] bg-[var(--edit-teal-500)] font-medium text-[14px] leading-5 text-[var(--edit-foreground)] whitespace-nowrap hover:opacity-90 transition-opacity"
           >
             Export
           </button>
         </div>
       </header>
       <div className="flex flex-1 min-h-0">
+        <EditSidebar>
+          <SidebarEditButton />
+          <SidebarResultsButton />
+        </EditSidebar>
+
         <div
           className={`shrink-0 h-full overflow-hidden transition-[width] duration-300 ease-in-out ${isSidebarOpen ? "w-72" : "w-0"}`}
         >

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -145,12 +145,9 @@ export default function ResultsPage() {
               />
             </svg>
           </button>
-          <div className="min-w-0">
-            <span className="block truncate text-sm font-semibold tracking-wide text-zinc-800 uppercase">
-              Delivery Optimizer
-            </span>
-            <h1 className="sr-only">Results</h1>
-          </div>
+          <p className="truncate text-sm font-semibold tracking-wide text-zinc-800 uppercase">
+            Delivery Optimizer
+          </p>
         </div>
 
         <div className="ml-auto flex items-center gap-2">
@@ -166,7 +163,7 @@ export default function ResultsPage() {
               <button
                 type="button"
                 onClick={savePendingPinMove}
-                className="rounded-full bg-amber-500 px-3 py-1 text-xs font-medium text-white hover:bg-amber-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-amber-500"
+                className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50"
               >
                 Save
               </button>
@@ -174,10 +171,7 @@ export default function ResultsPage() {
           )}
           <button
             type="button"
-            disabled
-            aria-disabled="true"
-            title="Export coming soon"
-            className="rounded-full bg-emerald-500 px-3 py-1 text-xs font-medium text-white opacity-50 cursor-not-allowed"
+            className="rounded-full bg-emerald-500 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-600"
           >
             Export
           </button>


### PR DESCRIPTION
## Summary

- Updates Results edit-mode visuals to match hi-fi mock: teal “Save edits” control, route-card styling in edit mode, a centered map banner (“You are now in editing mode”), and a wider routes sidebar for card layout.
- Rebases onto `upstream/main` and keeps shared Results infrastructure (directions polylines, distance updates, route-colored map pins, edit nav rail).

## Motivation

- The Results page edit state still used the older amber toggle and inset-shadow route cards, which did not match the hi-fi edit-mode design.
- Reviewers need clearer affordance when editing (banner + button label) and more horizontal room in the routes panel while adjusting stops and notes.

## Changes

### Frontend

- `app/ui/src/app/results/page.tsx`
  - Centered “You are now in editing mode” banner over the map when `isEditMode` is true (teal pill, non-interactive overlay).
  - Widened routes sidebar from `w-72` to `w-[26rem]` for card layout room.
  - Hi-fi top bar (`NAVBAR_V2_*`) and left edit nav rail (`EditSidebar`, `SidebarEditButton`, `SidebarResultsButton`).
  - `edit.module.css` root tokens on `<main>` for shared design variables.
- `app/ui/src/app/results/components/Sidebar.tsx`
  - Replaced amber edit toggle with **Edit** / **Save edits** pill (`#7BCFC2` when active).
  - Edit-mode route cards: teal border (`#6CCBBE`), white background; view mode keeps zinc styling.
  - Left accent strip via `border-l-4` + `routeColorHex`; `whitespace-nowrap` on “Optimized Routes” title.
  - Footer branding block retained.
- `app/ui/src/app/results/components/Map.tsx`
  - Route-colored SVG teardrop pin markers (from stacked pin-colors work on this branch).
- `app/ui/src/app/edit/components/layout/sidebar/SidebarResultsButton.tsx` + `app/ui/src/app/edit/utils/hasOptimizeResults.ts`
  - Results nav link enabled when `optimizeResults` exists in `sessionStorage` (post-rebase wiring).

## Validation

### Frontend

- [x] `npm --prefix app/ui run lint`
- [x] `npm --prefix app/ui run format:check`
- [x] `npm --prefix app/ui run typecheck`
- [x] `npm --prefix app/ui run test`
- [x] `npm --prefix app/ui run build`
- [x] `npm --prefix app/mobile run lint`
- [x] `npm --prefix app/mobile run typecheck`

### Backend

- [ ] `cmake --preset dev`
- [ ] `.github/scripts/check-backend-static.sh build/dev`
- [ ] `cmake --build --preset dev --parallel`
- [ ] `ctest --preset dev --output-on-failure --no-tests=error -LE 'e2e|docker'`
- [ ] `docker compose -f deploy/compose/docker-compose.arm64.yml --env-file deploy/env/http-server.arm64.env config`

Manual: on `/results`, toggle **Edit** → confirm teal **Save edits**, map banner, wider sidebar, and teal-bordered route cards; toggle off → banner and edit styling clear.

## Risk

- Low. UI-only changes on Results; no API or persistence changes.
- Edit-mode colors use fixed hex values (`#7BCFC2`, `#6CCBBE`) rather than CSS tokens; future token consolidation may need a small follow-up.
- Branch includes map pin styling from earlier stacked commits; behavior unchanged aside from pin appearance.

## Rollout and Recovery

- Safe to merge and deploy with the frontend; no migrations or feature flags.
- Rollback: revert this PR to restore amber toggle, narrower sidebar, and prior route-card styling.
- No backend recovery steps required.

## High-Signal PR Checklist

- [x] The summary states the user-visible or operational outcome, not just file names.
- [x] The motivation explains why this change is needed now.
- [x] The change list separates frontend, backend, infrastructure, and documentation work where applicable.
- [x] Validation includes exact commands run, relevant output, and any checks intentionally skipped.
- [x] Risks, migrations, feature flags, and rollback steps are called out when relevant.
- [ ] Screenshots or request/response examples are included for UI and API behavior changes.