### PR TITLE
HI-FI: Wire Recipient And Delivery Window Data To Results

### DIFF
--- a/app/ui/src/app/edit/utils/vroomToRoutes.ts
+++ b/app/ui/src/app/edit/utils/vroomToRoutes.ts
@@ -57,10 +57,6 @@ export function vroomToRoutes(
       // arrival is in seconds; % 86400 extracts the within-day portion for display
       const arrivalTimeStr = secondsToTimeString(step.arrival % 86400);
 
-      const qtyFromForm =
-        address && address.deliveryQuantity > 0 ? address.deliveryQuantity : undefined;
-      const capacityUsed = qtyFromForm ?? step.load?.[0] ?? 0;
-
       const winStart = address?.deliveryTimeStart?.trim();
       const winEnd = address?.deliveryTimeEnd?.trim();
 
@@ -71,7 +67,7 @@ export function vroomToRoutes(
         lat,
         lng,
         sequence: idx + 1,
-        capacityUsed,
+        capacityUsed: step.load?.[0] ?? 0,
         timeWindow: {
           kind: inferTimeWindowKind(
             address?.deliveryTimeStart,

--- a/app/ui/src/app/edit/utils/vroomToRoutes.ts
+++ b/app/ui/src/app/edit/utils/vroomToRoutes.ts
@@ -69,17 +69,14 @@ export function vroomToRoutes(
         sequence: idx + 1,
         capacityUsed: step.load?.[0] ?? 0,
         timeWindow: {
-          kind: inferTimeWindowKind(
-            address?.deliveryTimeStart,
-            address?.deliveryTimeEnd,
-          ),
+          kind: inferTimeWindowKind(winStart, winEnd),
           time: arrivalTimeStr,
         },
         note: address?.notes ?? "",
         addresseeName: address?.recipientName?.trim() || undefined,
         phoneNumber: address?.phoneNumber?.trim() || undefined,
         ...(winStart && winEnd
-          ? { deliveryWindowStart: winStart, deliveryWindowEnd: winEnd }
+          ? { deliveryWindow: { start: winStart, end: winEnd } }
           : {}),
       };
     });

--- a/app/ui/src/app/edit/utils/vroomToRoutes.ts
+++ b/app/ui/src/app/edit/utils/vroomToRoutes.ts
@@ -57,6 +57,13 @@ export function vroomToRoutes(
       // arrival is in seconds; % 86400 extracts the within-day portion for display
       const arrivalTimeStr = secondsToTimeString(step.arrival % 86400);
 
+      const qtyFromForm =
+        address && address.deliveryQuantity > 0 ? address.deliveryQuantity : undefined;
+      const capacityUsed = qtyFromForm ?? step.load?.[0] ?? 0;
+
+      const winStart = address?.deliveryTimeStart?.trim();
+      const winEnd = address?.deliveryTimeEnd?.trim();
+
       return {
         id: step.job_external_id!,
         address:
@@ -64,7 +71,7 @@ export function vroomToRoutes(
         lat,
         lng,
         sequence: idx + 1,
-        capacityUsed: step.load?.[0] ?? 0,
+        capacityUsed,
         timeWindow: {
           kind: inferTimeWindowKind(
             address?.deliveryTimeStart,
@@ -73,8 +80,11 @@ export function vroomToRoutes(
           time: arrivalTimeStr,
         },
         note: address?.notes ?? "",
-        addresseeName: address?.recipientName || undefined,
-        phoneNumber: address?.phoneNumber || undefined,
+        addresseeName: address?.recipientName?.trim() || undefined,
+        phoneNumber: address?.phoneNumber?.trim() || undefined,
+        ...(winStart && winEnd
+          ? { deliveryWindowStart: winStart, deliveryWindowEnd: winEnd }
+          : {}),
       };
     });
 

--- a/app/ui/src/app/results/components/EditableStopItem.tsx
+++ b/app/ui/src/app/results/components/EditableStopItem.tsx
@@ -42,6 +42,16 @@ export default function EditableStopItem({
           {stop.addresseeName ?? "—"}
         </div>
         <div>
+          <span className="font-medium text-zinc-700">Phone:</span>{" "}
+          {stop.phoneNumber ?? "—"}
+        </div>
+        {stop.deliveryWindowStart && stop.deliveryWindowEnd ? (
+          <div>
+            <span className="font-medium text-zinc-700">Delivery window:</span>{" "}
+            {stop.deliveryWindowStart} – {stop.deliveryWindowEnd}
+          </div>
+        ) : null}
+        <div>
           <span className="font-medium text-zinc-700">
             Est time of arrival:
           </span>{" "}

--- a/app/ui/src/app/results/components/EditableStopItem.tsx
+++ b/app/ui/src/app/results/components/EditableStopItem.tsx
@@ -36,19 +36,17 @@ export default function EditableStopItem({
       </div>
       <div className="mt-1.5 space-y-0.5 text-xs text-zinc-600">
         <div>
-          <span className="font-medium text-zinc-700">
-            Name of addressed to:
-          </span>{" "}
+          <span className="font-medium text-zinc-700">Addressee:</span>{" "}
           {stop.addresseeName ?? "—"}
         </div>
         <div>
           <span className="font-medium text-zinc-700">Phone:</span>{" "}
           {stop.phoneNumber ?? "—"}
         </div>
-        {stop.deliveryWindowStart && stop.deliveryWindowEnd ? (
+        {stop.deliveryWindow ? (
           <div>
             <span className="font-medium text-zinc-700">Delivery window:</span>{" "}
-            {stop.deliveryWindowStart} – {stop.deliveryWindowEnd}
+            {stop.deliveryWindow.start} – {stop.deliveryWindow.end}
           </div>
         ) : null}
         <div>

--- a/app/ui/src/app/results/types.ts
+++ b/app/ui/src/app/results/types.ts
@@ -23,9 +23,8 @@ export interface Stop {
   note: string; // driver notes for the stop
   addresseeName?: string; // name of person at address
   phoneNumber?: string; // phone number of person at address
-  /** When both set (from delivery window picks), displayed as “start – end” on results */
-  deliveryWindowStart?: string;
-  deliveryWindowEnd?: string;
+  /** Delivery window from edit form; start and end are always set together */
+  deliveryWindow?: { start: string; end: string };
 }
 
 // Data that a single route contains (one driver, their stops in order, and the path to draw for the route)

--- a/app/ui/src/app/results/types.ts
+++ b/app/ui/src/app/results/types.ts
@@ -23,6 +23,9 @@ export interface Stop {
   note: string; // driver notes for the stop
   addresseeName?: string; // name of person at address
   phoneNumber?: string; // phone number of person at address
+  /** When both set (from delivery window picks), displayed as “start – end” on results */
+  deliveryWindowStart?: string;
+  deliveryWindowEnd?: string;
 }
 
 // Data that a single route contains (one driver, their stops in order, and the path to draw for the route)

--- a/app/ui/src/tests/vroomToRoutes.test.ts
+++ b/app/ui/src/tests/vroomToRoutes.test.ts
@@ -181,6 +181,26 @@ describe("vroomToRoutes", () => {
     expect(route.stops[1].sequence).toBe(2);
   });
 
+  it("maps recipient, phone, and delivery window from address card", () => {
+    const [route] = vroomToRoutes(
+      SINGLE_STOP,
+      [makeVehicle(1)],
+      [
+        makeAddress(1, {
+          recipientName: " Jane Doe ",
+          phoneNumber: "555-123-4567",
+          deliveryTimeStart: "9:00 AM",
+          deliveryTimeEnd: "11:00 AM",
+        }),
+      ],
+    );
+    const stop = route.stops[0];
+    expect(stop.addresseeName).toBe("Jane Doe");
+    expect(stop.phoneNumber).toBe("555-123-4567");
+    expect(stop.deliveryWindowStart).toBe("9:00 AM");
+    expect(stop.deliveryWindowEnd).toBe("11:00 AM");
+  });
+
   it("arrival wraps via % 86400 — 86400 + 32400 still shows 9:00 AM", () => {
     const response: VroomResponse = {
       routes: [

--- a/app/ui/src/tests/vroomToRoutes.test.ts
+++ b/app/ui/src/tests/vroomToRoutes.test.ts
@@ -197,8 +197,29 @@ describe("vroomToRoutes", () => {
     const stop = route.stops[0];
     expect(stop.addresseeName).toBe("Jane Doe");
     expect(stop.phoneNumber).toBe("555-123-4567");
-    expect(stop.deliveryWindowStart).toBe("9:00 AM");
-    expect(stop.deliveryWindowEnd).toBe("11:00 AM");
+    expect(stop.deliveryWindow).toEqual({
+      start: "9:00 AM",
+      end: "11:00 AM",
+    });
+  });
+
+  it("trims delivery window fields for kind and deliveryWindow", () => {
+    const [route] = vroomToRoutes(
+      SINGLE_STOP,
+      [makeVehicle(1)],
+      [
+        makeAddress(1, {
+          deliveryTimeStart: " 9:00 AM",
+          deliveryTimeEnd: "11:00 AM ",
+        }),
+      ],
+    );
+    const stop = route.stops[0];
+    expect(stop.timeWindow.kind).toBe("at");
+    expect(stop.deliveryWindow).toEqual({
+      start: "9:00 AM",
+      end: "11:00 AM",
+    });
   });
 
   it("arrival wraps via % 86400 — 86400 + 32400 still shows 9:00 AM", () => {


### PR DESCRIPTION
## Summary

Results expanded stop cards show recipient name, phone, and delivery window from the edit session, mapped through `vroomToRoutes` into `Stop` and rendered on each card.

## Motivation

Stop cards only showed address, package count, and optimizer arrival time. Recipient contact and the user’s delivery window lived on the edit form but were not passed through to results, so drivers could not see them after optimization.

## Changes

- `app/ui/src/app/results/types.ts` — add optional `phoneNumber`, `deliveryWindowStart`, and `deliveryWindowEnd` on `Stop`.
- `app/ui/src/app/edit/utils/vroomToRoutes.ts` — map `recipientName`, `phoneNumber`, and delivery window bounds from `AddressCard` onto each stop (trim empty strings; window only when both start and end are set). Keep `capacityUsed` from VROOM `step.load`, not form quantity.
- `app/ui/src/app/results/components/EditableStopItem.tsx` — render phone and delivery window rows on expanded stop cards.
- `app/ui/src/tests/vroomToRoutes.test.ts` — test recipient, phone, and window mapping.

**Out of scope for this PR (already on `main`, unchanged here):** `optimizeMapper.ts`, `sessionMapper.ts`, `delivery.ts`, `useAddresses.ts`, `useCSVUpload.ts`.

## Validation

### Frontend

- [x] `npm --prefix app/ui run lint`
- [x] `npm --prefix app/ui run format:check`
- [x] `npm --prefix app/ui run typecheck`
- [x] `npm --prefix app/ui run test`
- [ ] `npm --prefix app/ui run build`
- [ ] `npm --prefix app/mobile run lint`
- [ ] `npm --prefix app/mobile run typecheck`

### Backend

- [ ] `cmake --preset dev`
- [ ] `.github/scripts/check-backend-static.sh build/dev`
- [ ] `cmake --build --preset dev --parallel`
- [ ] `ctest --preset dev --output-on-failure --no-tests=error -LE 'e2e|docker'`
- [ ] `docker compose -f deploy/compose/docker-compose.arm64.yml --env-file deploy/env/http-server.arm64.env config`

## Risk

Low — UI-only mapping and display. `capacityUsed` still comes from the optimizer’s `step.load`. Phone uses `phoneNumber` on `Stop` (same field name as edit → API), not a separate `addresseePhone`.

## Rollout and Recovery

Ship with the results page. Revert this PR if stop card field layout or mapping needs adjustment.