### PR TITLE
Hifi- Driver assist

### DIFF
--- a/app/ui/next.config.ts
+++ b/app/ui/next.config.ts
@@ -1,8 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
+  turbopack: {
+    root: __dirname,
+  },
 };
 
 export default nextConfig;

--- a/app/ui/public/pwa-icon.svg
+++ b/app/ui/public/pwa-icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="108" fill="#111827"/>
+  <path d="M140 158h157c38 0 69 31 69 69v98c0 38-31 69-69 69H140V158Z" fill="#ffffff"/>
+  <path d="M164 194h128c17 0 31 14 31 31v102c0 17-14 31-31 31H164V194Z" fill="#22c55e"/>
+  <path d="M350 218h31c26 0 47 21 47 47v60c0 26-21 47-47 47h-31V218Z" fill="#ffffff"/>
+  <circle cx="189" cy="394" r="34" fill="#111827"/>
+  <circle cx="363" cy="394" r="34" fill="#111827"/>
+  <path d="M178 237h92M178 276h70M178 315h104" stroke="#ffffff" stroke-width="24" stroke-linecap="round"/>
+</svg>

--- a/app/ui/public/sw.js
+++ b/app/ui/public/sw.js
@@ -1,0 +1,59 @@
+const CACHE_NAME = "delivery-optimizer-pwa-v1";
+const APP_SHELL = ["/driver_assist", "/manifest.webmanifest", "/pwa-icon.svg"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(APP_SHELL))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") return;
+
+  const requestUrl = new URL(event.request.url);
+  if (requestUrl.origin !== self.location.origin) return;
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached;
+
+      return fetch(event.request)
+        .then((response) => {
+          const shouldCache =
+            response.ok &&
+            (event.request.mode === "navigate" ||
+              requestUrl.pathname.startsWith("/_next/static/"));
+
+          if (!shouldCache) return response;
+
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(() => {
+          if (event.request.mode === "navigate") {
+            return caches.match("/driver_assist");
+          }
+          throw new Error("Network unavailable");
+        });
+    })
+  );
+});

--- a/app/ui/public/sw.js
+++ b/app/ui/public/sw.js
@@ -6,7 +6,7 @@ self.addEventListener("install", (event) => {
     caches
       .open(CACHE_NAME)
       .then((cache) => cache.addAll(APP_SHELL))
-      .then(() => self.skipWaiting())
+      .then(() => self.skipWaiting()),
   );
 });
 
@@ -18,10 +18,10 @@ self.addEventListener("activate", (event) => {
         Promise.all(
           keys
             .filter((key) => key !== CACHE_NAME)
-            .map((key) => caches.delete(key))
-        )
+            .map((key) => caches.delete(key)),
+        ),
       )
-      .then(() => self.clients.claim())
+      .then(() => self.clients.claim()),
   );
 });
 
@@ -45,7 +45,9 @@ self.addEventListener("fetch", (event) => {
           if (!shouldCache) return response;
 
           const copy = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          caches
+            .open(CACHE_NAME)
+            .then((cache) => cache.put(event.request, copy));
           return response;
         })
         .catch(() => {
@@ -54,6 +56,6 @@ self.addEventListener("fetch", (event) => {
           }
           throw new Error("Network unavailable");
         });
-    })
+    }),
   );
 });

--- a/app/ui/src/app/components/ServiceWorkerRegistration.tsx
+++ b/app/ui/src/app/components/ServiceWorkerRegistration.tsx
@@ -4,7 +4,10 @@ import { useEffect } from "react";
 
 export default function ServiceWorkerRegistration() {
   useEffect(() => {
-    if (!("serviceWorker" in navigator) || process.env.NODE_ENV !== "production") {
+    if (
+      !("serviceWorker" in navigator) ||
+      process.env.NODE_ENV !== "production"
+    ) {
       return;
     }
 

--- a/app/ui/src/app/components/ServiceWorkerRegistration.tsx
+++ b/app/ui/src/app/components/ServiceWorkerRegistration.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function ServiceWorkerRegistration() {
+  useEffect(() => {
+    if (!("serviceWorker" in navigator) || process.env.NODE_ENV !== "production") {
+      return;
+    }
+
+    navigator.serviceWorker.register("/sw.js").catch((error) => {
+      console.error("Service worker registration failed", error);
+    });
+  }, []);
+
+  return null;
+}

--- a/app/ui/src/app/driver_assist/page.tsx
+++ b/app/ui/src/app/driver_assist/page.tsx
@@ -2,6 +2,7 @@
 
 import type { CSSProperties } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import Image from "next/image";
 
 import {
   createPersistedRouteState,
@@ -62,6 +63,10 @@ function openNavigation(stop: DeliveryStop) {
 
 export default function DriverAssistPwaPage() {
   const inputRef = useRef<HTMLInputElement>(null);
+  const topRef = useRef<HTMLDivElement>(null);
+  const remainingRef = useRef<HTMLDivElement>(null);
+  const deliveredRef = useRef<HTMLDivElement>(null);
+  const reportedRef = useRef<HTMLDivElement>(null);
   const [route, setRoute] = useState<DriverRoute | null>(null);
   const [openId, setOpenId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -152,9 +157,15 @@ export default function DriverAssistPwaPage() {
     setError(null);
   };
 
+  const scrollToSection = (target: React.RefObject<HTMLElement | null>) => {
+    target.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
   const pendingStops = route?.stops.filter((stop) => stop.status === "pending") || [];
-  const completedStops =
-    route?.stops.filter((stop) => stop.status !== "pending") || [];
+  const deliveredStops =
+    route?.stops.filter((stop) => stop.status === "completed") || [];
+  const reportedStops =
+    route?.stops.filter((stop) => stop.status === "failed") || [];
 
   if (!route) {
     return (
@@ -187,24 +198,36 @@ export default function DriverAssistPwaPage() {
 
   return (
     <main style={styles.safeArea}>
-      <section style={styles.container}>
+      <section ref={topRef} style={styles.container}>
         <div style={styles.topBar}>
-          <h1 style={styles.appHeader}>driver_assist</h1>
-          <button type="button" style={styles.textButton} onClick={resetRoute}>
-            New route
+          <h1 style={styles.appHeader}>Driver Assist</h1>
+          <button
+            type="button"
+            style={styles.iconButton}
+            onClick={() => scrollToSection(reportedRef)}
+            aria-label="View reported deliveries"
+          >
+            <WarningIcon />
           </button>
         </div>
 
         <section style={styles.summaryCard}>
-          <p style={styles.headerLabel}>Current Route</p>
-          <h2 style={styles.driverName}>{route.driverName}</h2>
-          <p style={styles.routeLabel}>{route.routeLabel}</p>
-
-          <div style={styles.progressHeader}>
-            <span>Progress</span>
-            <span>
-              {totals.completed}/{totals.total} Deliveries Complete
-            </span>
+          <div style={styles.statsRow}>
+            <StatBlock
+              value={totals.total}
+              label="Total"
+              onClick={() => scrollToSection(topRef)}
+            />
+            <StatBlock
+              value={totals.completed}
+              label="Complete"
+              onClick={() => scrollToSection(deliveredRef)}
+            />
+            <StatBlock
+              value={totals.pending}
+              label="Remaining"
+              onClick={() => scrollToSection(remainingRef)}
+            />
           </div>
 
           <div style={styles.progressTrack}>
@@ -215,44 +238,43 @@ export default function DriverAssistPwaPage() {
               }}
             />
           </div>
-
-          <div style={styles.statsRow}>
-            <StatBlock value={totals.pending} label="Remaining" />
-            <StatBlock value={totals.failed} label="Failed" />
-            <StatBlock value={totals.completed} label="Completed" />
-          </div>
         </section>
 
-        {pendingStops.map((stop) => (
-          <StopCard
-            key={stop.id}
-            stop={stop}
-            isOpen={openId === stop.id}
-            onToggle={() => setOpenId(openId === stop.id ? null : stop.id)}
-            onChangeNote={(notes) => updateStop(stop.id, { notes })}
-            onComplete={() => {
-              updateStop(stop.id, {
-                status: "completed",
-                completedAt: new Date().toISOString(),
-              });
-              setOpenId(null);
-            }}
-            onReport={() => {
-              const reason = window.prompt("Reason this delivery failed?");
-              updateStop(stop.id, {
-                status: "failed",
-                failureReason: reason || "No reason provided",
-              });
-              setOpenId(null);
-            }}
-            onNavigate={() => openNavigation(stop)}
-          />
-        ))}
+        <section ref={remainingRef} style={styles.routeSection}>
+          <h2 style={styles.sectionTitle}>Remaining</h2>
 
-        {completedStops.length > 0 ? (
-          <section style={styles.historySection}>
-            <h2 style={styles.historyTitle}>Completed & Failed</h2>
-            {completedStops.map((stop) => (
+          {pendingStops.map((stop) => (
+            <StopCard
+              key={stop.id}
+              stop={stop}
+              isOpen={openId === stop.id}
+              onToggle={() => setOpenId(openId === stop.id ? null : stop.id)}
+              onChangeNote={(notes) => updateStop(stop.id, { notes })}
+              onComplete={() => {
+                updateStop(stop.id, {
+                  status: "completed",
+                  completedAt: new Date().toISOString(),
+                });
+                setOpenId(null);
+              }}
+              onReport={() => {
+                const reason = window.prompt("Reason this delivery failed?");
+                updateStop(stop.id, {
+                  status: "failed",
+                  failureReason: reason || "No reason provided",
+                });
+                setOpenId(null);
+              }}
+              onNavigate={() => openNavigation(stop)}
+            />
+          ))}
+        </section>
+
+        <section ref={deliveredRef} style={styles.historySection}>
+          {deliveredStops.length > 0 ? (
+            <>
+            <h2 style={styles.historyTitle}>Delivered</h2>
+            {deliveredStops.map((stop) => (
               <StopCard
                 key={stop.id}
                 stop={stop}
@@ -264,19 +286,56 @@ export default function DriverAssistPwaPage() {
                 onNavigate={() => openNavigation(stop)}
               />
             ))}
-          </section>
-        ) : null}
+            </>
+          ) : null}
+        </section>
+
+        <section ref={reportedRef} style={styles.historySection}>
+          {reportedStops.length > 0 ? (
+            <>
+              <h2 style={styles.historyTitle}>Incomplete delivery</h2>
+              {reportedStops.map((stop) => (
+                <StopCard
+                  key={stop.id}
+                  stop={stop}
+                  isOpen={openId === stop.id}
+                  onToggle={() => setOpenId(openId === stop.id ? null : stop.id)}
+                  onChangeNote={(notes) => updateStop(stop.id, { notes })}
+                  onComplete={() => undefined}
+                  onReport={() => undefined}
+                  onNavigate={() => openNavigation(stop)}
+                />
+              ))}
+            </>
+          ) : null}
+        </section>
+
+        <DriverFooter />
       </section>
+
+      <div style={styles.finishBar}>
+        <button type="button" style={styles.finishButton} onClick={resetRoute}>
+          Finish
+        </button>
+      </div>
     </main>
   );
 }
 
-function StatBlock({ value, label }: { value: number; label: string }) {
+function StatBlock({
+  value,
+  label,
+  onClick,
+}: {
+  value: number;
+  label: string;
+  onClick: () => void;
+}) {
   return (
-    <div style={styles.statBlock}>
+    <button type="button" style={styles.statBlock} onClick={onClick}>
       <strong style={styles.statNumber}>{value}</strong>
       <span style={styles.statLabel}>{label}</span>
-    </div>
+    </button>
   );
 }
 
@@ -313,26 +372,31 @@ function StopCard({
       }}
     >
       <button type="button" style={styles.cardButton} onClick={onToggle}>
-        <span
-          style={{
-            ...styles.statusCircle,
-            ...(isCompleted ? styles.completedCircle : {}),
-            ...(isFailed ? styles.failedCircle : {}),
-          }}
-        />
         <span style={styles.textBlock}>
-          <strong style={styles.stopText}>Stop {stop.stopNumber}</strong>
-          <span style={styles.nameText}>{stop.customerName}</span>
-          {stop.phoneNumber ? (
-            <span style={styles.phoneText}>{stop.phoneNumber}</span>
-          ) : null}
-          <span style={styles.addressText}>{stop.address}</span>
+          <span style={styles.stopMetaRow}>
+            <span style={styles.stopNumberBadge}>{stop.stopNumber}</span>
+            <span style={styles.stopWindow}>Deliver between 4:00pm - 5:00pm</span>
+          </span>
+          <strong style={styles.addressText}>{stop.address}</strong>
+          <InfoLine icon={<PersonIcon />} text={stop.customerName} />
+          <InfoLine icon={<NoteIcon />} text={stop.notes || "N/A"} />
         </span>
       </button>
 
       {isOpen ? (
         <div style={styles.expandedSection}>
-          <p style={styles.metaText}>Packages: {stop.packageCount}</p>
+          <button type="button" style={styles.primaryActionButton} onClick={onNavigate}>
+            <NavigateIcon />
+            Navigate
+          </button>
+
+          {!isDone ? (
+            <button type="button" style={styles.deliveredButton} onClick={onComplete}>
+              <DeliveredIcon />
+              Delivered
+            </button>
+          ) : null}
+
           <textarea
             style={styles.noteInput}
             value={stop.notes}
@@ -350,14 +414,13 @@ function StopCard({
 
           {!isDone ? (
             <div style={styles.buttonRow}>
-              <button type="button" style={styles.actionButton} onClick={onComplete}>
-                Complete
-              </button>
               <button type="button" style={styles.actionButton} onClick={onNavigate}>
-                Navigate
+                <PhoneIcon />
+                Call
               </button>
               <button type="button" style={styles.actionButton} onClick={onReport}>
-                Report
+                <ReportIcon />
+                Report issue
               </button>
             </div>
           ) : (
@@ -371,15 +434,99 @@ function StopCard({
   );
 }
 
+function InfoLine({ icon, text }: { icon: React.ReactNode; text: string }) {
+  return (
+    <span style={styles.infoLine}>
+      <span style={styles.infoIcon}>{icon}</span>
+      <span style={styles.infoText}>{text}</span>
+    </span>
+  );
+}
+
+function DriverFooter() {
+  return (
+    <footer style={styles.footer}>
+      <Image src="/logo.png" alt="b2 logo" width={25} height={28} style={styles.footerLogo} />
+      <p style={styles.footerText}>Built with ❤️ for Humanity.</p>
+      <p style={styles.footerText}>The Benevolent Bandwidth Foundation</p>
+    </footer>
+  );
+}
+
+function WarningIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 4 21 20H3L12 4Z" stroke="currentColor" strokeWidth="1.7" />
+      <path d="M12 9v5" stroke="currentColor" strokeLinecap="round" strokeWidth="1.7" />
+      <circle cx="12" cy="17" r="1" fill="currentColor" />
+    </svg>
+  );
+}
+
+function NavigateIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="2" />
+      <path d="m12 7 4 10-4-2-4 2 4-10Z" stroke="currentColor" strokeLinejoin="round" strokeWidth="2" />
+    </svg>
+  );
+}
+
+function DeliveredIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M8 5h8v3h3v11H5V8h3V5Z" stroke="currentColor" strokeLinejoin="round" strokeWidth="1.8" />
+      <path d="m9 13 2 2 4-5" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
+    </svg>
+  );
+}
+
+function PhoneIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M8 5 6 7c1 5 6 10 11 11l2-2-4-3-2 2c-2-1-4-3-5-5l2-2-2-3Z" stroke="currentColor" strokeLinejoin="round" strokeWidth="1.8" />
+    </svg>
+  );
+}
+
+function ReportIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M12 7v6" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
+      <circle cx="12" cy="16.5" r="1" fill="currentColor" />
+    </svg>
+  );
+}
+
+function PersonIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="8" r="3" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M5 20c1.2-4 12.8-4 14 0" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
+    </svg>
+  );
+}
+
+function NoteIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M6 4h12v16H6V4Z" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M9 8h6M9 12h6M9 16h4" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
+    </svg>
+  );
+}
+
 const styles: Record<string, CSSProperties> = {
   safeArea: {
-    minHeight: "100svh",
+    minHeight: "100dvh",
     backgroundColor: "#ffffff",
-    color: "#111827",
+    color: "#222222",
     fontFamily: "var(--font-geist-sans), Arial, sans-serif",
+    paddingBottom: "calc(75px + env(safe-area-inset-bottom))",
   },
   uploadScreen: {
-    minHeight: "100svh",
+    minHeight: "100dvh",
     display: "flex",
     flexDirection: "column",
     justifyContent: "center",
@@ -390,10 +537,10 @@ const styles: Record<string, CSSProperties> = {
     display: "none",
   },
   appHeader: {
-    fontSize: 32,
+    fontSize: 14,
     fontWeight: 700,
-    color: "#111827",
-    margin: "0 0 16px",
+    color: "#202020",
+    margin: 0,
   },
   uploadButton: {
     backgroundColor: "#111827",
@@ -413,130 +560,108 @@ const styles: Record<string, CSSProperties> = {
     textAlign: "center",
   },
   container: {
-    maxWidth: 520,
+    width: "100%",
+    maxWidth: "none",
     margin: "0 auto",
-    padding: 16,
+    padding: "24px 12px 22px",
   },
   topBar: {
     display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 16,
+    alignItems: "flex-start",
+    flexDirection: "column",
+    gap: 8,
+    marginBottom: 20,
+    width: "100%",
   },
-  textButton: {
+  iconButton: {
     background: "transparent",
-    border: "1px solid #d1d5db",
-    borderRadius: 8,
-    color: "#111827",
+    border: 0,
+    color: "#202020",
     cursor: "pointer",
-    fontSize: 14,
-    fontWeight: 600,
-    padding: "9px 12px",
+    display: "inline-flex",
+    padding: 0,
   },
   summaryCard: {
-    backgroundColor: "#ffffff",
-    border: "2px solid #4b5563",
-    borderRadius: 8,
     marginBottom: 16,
-    padding: 20,
-  },
-  headerLabel: {
-    color: "#6b7280",
-    fontSize: 18,
-    margin: "0 0 8px",
-  },
-  driverName: {
-    color: "#111827",
-    fontSize: 36,
-    fontWeight: 700,
-    lineHeight: 1.1,
-    margin: 0,
-  },
-  routeLabel: {
-    color: "#374151",
-    fontSize: 18,
-    margin: "4px 0 18px",
-  },
-  progressHeader: {
-    color: "#111827",
-    display: "flex",
-    fontSize: 15,
-    justifyContent: "space-between",
-    marginBottom: 8,
+    width: "100%",
   },
   progressTrack: {
-    backgroundColor: "#e5e7eb",
+    backgroundColor: "#dfdfde",
     borderRadius: 999,
-    height: 12,
-    marginBottom: 18,
+    height: 6,
     overflow: "hidden",
   },
   progressFill: {
-    backgroundColor: "#22c55e",
-    height: 12,
+    backgroundColor: "#73b99f",
+    height: "100%",
   },
   statsRow: {
-    backgroundColor: "#f3f4f6",
-    borderRadius: 8,
+    alignItems: "center",
+    alignSelf: "stretch",
     display: "flex",
-    justifyContent: "space-between",
-    padding: "18px 0",
+    gap: 16,
+    justifyContent: "center",
+    marginBottom: 21,
   },
   statBlock: {
     alignItems: "center",
+    background: "transparent",
+    border: 0,
+    cursor: "pointer",
     display: "flex",
-    flex: 1,
+    flex: "0 0 auto",
     flexDirection: "column",
+    font: "inherit",
+    padding: 0,
   },
   statNumber: {
-    color: "#111827",
-    fontSize: 28,
+    color: "#202020",
+    fontSize: 15,
     fontWeight: 700,
+    lineHeight: 1,
   },
   statLabel: {
-    color: "#4b5563",
-    fontSize: 14,
-    marginTop: 4,
+    color: "#555555",
+    fontSize: 12,
+    marginTop: 7,
+  },
+  sectionTitle: {
+    color: "#202020",
+    fontSize: 13,
+    fontWeight: 700,
+    margin: "0 0 7px",
+  },
+  routeSection: {
+    scrollMarginTop: 16,
   },
   card: {
-    backgroundColor: "#f3f4f6",
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+    backgroundColor: "#FDFDFC",
+    border: "1px solid #DCDBD8",
     borderRadius: 8,
-    marginBottom: 14,
-    padding: 18,
+    display: "flex",
+    flexDirection: "column",
+    gap: 20,
+    marginBottom: 10,
+    padding: 16,
   },
   completedCard: {
-    backgroundColor: "#e5e7eb",
+    opacity: 0.68,
   },
   failedCard: {
-    backgroundColor: "#fee2e2",
+    backgroundColor: "#fff6f6",
   },
   cardButton: {
     alignItems: "flex-start",
     background: "transparent",
     border: 0,
     cursor: "pointer",
-    display: "flex",
-    gap: 12,
+    display: "block",
+    font: "inherit",
     padding: 0,
     textAlign: "left",
     width: "100%",
-  },
-  statusCircle: {
-    backgroundColor: "#ffffff",
-    border: "2px solid #d1d5db",
-    borderRadius: 11,
-    flex: "0 0 22px",
-    height: 22,
-    marginTop: 4,
-    width: 22,
-  },
-  completedCircle: {
-    backgroundColor: "#22c55e",
-    borderColor: "#22c55e",
-  },
-  failedCircle: {
-    backgroundColor: "#ef4444",
-    borderColor: "#ef4444",
   },
   textBlock: {
     display: "flex",
@@ -544,46 +669,76 @@ const styles: Record<string, CSSProperties> = {
     flexDirection: "column",
     minWidth: 0,
   },
-  stopText: {
-    color: "#111827",
-    fontSize: 24,
-    fontWeight: 700,
-    marginBottom: 2,
+  stopMetaRow: {
+    alignItems: "center",
+    display: "flex",
+    gap: 6,
+    marginBottom: 9,
   },
-  nameText: {
-    color: "#6b7280",
-    fontSize: 16,
-    marginBottom: 2,
+  stopNumberBadge: {
+    alignItems: "center",
+    backgroundColor: "#D5F2E8",
+    borderRadius: 2,
+    color: "#285241",
+    display: "inline-flex",
+    fontSize: 10,
+    height: 18,
+    justifyContent: "center",
+    lineHeight: 1,
+    minWidth: 20,
   },
-  phoneText: {
-    color: "#6b7280",
-    fontSize: 15,
-    marginBottom: 4,
+  stopWindow: {
+    color: "#464544",
+    fontFamily: "var(--font-manrope), var(--font-geist-sans), Arial, sans-serif",
+    fontSize: 14,
+    fontStyle: "normal",
+    fontWeight: 600,
+    lineHeight: "normal",
   },
   addressText: {
-    color: "#374151",
-    fontSize: 16,
+    color: "#222222",
+    fontSize: 12,
+    fontWeight: 700,
+    lineHeight: 1.35,
+    marginBottom: 10,
+    overflowWrap: "anywhere",
+  },
+  infoLine: {
+    alignItems: "flex-start",
+    color: "#444444",
+    display: "flex",
+    gap: 7,
+    marginTop: 4,
+  },
+  infoIcon: {
+    color: "#2f3432",
+    display: "inline-flex",
+    flex: "0 0 16px",
+  },
+  infoText: {
+    color: "#444444",
+    flex: 1,
+    fontSize: 12,
+    lineHeight: 1.35,
     overflowWrap: "anywhere",
   },
   expandedSection: {
-    borderTop: "1px solid #e5e7eb",
-    marginTop: 16,
-    paddingTop: 14,
+    marginTop: 13,
+    width: "100%",
   },
   metaText: {
-    color: "#111827",
-    fontSize: 16,
-    margin: "0 0 12px",
+    display: "none",
   },
   noteInput: {
     backgroundColor: "#ffffff",
-    border: "1px solid #d1d5db",
-    borderRadius: 8,
-    color: "#111827",
+    border: "1px solid #dddddd",
+    borderRadius: 5,
+    color: "#222222",
     font: "inherit",
-    marginBottom: 12,
-    minHeight: 72,
-    padding: 12,
+    fontSize: 12,
+    marginBottom: 8,
+    minHeight: 58,
+    padding: 8,
     resize: "vertical",
     width: "100%",
   },
@@ -595,25 +750,105 @@ const styles: Record<string, CSSProperties> = {
   buttonRow: {
     display: "grid",
     gap: 8,
-    gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
   },
   actionButton: {
+    alignItems: "center",
     backgroundColor: "#ffffff",
-    border: "1px solid #e5e7eb",
+    border: "1px solid #eeeeee",
     borderRadius: 8,
-    color: "#111827",
+    color: "#222222",
     cursor: "pointer",
-    fontWeight: 600,
-    minHeight: 44,
-    padding: "12px 8px",
+    display: "inline-flex",
+    fontSize: 11,
+    fontWeight: 500,
+    gap: 6,
+    justifyContent: "center",
+    minHeight: 42,
+    padding: "0 8px",
+  },
+  primaryActionButton: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    backgroundColor: "#4CB599",
+    border: 0,
+    borderRadius: 16,
+    color: "#143228",
+    cursor: "pointer",
+    display: "inline-flex",
+    fontSize: 11,
+    fontWeight: 500,
+    gap: 6,
+    justifyContent: "center",
+    marginBottom: 7,
+    padding: "20px 24px",
+    width: "100%",
+  },
+  deliveredButton: {
+    alignItems: "center",
+    backgroundColor: "#ffffff",
+    border: "1px solid #222222",
+    borderRadius: 16,
+    color: "#222222",
+    cursor: "pointer",
+    display: "inline-flex",
+    fontSize: 11,
+    fontWeight: 500,
+    gap: 6,
+    justifyContent: "center",
+    marginBottom: 7,
+    padding: "20px 24px",
+    width: "100%",
   },
   historySection: {
-    marginTop: 8,
+    marginTop: 29,
+    scrollMarginTop: 16,
   },
   historyTitle: {
-    color: "#111827",
-    fontSize: 20,
+    color: "#202020",
+    fontSize: 13,
     fontWeight: 700,
-    margin: "0 0 10px",
+    margin: "0 0 24px",
+  },
+  footer: {
+    marginTop: 36,
+    paddingBottom: 48,
+  },
+  footerLogo: {
+    display: "block",
+    height: 28,
+    objectFit: "contain",
+    width: 25,
+  },
+  footerText: {
+    color: "#202020",
+    fontSize: 12,
+    lineHeight: 1.35,
+    margin: 0,
+  },
+  finishBar: {
+    backgroundColor: "#ffffff",
+    border: "1px solid #dcdcdc",
+    borderBottom: 0,
+    borderTopLeftRadius: 6,
+    borderTopRightRadius: 6,
+    bottom: 0,
+    left: "50%",
+    maxWidth: "none",
+    padding: "10px 12px calc(10px + env(safe-area-inset-bottom))",
+    position: "fixed",
+    transform: "translateX(-50%)",
+    width: "100%",
+  },
+  finishButton: {
+    backgroundColor: "#4CB599",
+    border: 0,
+    borderRadius: 999,
+    color: "#143228",
+    cursor: "pointer",
+    fontSize: 14,
+    fontWeight: 500,
+    height: 41,
+    width: "100%",
   },
 };

--- a/app/ui/src/app/driver_assist/page.tsx
+++ b/app/ui/src/app/driver_assist/page.tsx
@@ -60,7 +60,10 @@ function openNavigation(stop: DeliveryStop) {
       ? `${stop.lat},${stop.lng}`
       : encodeURIComponent(stop.address);
 
-  window.open(`https://www.google.com/maps/dir/?api=1&destination=${query}`, "_blank");
+  window.open(
+    `https://www.google.com/maps/dir/?api=1&destination=${query}`,
+    "_blank",
+  );
 }
 
 export default function DriverAssistPwaPage() {
@@ -72,7 +75,9 @@ export default function DriverAssistPwaPage() {
   const [route, setRoute] = useState<DriverRoute | null>(null);
   const [openId, setOpenId] = useState<string | null>(null);
   const [reportStopId, setReportStopId] = useState<string | null>(null);
-  const [reportReason, setReportReason] = useState<ReportReason>("Customer unavailable");
+  const [reportReason, setReportReason] = useState<ReportReason>(
+    "Customer unavailable",
+  );
   const [reportDetails, setReportDetails] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isImporting, setIsImporting] = useState(false);
@@ -91,7 +96,7 @@ export default function DriverAssistPwaPage() {
         setError(
           importError instanceof Error
             ? importError.message
-            : "Please upload a valid JSON file."
+            : "Please upload a valid JSON file.",
         );
       }
     }
@@ -103,13 +108,15 @@ export default function DriverAssistPwaPage() {
     if (!route) return;
     window.localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify(createPersistedRouteState(route))
+      JSON.stringify(createPersistedRouteState(route)),
     );
   }, [route]);
 
   const totals = useMemo(() => {
     const stops = route?.stops || [];
-    const completed = stops.filter((stop) => stop.status === "completed").length;
+    const completed = stops.filter(
+      (stop) => stop.status === "completed",
+    ).length;
     const failed = stops.filter((stop) => stop.status === "failed").length;
     const pending = stops.filter((stop) => stop.status === "pending").length;
 
@@ -135,7 +142,7 @@ export default function DriverAssistPwaPage() {
       setError(
         importError instanceof Error
           ? importError.message
-          : "Please upload a valid JSON file."
+          : "Please upload a valid JSON file.",
       );
     } finally {
       setIsImporting(false);
@@ -149,7 +156,7 @@ export default function DriverAssistPwaPage() {
       return {
         ...current,
         stops: current.stops.map((stop) =>
-          stop.id === stopId ? { ...stop, ...changes } : stop
+          stop.id === stopId ? { ...stop, ...changes } : stop,
         ),
       };
     });
@@ -190,7 +197,8 @@ export default function DriverAssistPwaPage() {
     target.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
-  const pendingStops = route?.stops.filter((stop) => stop.status === "pending") || [];
+  const pendingStops =
+    route?.stops.filter((stop) => stop.status === "pending") || [];
   const deliveredStops =
     route?.stops.filter((stop) => stop.status === "completed") || [];
   const reportedStops =
@@ -295,19 +303,21 @@ export default function DriverAssistPwaPage() {
         <section ref={deliveredRef} style={styles.historySection}>
           {deliveredStops.length > 0 ? (
             <>
-            <h2 style={styles.historyTitle}>Delivered</h2>
-            {deliveredStops.map((stop) => (
-              <StopCard
-                key={stop.id}
-                stop={stop}
-                isOpen={openId === stop.id}
-                onToggle={() => setOpenId(openId === stop.id ? null : stop.id)}
-                onChangeNote={(notes) => updateStop(stop.id, { notes })}
-                onComplete={() => undefined}
-                onReport={() => undefined}
-                onNavigate={() => openNavigation(stop)}
-              />
-            ))}
+              <h2 style={styles.historyTitle}>Delivered</h2>
+              {deliveredStops.map((stop) => (
+                <StopCard
+                  key={stop.id}
+                  stop={stop}
+                  isOpen={openId === stop.id}
+                  onToggle={() =>
+                    setOpenId(openId === stop.id ? null : stop.id)
+                  }
+                  onChangeNote={(notes) => updateStop(stop.id, { notes })}
+                  onComplete={() => undefined}
+                  onReport={() => undefined}
+                  onNavigate={() => openNavigation(stop)}
+                />
+              ))}
             </>
           ) : null}
         </section>
@@ -321,7 +331,9 @@ export default function DriverAssistPwaPage() {
                   key={stop.id}
                   stop={stop}
                   isOpen={openId === stop.id}
-                  onToggle={() => setOpenId(openId === stop.id ? null : stop.id)}
+                  onToggle={() =>
+                    setOpenId(openId === stop.id ? null : stop.id)
+                  }
                   onChangeNote={(notes) => updateStop(stop.id, { notes })}
                   onComplete={() => undefined}
                   onReport={() => undefined}
@@ -408,7 +420,9 @@ function StopCard({
         <span style={styles.textBlock}>
           <span style={styles.stopMetaRow}>
             <span style={styles.stopNumberBadge}>{stop.stopNumber}</span>
-            <span style={styles.stopWindow}>Deliver between 4:00pm - 5:00pm</span>
+            <span style={styles.stopWindow}>
+              Deliver between 4:00pm - 5:00pm
+            </span>
           </span>
           <strong style={styles.addressText}>{stop.address}</strong>
           <InfoLine icon={<PersonIcon />} text={stop.customerName} />
@@ -418,13 +432,21 @@ function StopCard({
 
       {isOpen ? (
         <div style={styles.expandedSection}>
-          <button type="button" style={styles.primaryActionButton} onClick={onNavigate}>
+          <button
+            type="button"
+            style={styles.primaryActionButton}
+            onClick={onNavigate}
+          >
             <NavigateIcon />
             Navigate
           </button>
 
           {!isDone ? (
-            <button type="button" style={styles.deliveredButton} onClick={onComplete}>
+            <button
+              type="button"
+              style={styles.deliveredButton}
+              onClick={onComplete}
+            >
               <DeliveredIcon />
               Delivered
             </button>
@@ -442,22 +464,36 @@ function StopCard({
           ) : null}
 
           {isFailed && stop.failureReason ? (
-            <p style={styles.statusText}>Failure reason: {stop.failureReason}</p>
+            <p style={styles.statusText}>
+              Failure reason: {stop.failureReason}
+            </p>
           ) : null}
 
           {!isDone ? (
             <div style={styles.buttonRow}>
-              <button type="button" style={styles.actionButton} onClick={onNavigate}>
+              <button
+                type="button"
+                style={styles.actionButton}
+                onClick={onNavigate}
+              >
                 <PhoneIcon />
                 Call
               </button>
-              <button type="button" style={styles.actionButton} onClick={onReport}>
+              <button
+                type="button"
+                style={styles.actionButton}
+                onClick={onReport}
+              >
                 <ReportIcon />
                 Report issue
               </button>
             </div>
           ) : (
-            <button type="button" style={styles.actionButton} onClick={onNavigate}>
+            <button
+              type="button"
+              style={styles.actionButton}
+              onClick={onNavigate}
+            >
               Navigate
             </button>
           )}
@@ -479,7 +515,13 @@ function InfoLine({ icon, text }: { icon: React.ReactNode; text: string }) {
 function DriverFooter() {
   return (
     <footer style={styles.footer}>
-      <Image src="/logo.png" alt="b2 logo" width={25} height={28} style={styles.footerLogo} />
+      <Image
+        src="/logo.png"
+        alt="b2 logo"
+        width={25}
+        height={28}
+        style={styles.footerLogo}
+      />
       <p style={styles.footerText}>Built with ❤️ for Humanity.</p>
       <p style={styles.footerText}>The Benevolent Bandwidth Foundation</p>
     </footer>
@@ -530,7 +572,8 @@ function ReportIssueDialog({
         </div>
 
         <p style={styles.reportPrompt}>
-          Select a reason for the delivery issue<span style={styles.required}>*</span>
+          Select a reason for the delivery issue
+          <span style={styles.required}>*</span>
         </p>
 
         <div style={styles.reportOptions}>
@@ -559,10 +602,18 @@ function ReportIssueDialog({
         ) : null}
 
         <div style={styles.reportActions}>
-          <button type="button" style={styles.reportCancelButton} onClick={onCancel}>
+          <button
+            type="button"
+            style={styles.reportCancelButton}
+            onClick={onCancel}
+          >
             Cancel
           </button>
-          <button type="button" style={styles.reportSubmitButton} onClick={onSubmit}>
+          <button
+            type="button"
+            style={styles.reportSubmitButton}
+            onClick={onSubmit}
+          >
             Submit
           </button>
         </div>
@@ -573,9 +624,20 @@ function ReportIssueDialog({
 
 function WarningIcon() {
   return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
       <path d="M12 4 21 20H3L12 4Z" stroke="currentColor" strokeWidth="1.7" />
-      <path d="M12 9v5" stroke="currentColor" strokeLinecap="round" strokeWidth="1.7" />
+      <path
+        d="M12 9v5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.7"
+      />
       <circle cx="12" cy="17" r="1" fill="currentColor" />
     </svg>
   );
@@ -583,35 +645,85 @@ function WarningIcon() {
 
 function NavigateIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
       <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="2" />
-      <path d="m12 7 4 10-4-2-4 2 4-10Z" stroke="currentColor" strokeLinejoin="round" strokeWidth="2" />
+      <path
+        d="m12 7 4 10-4-2-4 2 4-10Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
     </svg>
   );
 }
 
 function DeliveredIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <path d="M8 5h8v3h3v11H5V8h3V5Z" stroke="currentColor" strokeLinejoin="round" strokeWidth="1.8" />
-      <path d="m9 13 2 2 4-5" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" />
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M8 5h8v3h3v11H5V8h3V5Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+      <path
+        d="m9 13 2 2 4-5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
     </svg>
   );
 }
 
 function PhoneIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <path d="M8 5 6 7c1 5 6 10 11 11l2-2-4-3-2 2c-2-1-4-3-5-5l2-2-2-3Z" stroke="currentColor" strokeLinejoin="round" strokeWidth="1.8" />
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M8 5 6 7c1 5 6 10 11 11l2-2-4-3-2 2c-2-1-4-3-5-5l2-2-2-3Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
     </svg>
   );
 }
 
 function ReportIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
       <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.8" />
-      <path d="M12 7v6" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
+      <path
+        d="M12 7v6"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.8"
+      />
       <circle cx="12" cy="16.5" r="1" fill="currentColor" />
     </svg>
   );
@@ -619,18 +731,40 @@ function ReportIcon() {
 
 function PersonIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
       <circle cx="12" cy="8" r="3" stroke="currentColor" strokeWidth="1.8" />
-      <path d="M5 20c1.2-4 12.8-4 14 0" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
+      <path
+        d="M5 20c1.2-4 12.8-4 14 0"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.8"
+      />
     </svg>
   );
 }
 
 function NoteIcon() {
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
       <path d="M6 4h12v16H6V4Z" stroke="currentColor" strokeWidth="1.8" />
-      <path d="M9 8h6M9 12h6M9 16h4" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
+      <path
+        d="M9 8h6M9 12h6M9 16h4"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.8"
+      />
     </svg>
   );
 }
@@ -807,7 +941,8 @@ const styles: Record<string, CSSProperties> = {
   },
   stopWindow: {
     color: "#464544",
-    fontFamily: "var(--font-manrope), var(--font-geist-sans), Arial, sans-serif",
+    fontFamily:
+      "var(--font-manrope), var(--font-geist-sans), Arial, sans-serif",
     fontSize: 14,
     fontStyle: "normal",
     fontWeight: 600,

--- a/app/ui/src/app/driver_assist/page.tsx
+++ b/app/ui/src/app/driver_assist/page.tsx
@@ -6,12 +6,19 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   createPersistedRouteState,
   loadSessionFromFile,
+  loadSessionFromText,
   parsePersistedRouteState,
 } from "@/lib/driver-route/importSession";
 import { transformSessionToDriverRoute } from "@/lib/driver-route/transformSession";
 import type { DeliveryStop, DriverRoute } from "@/lib/driver-route/types";
 
 const STORAGE_KEY = "driver_assist.routeState";
+const UPLOADED_ROUTE_KEY = "routeFile";
+
+type UploadedRouteFile = {
+  name: string;
+  content: string;
+};
 
 function readSavedRoute(): DriverRoute | null {
   if (typeof window === "undefined") return null;
@@ -23,6 +30,24 @@ function readSavedRoute(): DriverRoute | null {
   } catch {
     window.localStorage.removeItem(STORAGE_KEY);
     return null;
+  }
+}
+
+function readUploadedRouteFile(): UploadedRouteFile | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = window.sessionStorage.getItem(UPLOADED_ROUTE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<UploadedRouteFile>;
+    if (typeof parsed.name !== "string" || typeof parsed.content !== "string") {
+      return null;
+    }
+    return { name: parsed.name, content: parsed.content };
+  } catch {
+    return null;
+  } finally {
+    window.sessionStorage.removeItem(UPLOADED_ROUTE_KEY);
   }
 }
 
@@ -43,6 +68,24 @@ export default function DriverAssistPwaPage() {
   const [isImporting, setIsImporting] = useState(false);
 
   useEffect(() => {
+    const uploadedRoute = readUploadedRouteFile();
+
+    if (uploadedRoute) {
+      try {
+        const session = loadSessionFromText(uploadedRoute.content);
+        const nextRoute = transformSessionToDriverRoute(session);
+        setRoute(nextRoute);
+        setOpenId(nextRoute.stops[0]?.id || null);
+        return;
+      } catch (importError) {
+        setError(
+          importError instanceof Error
+            ? importError.message
+            : "Please upload a valid JSON file."
+        );
+      }
+    }
+
     setRoute(readSavedRoute());
   }, []);
 

--- a/app/ui/src/app/driver_assist/page.tsx
+++ b/app/ui/src/app/driver_assist/page.tsx
@@ -21,6 +21,8 @@ type UploadedRouteFile = {
   content: string;
 };
 
+type ReportReason = "Customer unavailable" | "Can't access location" | "Other";
+
 function readSavedRoute(): DriverRoute | null {
   if (typeof window === "undefined") return null;
 
@@ -69,6 +71,9 @@ export default function DriverAssistPwaPage() {
   const reportedRef = useRef<HTMLDivElement>(null);
   const [route, setRoute] = useState<DriverRoute | null>(null);
   const [openId, setOpenId] = useState<string | null>(null);
+  const [reportStopId, setReportStopId] = useState<string | null>(null);
+  const [reportReason, setReportReason] = useState<ReportReason>("Customer unavailable");
+  const [reportDetails, setReportDetails] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isImporting, setIsImporting] = useState(false);
 
@@ -155,6 +160,30 @@ export default function DriverAssistPwaPage() {
     setRoute(null);
     setOpenId(null);
     setError(null);
+  };
+
+  const openReportDialog = (stopId: string) => {
+    setReportStopId(stopId);
+    setReportReason("Customer unavailable");
+    setReportDetails("");
+  };
+
+  const closeReportDialog = () => {
+    setReportStopId(null);
+    setReportDetails("");
+  };
+
+  const submitReport = () => {
+    if (!reportStopId) return;
+    const reason =
+      reportReason === "Other" ? reportDetails.trim() || "Other" : reportReason;
+
+    updateStop(reportStopId, {
+      status: "failed",
+      failureReason: reason,
+    });
+    setOpenId(null);
+    closeReportDialog();
   };
 
   const scrollToSection = (target: React.RefObject<HTMLElement | null>) => {
@@ -257,14 +286,7 @@ export default function DriverAssistPwaPage() {
                 });
                 setOpenId(null);
               }}
-              onReport={() => {
-                const reason = window.prompt("Reason this delivery failed?");
-                updateStop(stop.id, {
-                  status: "failed",
-                  failureReason: reason || "No reason provided",
-                });
-                setOpenId(null);
-              }}
+              onReport={() => openReportDialog(stop.id)}
               onNavigate={() => openNavigation(stop)}
             />
           ))}
@@ -318,6 +340,17 @@ export default function DriverAssistPwaPage() {
           Finish
         </button>
       </div>
+
+      {reportStopId ? (
+        <ReportIssueDialog
+          reason={reportReason}
+          details={reportDetails}
+          onReasonChange={setReportReason}
+          onDetailsChange={setReportDetails}
+          onCancel={closeReportDialog}
+          onSubmit={submitReport}
+        />
+      ) : null}
     </main>
   );
 }
@@ -450,6 +483,91 @@ function DriverFooter() {
       <p style={styles.footerText}>Built with ❤️ for Humanity.</p>
       <p style={styles.footerText}>The Benevolent Bandwidth Foundation</p>
     </footer>
+  );
+}
+
+function ReportIssueDialog({
+  reason,
+  details,
+  onReasonChange,
+  onDetailsChange,
+  onCancel,
+  onSubmit,
+}: {
+  reason: ReportReason;
+  details: string;
+  onReasonChange: (reason: ReportReason) => void;
+  onDetailsChange: (details: string) => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+}) {
+  const reasons: ReportReason[] = [
+    "Customer unavailable",
+    "Can't access location",
+    "Other",
+  ];
+
+  return (
+    <div style={styles.modalBackdrop} role="presentation">
+      <section
+        aria-modal="true"
+        role="dialog"
+        aria-labelledby="report-issue-title"
+        style={styles.reportDialog}
+      >
+        <div style={styles.reportHeader}>
+          <h2 id="report-issue-title" style={styles.reportTitle}>
+            Report issue
+          </h2>
+          <button
+            type="button"
+            aria-label="Close report issue"
+            style={styles.reportCloseButton}
+            onClick={onCancel}
+          >
+            ×
+          </button>
+        </div>
+
+        <p style={styles.reportPrompt}>
+          Select a reason for the delivery issue<span style={styles.required}>*</span>
+        </p>
+
+        <div style={styles.reportOptions}>
+          {reasons.map((option) => (
+            <label key={option} style={styles.reportOption}>
+              <input
+                type="radio"
+                name="report-reason"
+                value={option}
+                checked={reason === option}
+                onChange={() => onReasonChange(option)}
+                style={styles.reportRadio}
+              />
+              <span>{option}</span>
+            </label>
+          ))}
+        </div>
+
+        {reason === "Other" ? (
+          <textarea
+            style={styles.reportDetails}
+            placeholder="Please provide details"
+            value={details}
+            onChange={(event) => onDetailsChange(event.target.value)}
+          />
+        ) : null}
+
+        <div style={styles.reportActions}>
+          <button type="button" style={styles.reportCancelButton} onClick={onCancel}>
+            Cancel
+          </button>
+          <button type="button" style={styles.reportSubmitButton} onClick={onSubmit}>
+            Submit
+          </button>
+        </div>
+      </section>
+    </div>
   );
 }
 
@@ -850,5 +968,131 @@ const styles: Record<string, CSSProperties> = {
     fontWeight: 500,
     height: 41,
     width: "100%",
+  },
+  modalBackdrop: {
+    alignItems: "center",
+    backgroundColor: "rgba(0, 0, 0, 0.2)",
+    bottom: 0,
+    display: "flex",
+    justifyContent: "center",
+    left: 0,
+    padding: 12,
+    position: "fixed",
+    right: 0,
+    top: 0,
+    zIndex: 50,
+  },
+  reportDialog: {
+    alignItems: "flex-start",
+    backgroundColor: "#FDFDFC",
+    borderRadius: 4,
+    boxShadow: "0 8px 24px rgba(0, 0, 0, 0.12)",
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    padding: 24,
+    width: 352,
+    maxWidth: "calc(100vw - 24px)",
+  },
+  reportHeader: {
+    alignItems: "center",
+    display: "flex",
+    justifyContent: "space-between",
+    width: "100%",
+  },
+  reportTitle: {
+    color: "#202020",
+    fontSize: 16,
+    fontWeight: 700,
+    lineHeight: 1.4,
+    margin: 0,
+  },
+  reportCloseButton: {
+    alignItems: "center",
+    background: "transparent",
+    border: 0,
+    color: "#202020",
+    cursor: "pointer",
+    display: "inline-flex",
+    fontSize: 24,
+    height: 28,
+    justifyContent: "center",
+    lineHeight: 1,
+    padding: 0,
+    width: 28,
+  },
+  reportPrompt: {
+    color: "#464544",
+    fontSize: 12,
+    lineHeight: 1.4,
+    margin: "8px 0 0",
+  },
+  required: {
+    color: "#C2410C",
+  },
+  reportOptions: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    width: "100%",
+  },
+  reportOption: {
+    alignItems: "center",
+    border: "1px solid #DCDBD8",
+    borderRadius: 4,
+    color: "#464544",
+    cursor: "pointer",
+    display: "flex",
+    fontSize: 12,
+    gap: 8,
+    minHeight: 32,
+    padding: "6px 8px",
+    width: "100%",
+  },
+  reportRadio: {
+    accentColor: "#464544",
+    height: 16,
+    margin: 0,
+    width: 16,
+  },
+  reportDetails: {
+    border: "1px solid #DCDBD8",
+    borderRadius: 4,
+    color: "#202020",
+    font: "inherit",
+    fontSize: 12,
+    minHeight: 72,
+    padding: 8,
+    resize: "vertical",
+    width: "100%",
+  },
+  reportActions: {
+    alignItems: "center",
+    alignSelf: "stretch",
+    display: "flex",
+    gap: 8,
+    justifyContent: "flex-end",
+    marginTop: 4,
+  },
+  reportCancelButton: {
+    backgroundColor: "transparent",
+    border: 0,
+    color: "#202020",
+    cursor: "pointer",
+    fontSize: 12,
+    fontWeight: 500,
+    minHeight: 36,
+    padding: "0 12px",
+  },
+  reportSubmitButton: {
+    backgroundColor: "#4CB599",
+    border: 0,
+    borderRadius: 4,
+    color: "#143228",
+    cursor: "pointer",
+    fontSize: 12,
+    fontWeight: 500,
+    minHeight: 36,
+    padding: "0 16px",
   },
 };

--- a/app/ui/src/app/driver_assist/page.tsx
+++ b/app/ui/src/app/driver_assist/page.tsx
@@ -1,0 +1,576 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  createPersistedRouteState,
+  loadSessionFromFile,
+  parsePersistedRouteState,
+} from "@/lib/driver-route/importSession";
+import { transformSessionToDriverRoute } from "@/lib/driver-route/transformSession";
+import type { DeliveryStop, DriverRoute } from "@/lib/driver-route/types";
+
+const STORAGE_KEY = "driver_assist.routeState";
+
+function readSavedRoute(): DriverRoute | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    if (!saved) return null;
+    return parsePersistedRouteState(JSON.parse(saved)).route;
+  } catch {
+    window.localStorage.removeItem(STORAGE_KEY);
+    return null;
+  }
+}
+
+function openNavigation(stop: DeliveryStop) {
+  const query =
+    stop.lat !== 0 || stop.lng !== 0
+      ? `${stop.lat},${stop.lng}`
+      : encodeURIComponent(stop.address);
+
+  window.open(`https://www.google.com/maps/dir/?api=1&destination=${query}`, "_blank");
+}
+
+export default function DriverAssistPwaPage() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [route, setRoute] = useState<DriverRoute | null>(null);
+  const [openId, setOpenId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isImporting, setIsImporting] = useState(false);
+
+  useEffect(() => {
+    setRoute(readSavedRoute());
+  }, []);
+
+  useEffect(() => {
+    if (!route) return;
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(createPersistedRouteState(route))
+    );
+  }, [route]);
+
+  const totals = useMemo(() => {
+    const stops = route?.stops || [];
+    const completed = stops.filter((stop) => stop.status === "completed").length;
+    const failed = stops.filter((stop) => stop.status === "failed").length;
+    const pending = stops.filter((stop) => stop.status === "pending").length;
+
+    return {
+      completed,
+      failed,
+      pending,
+      total: stops.length,
+      progress: stops.length > 0 ? completed / stops.length : 0,
+    };
+  }, [route]);
+
+  const importRoute = async (file: File) => {
+    setError(null);
+    setIsImporting(true);
+
+    try {
+      const session = await loadSessionFromFile(file);
+      const nextRoute = transformSessionToDriverRoute(session);
+      setRoute(nextRoute);
+      setOpenId(nextRoute.stops[0]?.id || null);
+    } catch (importError) {
+      setError(
+        importError instanceof Error
+          ? importError.message
+          : "Please upload a valid JSON file."
+      );
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  const updateStop = (stopId: string, changes: Partial<DeliveryStop>) => {
+    setRoute((current) => {
+      if (!current) return current;
+
+      return {
+        ...current,
+        stops: current.stops.map((stop) =>
+          stop.id === stopId ? { ...stop, ...changes } : stop
+        ),
+      };
+    });
+  };
+
+  const resetRoute = () => {
+    window.localStorage.removeItem(STORAGE_KEY);
+    setRoute(null);
+    setOpenId(null);
+    setError(null);
+  };
+
+  const pendingStops = route?.stops.filter((stop) => stop.status === "pending") || [];
+  const completedStops =
+    route?.stops.filter((stop) => stop.status !== "pending") || [];
+
+  if (!route) {
+    return (
+      <main style={styles.safeArea}>
+        <section style={styles.uploadScreen}>
+          <h1 style={styles.appHeader}>driver_assist</h1>
+          <input
+            ref={inputRef}
+            type="file"
+            accept="application/json,.json"
+            style={styles.hiddenInput}
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) void importRoute(file);
+            }}
+          />
+          <button
+            type="button"
+            style={styles.uploadButton}
+            onClick={() => inputRef.current?.click()}
+            disabled={isImporting}
+          >
+            {isImporting ? "Uploading..." : "Upload JSON"}
+          </button>
+          {error ? <p style={styles.errorText}>{error}</p> : null}
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main style={styles.safeArea}>
+      <section style={styles.container}>
+        <div style={styles.topBar}>
+          <h1 style={styles.appHeader}>driver_assist</h1>
+          <button type="button" style={styles.textButton} onClick={resetRoute}>
+            New route
+          </button>
+        </div>
+
+        <section style={styles.summaryCard}>
+          <p style={styles.headerLabel}>Current Route</p>
+          <h2 style={styles.driverName}>{route.driverName}</h2>
+          <p style={styles.routeLabel}>{route.routeLabel}</p>
+
+          <div style={styles.progressHeader}>
+            <span>Progress</span>
+            <span>
+              {totals.completed}/{totals.total} Deliveries Complete
+            </span>
+          </div>
+
+          <div style={styles.progressTrack}>
+            <div
+              style={{
+                ...styles.progressFill,
+                width: `${totals.progress * 100}%`,
+              }}
+            />
+          </div>
+
+          <div style={styles.statsRow}>
+            <StatBlock value={totals.pending} label="Remaining" />
+            <StatBlock value={totals.failed} label="Failed" />
+            <StatBlock value={totals.completed} label="Completed" />
+          </div>
+        </section>
+
+        {pendingStops.map((stop) => (
+          <StopCard
+            key={stop.id}
+            stop={stop}
+            isOpen={openId === stop.id}
+            onToggle={() => setOpenId(openId === stop.id ? null : stop.id)}
+            onChangeNote={(notes) => updateStop(stop.id, { notes })}
+            onComplete={() => {
+              updateStop(stop.id, {
+                status: "completed",
+                completedAt: new Date().toISOString(),
+              });
+              setOpenId(null);
+            }}
+            onReport={() => {
+              const reason = window.prompt("Reason this delivery failed?");
+              updateStop(stop.id, {
+                status: "failed",
+                failureReason: reason || "No reason provided",
+              });
+              setOpenId(null);
+            }}
+            onNavigate={() => openNavigation(stop)}
+          />
+        ))}
+
+        {completedStops.length > 0 ? (
+          <section style={styles.historySection}>
+            <h2 style={styles.historyTitle}>Completed & Failed</h2>
+            {completedStops.map((stop) => (
+              <StopCard
+                key={stop.id}
+                stop={stop}
+                isOpen={openId === stop.id}
+                onToggle={() => setOpenId(openId === stop.id ? null : stop.id)}
+                onChangeNote={(notes) => updateStop(stop.id, { notes })}
+                onComplete={() => undefined}
+                onReport={() => undefined}
+                onNavigate={() => openNavigation(stop)}
+              />
+            ))}
+          </section>
+        ) : null}
+      </section>
+    </main>
+  );
+}
+
+function StatBlock({ value, label }: { value: number; label: string }) {
+  return (
+    <div style={styles.statBlock}>
+      <strong style={styles.statNumber}>{value}</strong>
+      <span style={styles.statLabel}>{label}</span>
+    </div>
+  );
+}
+
+function StopCard({
+  stop,
+  isOpen,
+  onToggle,
+  onChangeNote,
+  onComplete,
+  onReport,
+  onNavigate,
+}: {
+  stop: DeliveryStop;
+  isOpen: boolean;
+  onToggle: () => void;
+  onChangeNote: (value: string) => void;
+  onComplete: () => void;
+  onReport?: () => void;
+  onNavigate?: () => void;
+}) {
+  const isCompleted = stop.status === "completed";
+  const isFailed = stop.status === "failed";
+  const isDone = isCompleted || isFailed;
+  const completedAtText = stop.completedAt
+    ? new Date(stop.completedAt).toLocaleString()
+    : null;
+
+  return (
+    <article
+      style={{
+        ...styles.card,
+        ...(isCompleted ? styles.completedCard : {}),
+        ...(isFailed ? styles.failedCard : {}),
+      }}
+    >
+      <button type="button" style={styles.cardButton} onClick={onToggle}>
+        <span
+          style={{
+            ...styles.statusCircle,
+            ...(isCompleted ? styles.completedCircle : {}),
+            ...(isFailed ? styles.failedCircle : {}),
+          }}
+        />
+        <span style={styles.textBlock}>
+          <strong style={styles.stopText}>Stop {stop.stopNumber}</strong>
+          <span style={styles.nameText}>{stop.customerName}</span>
+          {stop.phoneNumber ? (
+            <span style={styles.phoneText}>{stop.phoneNumber}</span>
+          ) : null}
+          <span style={styles.addressText}>{stop.address}</span>
+        </span>
+      </button>
+
+      {isOpen ? (
+        <div style={styles.expandedSection}>
+          <p style={styles.metaText}>Packages: {stop.packageCount}</p>
+          <textarea
+            style={styles.noteInput}
+            value={stop.notes}
+            onChange={(event) => onChangeNote(event.target.value)}
+            placeholder="Add delivery note"
+          />
+
+          {isCompleted && completedAtText ? (
+            <p style={styles.statusText}>Completed at: {completedAtText}</p>
+          ) : null}
+
+          {isFailed && stop.failureReason ? (
+            <p style={styles.statusText}>Failure reason: {stop.failureReason}</p>
+          ) : null}
+
+          {!isDone ? (
+            <div style={styles.buttonRow}>
+              <button type="button" style={styles.actionButton} onClick={onComplete}>
+                Complete
+              </button>
+              <button type="button" style={styles.actionButton} onClick={onNavigate}>
+                Navigate
+              </button>
+              <button type="button" style={styles.actionButton} onClick={onReport}>
+                Report
+              </button>
+            </div>
+          ) : (
+            <button type="button" style={styles.actionButton} onClick={onNavigate}>
+              Navigate
+            </button>
+          )}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  safeArea: {
+    minHeight: "100svh",
+    backgroundColor: "#ffffff",
+    color: "#111827",
+    fontFamily: "var(--font-geist-sans), Arial, sans-serif",
+  },
+  uploadScreen: {
+    minHeight: "100svh",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  hiddenInput: {
+    display: "none",
+  },
+  appHeader: {
+    fontSize: 32,
+    fontWeight: 700,
+    color: "#111827",
+    margin: "0 0 16px",
+  },
+  uploadButton: {
+    backgroundColor: "#111827",
+    border: 0,
+    borderRadius: 8,
+    color: "#ffffff",
+    cursor: "pointer",
+    fontSize: 16,
+    fontWeight: 600,
+    padding: "14px 20px",
+  },
+  errorText: {
+    color: "#b91c1c",
+    fontSize: 14,
+    marginTop: 14,
+    maxWidth: 300,
+    textAlign: "center",
+  },
+  container: {
+    maxWidth: 520,
+    margin: "0 auto",
+    padding: 16,
+  },
+  topBar: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 16,
+  },
+  textButton: {
+    background: "transparent",
+    border: "1px solid #d1d5db",
+    borderRadius: 8,
+    color: "#111827",
+    cursor: "pointer",
+    fontSize: 14,
+    fontWeight: 600,
+    padding: "9px 12px",
+  },
+  summaryCard: {
+    backgroundColor: "#ffffff",
+    border: "2px solid #4b5563",
+    borderRadius: 8,
+    marginBottom: 16,
+    padding: 20,
+  },
+  headerLabel: {
+    color: "#6b7280",
+    fontSize: 18,
+    margin: "0 0 8px",
+  },
+  driverName: {
+    color: "#111827",
+    fontSize: 36,
+    fontWeight: 700,
+    lineHeight: 1.1,
+    margin: 0,
+  },
+  routeLabel: {
+    color: "#374151",
+    fontSize: 18,
+    margin: "4px 0 18px",
+  },
+  progressHeader: {
+    color: "#111827",
+    display: "flex",
+    fontSize: 15,
+    justifyContent: "space-between",
+    marginBottom: 8,
+  },
+  progressTrack: {
+    backgroundColor: "#e5e7eb",
+    borderRadius: 999,
+    height: 12,
+    marginBottom: 18,
+    overflow: "hidden",
+  },
+  progressFill: {
+    backgroundColor: "#22c55e",
+    height: 12,
+  },
+  statsRow: {
+    backgroundColor: "#f3f4f6",
+    borderRadius: 8,
+    display: "flex",
+    justifyContent: "space-between",
+    padding: "18px 0",
+  },
+  statBlock: {
+    alignItems: "center",
+    display: "flex",
+    flex: 1,
+    flexDirection: "column",
+  },
+  statNumber: {
+    color: "#111827",
+    fontSize: 28,
+    fontWeight: 700,
+  },
+  statLabel: {
+    color: "#4b5563",
+    fontSize: 14,
+    marginTop: 4,
+  },
+  card: {
+    backgroundColor: "#f3f4f6",
+    borderRadius: 8,
+    marginBottom: 14,
+    padding: 18,
+  },
+  completedCard: {
+    backgroundColor: "#e5e7eb",
+  },
+  failedCard: {
+    backgroundColor: "#fee2e2",
+  },
+  cardButton: {
+    alignItems: "flex-start",
+    background: "transparent",
+    border: 0,
+    cursor: "pointer",
+    display: "flex",
+    gap: 12,
+    padding: 0,
+    textAlign: "left",
+    width: "100%",
+  },
+  statusCircle: {
+    backgroundColor: "#ffffff",
+    border: "2px solid #d1d5db",
+    borderRadius: 11,
+    flex: "0 0 22px",
+    height: 22,
+    marginTop: 4,
+    width: 22,
+  },
+  completedCircle: {
+    backgroundColor: "#22c55e",
+    borderColor: "#22c55e",
+  },
+  failedCircle: {
+    backgroundColor: "#ef4444",
+    borderColor: "#ef4444",
+  },
+  textBlock: {
+    display: "flex",
+    flex: 1,
+    flexDirection: "column",
+    minWidth: 0,
+  },
+  stopText: {
+    color: "#111827",
+    fontSize: 24,
+    fontWeight: 700,
+    marginBottom: 2,
+  },
+  nameText: {
+    color: "#6b7280",
+    fontSize: 16,
+    marginBottom: 2,
+  },
+  phoneText: {
+    color: "#6b7280",
+    fontSize: 15,
+    marginBottom: 4,
+  },
+  addressText: {
+    color: "#374151",
+    fontSize: 16,
+    overflowWrap: "anywhere",
+  },
+  expandedSection: {
+    borderTop: "1px solid #e5e7eb",
+    marginTop: 16,
+    paddingTop: 14,
+  },
+  metaText: {
+    color: "#111827",
+    fontSize: 16,
+    margin: "0 0 12px",
+  },
+  noteInput: {
+    backgroundColor: "#ffffff",
+    border: "1px solid #d1d5db",
+    borderRadius: 8,
+    color: "#111827",
+    font: "inherit",
+    marginBottom: 12,
+    minHeight: 72,
+    padding: 12,
+    resize: "vertical",
+    width: "100%",
+  },
+  statusText: {
+    color: "#374151",
+    fontSize: 14,
+    margin: "0 0 12px",
+  },
+  buttonRow: {
+    display: "grid",
+    gap: 8,
+    gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+  },
+  actionButton: {
+    backgroundColor: "#ffffff",
+    border: "1px solid #e5e7eb",
+    borderRadius: 8,
+    color: "#111827",
+    cursor: "pointer",
+    fontWeight: 600,
+    minHeight: 44,
+    padding: "12px 8px",
+  },
+  historySection: {
+    marginTop: 8,
+  },
+  historyTitle: {
+    color: "#111827",
+    fontSize: 20,
+    fontWeight: 700,
+    margin: "0 0 10px",
+  },
+};

--- a/app/ui/src/app/layout.tsx
+++ b/app/ui/src/app/layout.tsx
@@ -1,6 +1,7 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Manrope } from "next/font/google";
+import ServiceWorkerRegistration from "@/app/components/ServiceWorkerRegistration";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -19,8 +20,21 @@ const manrope = Manrope({
 });
 
 export const metadata: Metadata = {
-  title: "Delivery Route Optimizer",
+  title: {
+    default: "Delivery Route Optimizer",
+    template: "%s | Delivery Route Optimizer",
+  },
   description: "Convert addresses to coordinates with CSV support",
+  manifest: "/manifest.webmanifest",
+  appleWebApp: {
+    capable: true,
+    title: "driver_assist",
+    statusBarStyle: "default",
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#111827",
 };
 
 export default function RootLayout({
@@ -33,6 +47,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${manrope.variable} antialiased`}
       >
+        <ServiceWorkerRegistration />
         {children}
       </body>
     </html>

--- a/app/ui/src/app/manifest.ts
+++ b/app/ui/src/app/manifest.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "driver_assist",
+    short_name: "driver_assist",
+    description: "Installable driver route assistant for Delivery Optimizer.",
+    start_url: "/driver_assist",
+    scope: "/",
+    display: "standalone",
+    background_color: "#ffffff",
+    theme_color: "#111827",
+    orientation: "portrait",
+    icons: [
+      {
+        src: "/pwa-icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "maskable",
+      },
+    ],
+  };
+}

--- a/app/ui/src/app/upload-route/page.tsx
+++ b/app/ui/src/app/upload-route/page.tsx
@@ -43,7 +43,7 @@ export default function UploadRoutePage() {
       "routeFile",
       JSON.stringify({ name: file.name, content: text }),
     );
-    router.push("/driver-view");
+    router.push("/driver_assist");
   };
 
   return (
@@ -52,11 +52,16 @@ export default function UploadRoutePage() {
         @import url('https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600&display=swap');
 
         .upload-root {
-          min-height: 100vh;
+          min-height: 100dvh;
           background: #f7f7f5;
           display: flex;
           flex-direction: column;
           font-family: 'DM Sans', sans-serif;
+        }
+
+        .upload-root,
+        .upload-root * {
+          box-sizing: border-box;
         }
 
         .upload-content {
@@ -65,7 +70,8 @@ export default function UploadRoutePage() {
           flex-direction: column;
           align-items: center;
           justify-content: center;
-          padding: 48px 24px;
+          width: 100%;
+          padding: clamp(28px, 8vw, 48px) clamp(16px, 5vw, 24px);
         }
 
         .upload-title {
@@ -90,7 +96,8 @@ export default function UploadRoutePage() {
           max-width: 580px;
           border: 1.5px dashed #ccc;
           border-radius: 12px;
-          padding: 52px 24px;
+          min-height: 184px;
+          padding: clamp(32px, 10vw, 52px) clamp(18px, 6vw, 24px);
           display: flex;
           flex-direction: column;
           align-items: center;
@@ -132,6 +139,7 @@ export default function UploadRoutePage() {
           align-items: center;
           gap: 10px;
           margin-bottom: 24px;
+          min-width: 0;
         }
 
         .upload-file-name {
@@ -139,9 +147,17 @@ export default function UploadRoutePage() {
           font-weight: 500;
           color: #111;
           flex: 1;
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
         }
 
-        .upload-file-size { font-size: 12px; color: #666; }
+        .upload-file-size {
+          flex-shrink: 0;
+          font-size: 12px;
+          color: #666;
+        }
 
         .upload-file-remove {
           background: none;
@@ -199,6 +215,40 @@ export default function UploadRoutePage() {
 
         .upload-continue-btn:not(:disabled):hover {
           background: #3d7a6a;
+        }
+
+        @media (max-width: 520px) {
+          .upload-content {
+            justify-content: flex-start;
+            padding-top: 36px;
+            padding-bottom: calc(24px + env(safe-area-inset-bottom));
+          }
+
+          .upload-title {
+            font-size: 1.75rem;
+          }
+
+          .upload-subtitle {
+            margin-bottom: 24px;
+            max-width: 280px;
+            line-height: 1.5;
+          }
+
+          .upload-actions {
+            align-items: stretch;
+            flex-direction: column-reverse;
+            gap: 16px;
+          }
+
+          .upload-back-btn {
+            justify-content: center;
+            min-height: 44px;
+          }
+
+          .upload-continue-btn {
+            min-height: 48px;
+            width: 100%;
+          }
         }
       `}</style>
 

--- a/app/ui/src/lib/driver-route/importSession.ts
+++ b/app/ui/src/lib/driver-route/importSession.ts
@@ -1,0 +1,140 @@
+import { ZodError, z } from "zod";
+
+import type { DriverRoute, OptimizeRequestLike } from "./types";
+
+const MAX_SESSION_FILE_BYTES = 1_000_000;
+
+const locationSchema = z.object({
+  lat: z.number(),
+  lng: z.number(),
+});
+
+const demandSchema = z.object({
+  value: z.number().optional(),
+});
+
+const deliverySchema = z.object({
+  id: z.number(),
+  recipientName: z.string().optional(),
+  phoneNumber: z.string().optional(),
+  address: z.string().optional(),
+  notes: z.string().optional(),
+  location: locationSchema.optional(),
+  demand: demandSchema.optional(),
+});
+
+const vehicleSchema = z.object({
+  id: z.number(),
+  driverName: z.string().optional(),
+  vehicleType: z.string().optional(),
+});
+
+const optimizeRequestSchema = z.object({
+  deliveries: z.array(deliverySchema),
+  vehicles: z.array(vehicleSchema),
+});
+
+const sessionSaveV1Schema = z.object({
+  version: z.literal(1),
+  savedAt: z.string().datetime(),
+  data: optimizeRequestSchema,
+});
+
+const persistedStopSchema = z.object({
+  id: z.string(),
+  stopNumber: z.number(),
+  address: z.string(),
+  customerName: z.string(),
+  phoneNumber: z.string().optional(),
+  packageCount: z.number(),
+  notes: z.string(),
+  status: z.enum(["pending", "completed", "failed"]),
+  lat: z.number(),
+  lng: z.number(),
+  completedAt: z.string().optional(),
+  failureReason: z.string().optional(),
+});
+
+const persistedRouteSchema = z.object({
+  driverName: z.string(),
+  routeLabel: z.string(),
+  stops: z.array(persistedStopSchema),
+});
+
+const persistedRouteStateSchema = z.object({
+  version: z.literal(1),
+  savedAt: z.string().datetime(),
+  route: persistedRouteSchema,
+});
+
+type SessionSaveFile = z.infer<typeof sessionSaveV1Schema>;
+type PersistedRouteState = z.infer<typeof persistedRouteStateSchema>;
+
+export async function loadSessionFromFile(
+  file: Pick<File, "name" | "size" | "type" | "text">
+): Promise<OptimizeRequestLike> {
+  const isJson =
+    file.type === "application/json" || file.name.toLowerCase().endsWith(".json");
+
+  if (!isJson) {
+    throw new Error("Please select a valid .json save file.");
+  }
+
+  if (file.size > MAX_SESSION_FILE_BYTES) {
+    throw new Error("File is too large to import.");
+  }
+
+  const text = await file.text();
+  return loadSessionFromText(text);
+}
+
+export function loadSessionFromText(text: string): OptimizeRequestLike {
+  if (text.length === 0) {
+    throw new Error("Invalid file contents.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("This file is not valid JSON.");
+  }
+
+  try {
+    return parseSessionSaveFile(parsed).data;
+  } catch (error) {
+    throw new Error(formatValidationError(error) ?? "Invalid save file format.");
+  }
+}
+
+export function createPersistedRouteState(
+  route: DriverRoute
+): PersistedRouteState {
+  return {
+    version: 1,
+    savedAt: new Date().toISOString(),
+    route,
+  };
+}
+
+export function parsePersistedRouteState(input: unknown): PersistedRouteState {
+  return persistedRouteStateSchema.parse(input);
+}
+
+function parseSessionSaveFile(input: unknown): SessionSaveFile {
+  return sessionSaveV1Schema.parse(input);
+}
+
+function formatValidationError(error: unknown): string | null {
+  if (!(error instanceof ZodError)) {
+    return error instanceof Error ? error.message : null;
+  }
+
+  const issue = error.issues[0];
+  if (!issue) return null;
+
+  const path =
+    Array.isArray(issue.path) && issue.path.length ? issue.path.join(".") : "file";
+
+  return `Invalid save file format at "${path}".`;
+}

--- a/app/ui/src/lib/driver-route/importSession.ts
+++ b/app/ui/src/lib/driver-route/importSession.ts
@@ -71,10 +71,11 @@ type SessionSaveFile = z.infer<typeof sessionSaveV1Schema>;
 type PersistedRouteState = z.infer<typeof persistedRouteStateSchema>;
 
 export async function loadSessionFromFile(
-  file: Pick<File, "name" | "size" | "type" | "text">
+  file: Pick<File, "name" | "size" | "type" | "text">,
 ): Promise<OptimizeRequestLike> {
   const isJson =
-    file.type === "application/json" || file.name.toLowerCase().endsWith(".json");
+    file.type === "application/json" ||
+    file.name.toLowerCase().endsWith(".json");
 
   if (!isJson) {
     throw new Error("Please select a valid .json save file.");
@@ -103,12 +104,14 @@ export function loadSessionFromText(text: string): OptimizeRequestLike {
   try {
     return parseSessionSaveFile(parsed).data;
   } catch (error) {
-    throw new Error(formatValidationError(error) ?? "Invalid save file format.");
+    throw new Error(
+      formatValidationError(error) ?? "Invalid save file format.",
+    );
   }
 }
 
 export function createPersistedRouteState(
-  route: DriverRoute
+  route: DriverRoute,
 ): PersistedRouteState {
   return {
     version: 1,
@@ -134,7 +137,9 @@ function formatValidationError(error: unknown): string | null {
   if (!issue) return null;
 
   const path =
-    Array.isArray(issue.path) && issue.path.length ? issue.path.join(".") : "file";
+    Array.isArray(issue.path) && issue.path.length
+      ? issue.path.join(".")
+      : "file";
 
   return `Invalid save file format at "${path}".`;
 }

--- a/app/ui/src/lib/driver-route/transformSession.ts
+++ b/app/ui/src/lib/driver-route/transformSession.ts
@@ -1,0 +1,31 @@
+import type { DeliveryStop, DriverRoute, OptimizeRequestLike } from "./types";
+
+export function transformSessionToDriverRoute(
+  input: OptimizeRequestLike
+): DriverRoute {
+  const deliveries = input.deliveries || [];
+  const firstVehicle = input.vehicles?.[0];
+
+  const stops: DeliveryStop[] = deliveries.map((delivery, index) => {
+    return {
+      id: String(delivery.id),
+      stopNumber: index + 1,
+      address: delivery.address || "No address provided",
+      customerName: delivery.recipientName || `Recipient ${index + 1}`,
+      phoneNumber: delivery.phoneNumber,
+      packageCount: delivery.demand?.value || 1,
+      notes: delivery.notes || "",
+      status: "pending",
+      lat: delivery.location?.lat || 0,
+      lng: delivery.location?.lng || 0,
+      completedAt: undefined,
+      failureReason: undefined,
+    };
+  });
+
+  return {
+    driverName: firstVehicle?.driverName || "driver_assist",
+    routeLabel: `Route ${firstVehicle?.id || "1"} - ${stops.length} stops`,
+    stops,
+  };
+}

--- a/app/ui/src/lib/driver-route/transformSession.ts
+++ b/app/ui/src/lib/driver-route/transformSession.ts
@@ -1,7 +1,7 @@
 import type { DeliveryStop, DriverRoute, OptimizeRequestLike } from "./types";
 
 export function transformSessionToDriverRoute(
-  input: OptimizeRequestLike
+  input: OptimizeRequestLike,
 ): DriverRoute {
   const deliveries = input.deliveries || [];
   const firstVehicle = input.vehicles?.[0];

--- a/app/ui/src/lib/driver-route/types.ts
+++ b/app/ui/src/lib/driver-route/types.ts
@@ -1,0 +1,44 @@
+export type DeliveryStatus = "pending" | "completed" | "failed";
+
+export type DeliveryStop = {
+  id: string;
+  stopNumber: number;
+  address: string;
+  customerName: string;
+  phoneNumber?: string;
+  packageCount: number;
+  notes: string;
+  status: DeliveryStatus;
+  lat: number;
+  lng: number;
+  completedAt?: string;
+  failureReason?: string;
+};
+
+export type DriverRoute = {
+  driverName: string;
+  routeLabel: string;
+  stops: DeliveryStop[];
+};
+
+export type OptimizeRequestLike = {
+  deliveries?: {
+    id: number;
+    recipientName?: string;
+    phoneNumber?: string;
+    address?: string;
+    notes?: string;
+    location?: {
+      lat: number;
+      lng: number;
+    };
+    demand?: {
+      value?: number;
+    };
+  }[];
+  vehicles?: {
+    id: number;
+    driverName?: string;
+    vehicleType?: string;
+  }[];
+};

--- a/app/ui/src/tests/driverRouteImport.test.ts
+++ b/app/ui/src/tests/driverRouteImport.test.ts
@@ -23,7 +23,7 @@ describe("driver route import", () => {
           ],
           vehicles: [{ id: 7, driverName: "Grace Hopper" }],
         },
-      })
+      }),
     );
 
     expect(transformSessionToDriverRoute(session)).toEqual({
@@ -50,7 +50,7 @@ describe("driver route import", () => {
 
   it("rejects files that do not match the saved session contract", () => {
     expect(() => loadSessionFromText(JSON.stringify({ version: 1 }))).toThrow(
-      'Invalid save file format at "savedAt".'
+      'Invalid save file format at "savedAt".',
     );
   });
 });

--- a/app/ui/src/tests/driverRouteImport.test.ts
+++ b/app/ui/src/tests/driverRouteImport.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { loadSessionFromText } from "@/lib/driver-route/importSession";
+import { transformSessionToDriverRoute } from "@/lib/driver-route/transformSession";
+
+describe("driver route import", () => {
+  it("loads a saved route-manager session into the driver_assist route shape", () => {
+    const session = loadSessionFromText(
+      JSON.stringify({
+        version: 1,
+        savedAt: "2026-05-16T12:00:00.000Z",
+        data: {
+          deliveries: [
+            {
+              id: 42,
+              recipientName: "Ada Lovelace",
+              phoneNumber: "555-0100",
+              address: "12 Compiler Way",
+              notes: "Leave near side door",
+              location: { lat: 37.1, lng: -122.2 },
+              demand: { value: 3 },
+            },
+          ],
+          vehicles: [{ id: 7, driverName: "Grace Hopper" }],
+        },
+      })
+    );
+
+    expect(transformSessionToDriverRoute(session)).toEqual({
+      driverName: "Grace Hopper",
+      routeLabel: "Route 7 - 1 stops",
+      stops: [
+        {
+          id: "42",
+          stopNumber: 1,
+          address: "12 Compiler Way",
+          customerName: "Ada Lovelace",
+          phoneNumber: "555-0100",
+          packageCount: 3,
+          notes: "Leave near side door",
+          status: "pending",
+          lat: 37.1,
+          lng: -122.2,
+          completedAt: undefined,
+          failureReason: undefined,
+        },
+      ],
+    });
+  });
+
+  it("rejects files that do not match the saved session contract", () => {
+    expect(() => loadSessionFromText(JSON.stringify({ version: 1 }))).toThrow(
+      'Invalid save file format at "savedAt".'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Adds a hi-fi Driver Assist mobile route flow where drivers can upload a route JSON, view stops, expand stop cards, mark deliveries complete, report incomplete deliveries, and navigate to destinations.

## Motivation
Driver users need a mobile-focused route assistant instead of the placeholder driver view, so they can work through assigned stops from an imported route-manager session.

## Changes

- Added a hi-fi `/driver_assist` mobile route screen with route stats, progress tracking, expandable stop cards, delivered/incomplete sections, sticky Finish action, and footer branding.
- Connected the existing driver upload flow so `/upload-route` stores the selected JSON route and continues into `/driver_assist`.
- Added Driver Assist route import helpers to validate saved route-manager JSON, transform it into driver stop data, and persist active route state locally.
- Added stop-level actions for Navigate, Delivered, Call, and Report issue.
- Added a Report issue modal with predefined reasons and an Other-only details field; submitted reports move stops into Incomplete delivery.
- Added clickable route stats that jump to the relevant sections of the page.
- Added PWA support for the Driver Assist experience, including manifest, service worker registration, and icon.
- Added focused tests for Driver Assist route import and invalid file handling.

## Validation
- Frontend:
  - Added `/driver_assist` with route stats, progress, remaining/delivered/incomplete sections, expandable stop cards, sticky Finish button, and footer branding.
  - Connected `/upload-route` Continue to `/driver_assist`.
  - Added mobile-friendly upload page spacing and file row behavior.
  - Added Report issue modal with reason choices and an Other-only details box.
  - Added Driver Assist route persistence using localStorage.
  - Added route import parsing/validation and transformation helpers.
  - Added PWA manifest, service worker registration, icon, and related config.

- Tests:
  - Added `driverRouteImport.test.ts` for saved-session parsing and transformation.

### Frontend

- [x] `npm --prefix app/ui run lint`
- [x] `npm --prefix app/ui run format:check`
- [x] `npm --prefix app/ui run typecheck`
- [x] `npm --prefix app/ui run test -- driverRouteImport.test.ts`
- [x] `npm --prefix app/ui run build`

## Risk

- Route import depends on the saved route-manager JSON shape staying compatible with the new Driver Assist parser.
- Driver progress is persisted in localStorage, so stale state can remain if a user leaves before tapping Finish.
- The Driver Assist UI is mobile-focused; desktop behavior is functional but not the primary optimized layout.
- Reported deliveries are now treated as failed/incomplete, so downstream expectations should align with that status model.

## Rollout and Recovery

- Rollout is frontend-only and can ship with the normal UI deployment.
- No database migrations or backend config changes are required.
- If issues appear, revert this PR or temporarily route Driver Continue back away from `/driver_assist`.
- Users can recover from stale local Driver Assist state by tapping Finish or clearing site storage.

## High-Signal PR Checklist

- [x] The summary states the user-visible or operational outcome, not just file names.
- [x] The motivation explains why this change is needed now.
- [x] The change list separates frontend, backend, infrastructure, and documentation work where applicable.
- [x] Validation includes exact commands run, relevant output, and any checks intentionally skipped.
- [x] Risks, migrations, feature flags, and rollback steps are called out when relevant.
- [x] Screenshots or request/response examples are included for UI and API behavior changes.
<img width="620" height="1343" alt="image" src="https://github.com/user-attachments/assets/03634e76-4ec1-41fd-8ee7-2d56d9027d67" />

