### PR TITLE
feat: use route duration accurate for weather-aware optimization

### DIFF
--- a/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
+++ b/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <json/json.h>
+#include <optional>
 #include <string>
 
 namespace deliveryoptimizer::api {
@@ -49,6 +50,8 @@ FetchOpenWeatherDelayEstimate(const WeatherForecastOptions& options, const Coord
 [[nodiscard]] WeatherImpactEstimate
 EstimateRouteWeatherImpact(const WeatherForecastOptions& options, const OptimizeRequestInput& input,
                            int baseline_duration_seconds);
+
+[[nodiscard]] std::optional<int> ReadVroomSummaryDurationSeconds(const Json::Value& vroom_output);
 
 [[nodiscard]] Json::Value BuildWeatherAdjustedVroomInput(const OptimizeRequestInput& input,
                                                          const WeatherImpactEstimate& impact);

--- a/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
+++ b/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
@@ -45,8 +45,13 @@ struct WeatherImpactEstimate {
 
 [[nodiscard]] int EstimateServiceSeconds(const OptimizeRequestInput& input);
 
-[[nodiscard]] OpenWeatherDelayEstimate
-FetchOpenWeatherDelayEstimate(const WeatherForecastOptions& options, const Coordinate& coordinate);
+[[nodiscard]] OpenWeatherDelayEstimate FetchOpenWeatherDelayEstimate(
+    const WeatherForecastOptions& options, const Coordinate& coordinate,
+    std::optional<std::chrono::sys_seconds> route_start_time = std::nullopt);
+
+[[nodiscard]] int
+ReadOpenWeatherDelay(const Json::Value& body,
+                     std::optional<std::chrono::sys_seconds> route_start_time = std::nullopt);
 
 [[nodiscard]] WeatherImpactEstimate EstimateWeatherImpact(const WeatherForecastOptions& options,
                                                           std::size_t stop_count,

--- a/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
+++ b/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
@@ -51,6 +51,9 @@ FetchOpenWeatherDelayEstimate(const WeatherForecastOptions& options, const Coord
 EstimateRouteWeatherImpact(const WeatherForecastOptions& options, const OptimizeRequestInput& input,
                            int baseline_duration_seconds);
 
+[[nodiscard]] std::optional<std::chrono::sys_seconds>
+ReadPlannedRouteStartTime(const OptimizeRequestInput& input);
+
 [[nodiscard]] std::optional<int> ReadVroomSummaryDurationSeconds(const Json::Value& vroom_output);
 
 [[nodiscard]] Json::Value BuildWeatherAdjustedVroomInput(const OptimizeRequestInput& input,

--- a/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
+++ b/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
@@ -47,11 +47,13 @@ struct WeatherImpactEstimate {
 
 [[nodiscard]] OpenWeatherDelayEstimate FetchOpenWeatherDelayEstimate(
     const WeatherForecastOptions& options, const Coordinate& coordinate,
-    std::optional<std::chrono::sys_seconds> route_start_time = std::nullopt);
+    std::optional<std::chrono::sys_seconds> route_start_time = std::nullopt,
+    std::optional<int> route_duration_seconds = std::nullopt);
 
 [[nodiscard]] int
 ReadOpenWeatherDelay(const Json::Value& body,
-                     std::optional<std::chrono::sys_seconds> route_start_time = std::nullopt);
+                     std::optional<std::chrono::sys_seconds> route_start_time = std::nullopt,
+                     std::optional<int> route_duration_seconds = std::nullopt);
 
 [[nodiscard]] WeatherImpactEstimate EstimateWeatherImpact(const WeatherForecastOptions& options,
                                                           std::size_t stop_count,
@@ -66,10 +68,9 @@ ReadRouteStartTime(const OptimizeRequestInput& input);
 
 [[nodiscard]] std::optional<int> ReadVroomDuration(const Json::Value& vroom_output);
 
-[[nodiscard]] WeatherImpactEstimate
-RecalculateWeatherImpact(const WeatherForecastOptions& options, const OptimizeRequestInput& input,
-                         const WeatherImpactEstimate& planned_impact,
-                         const Json::Value& vroom_output);
+[[nodiscard]] WeatherImpactEstimate RecalculateWeatherImpact(const WeatherForecastOptions& options,
+                                                             const OptimizeRequestInput& input,
+                                                             const Json::Value& vroom_output);
 
 [[nodiscard]] Json::Value BuildWeatherAdjustedVroomInput(const OptimizeRequestInput& input,
                                                          const WeatherImpactEstimate& impact);

--- a/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
+++ b/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
@@ -2,6 +2,7 @@
 
 #include "deliveryoptimizer/api/optimize_request.hpp"
 
+#include <chrono>
 #include <cstddef>
 #include <json/json.h>
 #include <optional>
@@ -27,11 +28,15 @@ struct OpenWeatherDelayEstimate {
 struct WeatherImpactEstimate {
   int stop_count{0};
   int baseline_duration_seconds{0};
+  int baseline_route_duration_seconds{0};
   int delay_seconds_per_stop{0};
   int weather_delay_seconds{0};
+  int weather_adjusted_duration_seconds{0};
   int reoptimize_threshold_seconds{300};
   bool should_reoptimize{false};
   std::string source;
+  std::optional<std::chrono::sys_seconds> planned_start_time;
+  std::optional<std::chrono::sys_seconds> estimated_finish_time;
 };
 
 [[nodiscard]] WeatherForecastOptions ResolveWeatherForecastOptionsFromEnv();

--- a/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
+++ b/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
@@ -52,9 +52,14 @@ EstimateRouteWeatherImpact(const WeatherForecastOptions& options, const Optimize
                            int baseline_duration_seconds);
 
 [[nodiscard]] std::optional<std::chrono::sys_seconds>
-ReadPlannedRouteStartTime(const OptimizeRequestInput& input);
+ReadRouteStartTime(const OptimizeRequestInput& input);
 
-[[nodiscard]] std::optional<int> ReadVroomSummaryDurationSeconds(const Json::Value& vroom_output);
+[[nodiscard]] std::optional<int> ReadVroomDuration(const Json::Value& vroom_output);
+
+[[nodiscard]] WeatherImpactEstimate
+RecalculateWeatherImpact(const WeatherForecastOptions& options, const OptimizeRequestInput& input,
+                         const WeatherImpactEstimate& planned_impact,
+                         const Json::Value& vroom_output);
 
 [[nodiscard]] Json::Value BuildWeatherAdjustedVroomInput(const OptimizeRequestInput& input,
                                                          const WeatherImpactEstimate& impact);

--- a/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
+++ b/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
@@ -186,6 +186,8 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
               }
 
               WeatherForecastOptions sync_weather_options = weather_options;
+              // Clear the key so recalculation short-circuits OpenWeather; sync path must not
+              // block the event loop.
               sync_weather_options.openweather_api_key.clear();
               const WeatherImpactEstimate impact = RecalculateWeatherImpact(
                   sync_weather_options, *optimize_request_ptr, *result.output);

--- a/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
+++ b/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
@@ -108,7 +108,7 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
 
   app.registerHandler(
       "/api/v1/deliveries/optimize",
-      [coordinator = std::move(coordinator), runner = std::move(runner), weather_options,
+      [coordinator = std::move(coordinator), weather_options,
        observability = std::move(observability)](
           const drogon::HttpRequestPtr& request,
           std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
@@ -176,21 +176,40 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
         };
         const SolveAdmissionStatus admission_status = coordinator->Submit(
             request_size, [optimize_request_ptr] { return BuildVroomInput(*optimize_request_ptr); },
-            [optimize_request_ptr, runner, weather_options,
+            [coordinator, optimize_request_ptr, request_size, weather_options,
              respond_with_completion](const CoordinatedSolveResult& result) mutable {
-              CoordinatedSolveResult final_result = result;
               std::optional<Json::Value> forecast;
-              if (result.output.has_value()) {
-                const WeatherImpactEstimate impact = RecalculateWeatherImpact(
-                    weather_options, *optimize_request_ptr, *result.output);
-                forecast = BuildWeatherForecastAnnotation(weather_options, impact);
-                if (impact.should_reoptimize) {
-                  final_result = ToCoordinatedSolveResult(
-                      runner->Run(BuildWeatherAdjustedVroomInput(*optimize_request_ptr, impact)));
-                }
+              if (!result.output.has_value()) {
+                respond_with_completion(BuildSolveExecutionResponse(
+                    BuildSolveExecutionResult(*optimize_request_ptr, result, forecast)));
+                return;
               }
-              respond_with_completion(BuildSolveExecutionResponse(
-                  BuildSolveExecutionResult(*optimize_request_ptr, final_result, forecast)));
+
+              WeatherForecastOptions sync_weather_options = weather_options;
+              sync_weather_options.openweather_api_key.clear();
+              const WeatherImpactEstimate impact =
+                  RecalculateWeatherImpact(sync_weather_options, *optimize_request_ptr,
+                                           *result.output);
+              forecast = BuildWeatherForecastAnnotation(sync_weather_options, impact);
+              if (!impact.should_reoptimize) {
+                respond_with_completion(BuildSolveExecutionResponse(
+                    BuildSolveExecutionResult(*optimize_request_ptr, result, forecast)));
+                return;
+              }
+
+              const SolveAdmissionStatus rerun_status = coordinator->Submit(
+                  request_size,
+                  [optimize_request_ptr, impact] {
+                    return BuildWeatherAdjustedVroomInput(*optimize_request_ptr, impact);
+                  },
+                  [optimize_request_ptr, forecast, respond_with_completion](
+                      const CoordinatedSolveResult& rerun_result) mutable {
+                    respond_with_completion(BuildSolveExecutionResponse(BuildSolveExecutionResult(
+                        *optimize_request_ptr, rerun_result, forecast)));
+                  });
+              if (rerun_status != SolveAdmissionStatus::kAccepted) {
+                respond_with_completion(BuildAdmissionRejectionResponse(rerun_status));
+              }
             },
             lifecycle);
         if (admission_status != SolveAdmissionStatus::kAccepted) {

--- a/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
+++ b/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
@@ -102,13 +102,13 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
                                         const SolveAdmissionConfig& admission_config,
                                         std::shared_ptr<ObservabilityRegistry> observability) {
   const WeatherForecastOptions weather_options = ResolveWeatherForecastOptionsFromEnv();
-  auto coordinator = std::make_shared<SolveCoordinator>(
-      admission_config, std::make_shared<ProcessVroomRunner>(ResolveVroomRuntimeConfigFromEnv()),
-      SolveCoordinatorOptions{}, observability);
+  auto runner = std::make_shared<ProcessVroomRunner>(ResolveVroomRuntimeConfigFromEnv());
+  auto coordinator = std::make_shared<SolveCoordinator>(admission_config, runner,
+                                                        SolveCoordinatorOptions{}, observability);
 
   app.registerHandler(
       "/api/v1/deliveries/optimize",
-      [coordinator = std::move(coordinator), weather_options,
+      [coordinator = std::move(coordinator), runner = std::move(runner), weather_options,
        observability = std::move(observability)](
           const drogon::HttpRequestPtr& request,
           std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
@@ -174,30 +174,23 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
             .jobs = optimize_request_ptr->jobs.size(),
             .vehicles = optimize_request_ptr->vehicles.size(),
         };
-        auto weather_impact = std::make_shared<std::optional<WeatherImpactEstimate>>(std::nullopt);
-
         const SolveAdmissionStatus admission_status = coordinator->Submit(
-            request_size,
-            [optimize_request_ptr, weather_options, weather_impact] {
-              const int baseline_seconds = EstimateServiceSeconds(*optimize_request_ptr);
-              const WeatherImpactEstimate impact = EstimateWeatherImpact(
-                  weather_options, optimize_request_ptr->jobs.size(), baseline_seconds);
-              *weather_impact = impact;
-              return BuildWeatherAdjustedVroomInput(*optimize_request_ptr, impact);
-            },
-            [optimize_request_ptr, weather_options, weather_impact,
+            request_size, [optimize_request_ptr] { return BuildVroomInput(*optimize_request_ptr); },
+            [optimize_request_ptr, runner, weather_options,
              respond_with_completion](const CoordinatedSolveResult& result) mutable {
+              CoordinatedSolveResult final_result = result;
               std::optional<Json::Value> forecast;
               if (result.output.has_value()) {
-                const WeatherImpactEstimate planned_impact = weather_impact->value_or(
-                    EstimateWeatherImpact(weather_options, optimize_request_ptr->jobs.size(),
-                                          EstimateServiceSeconds(*optimize_request_ptr)));
                 const WeatherImpactEstimate impact = RecalculateWeatherImpact(
-                    weather_options, *optimize_request_ptr, planned_impact, *result.output);
+                    weather_options, *optimize_request_ptr, *result.output);
                 forecast = BuildWeatherForecastAnnotation(weather_options, impact);
+                if (impact.should_reoptimize) {
+                  final_result = ToCoordinatedSolveResult(
+                      runner->Run(BuildWeatherAdjustedVroomInput(*optimize_request_ptr, impact)));
+                }
               }
               respond_with_completion(BuildSolveExecutionResponse(
-                  BuildSolveExecutionResult(*optimize_request_ptr, result, forecast)));
+                  BuildSolveExecutionResult(*optimize_request_ptr, final_result, forecast)));
             },
             lifecycle);
         if (admission_status != SolveAdmissionStatus::kAccepted) {

--- a/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
+++ b/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
@@ -189,9 +189,11 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
              respond_with_completion](const CoordinatedSolveResult& result) mutable {
               std::optional<Json::Value> forecast;
               if (result.output.has_value()) {
-                const WeatherImpactEstimate impact = weather_impact->value_or(
+                const WeatherImpactEstimate planned_impact = weather_impact->value_or(
                     EstimateWeatherImpact(weather_options, optimize_request_ptr->jobs.size(),
                                           EstimateServiceSeconds(*optimize_request_ptr)));
+                const WeatherImpactEstimate impact = RecalculateWeatherImpact(
+                    weather_options, *optimize_request_ptr, planned_impact, *result.output);
                 forecast = BuildWeatherForecastAnnotation(weather_options, impact);
               }
               respond_with_completion(BuildSolveExecutionResponse(

--- a/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
+++ b/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
@@ -187,9 +187,8 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
 
               WeatherForecastOptions sync_weather_options = weather_options;
               sync_weather_options.openweather_api_key.clear();
-              const WeatherImpactEstimate impact =
-                  RecalculateWeatherImpact(sync_weather_options, *optimize_request_ptr,
-                                           *result.output);
+              const WeatherImpactEstimate impact = RecalculateWeatherImpact(
+                  sync_weather_options, *optimize_request_ptr, *result.output);
               forecast = BuildWeatherForecastAnnotation(sync_weather_options, impact);
               if (!impact.should_reoptimize) {
                 respond_with_completion(BuildSolveExecutionResponse(
@@ -202,10 +201,10 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
                   [optimize_request_ptr, impact] {
                     return BuildWeatherAdjustedVroomInput(*optimize_request_ptr, impact);
                   },
-                  [optimize_request_ptr, forecast, respond_with_completion](
-                      const CoordinatedSolveResult& rerun_result) mutable {
-                    respond_with_completion(BuildSolveExecutionResponse(BuildSolveExecutionResult(
-                        *optimize_request_ptr, rerun_result, forecast)));
+                  [optimize_request_ptr, forecast,
+                   respond_with_completion](const CoordinatedSolveResult& rerun_result) mutable {
+                    respond_with_completion(BuildSolveExecutionResponse(
+                        BuildSolveExecutionResult(*optimize_request_ptr, rerun_result, forecast)));
                   });
               if (rerun_status != SolveAdmissionStatus::kAccepted) {
                 respond_with_completion(BuildAdmissionRejectionResponse(rerun_status));

--- a/app/api/src/forecast_optimizer.cpp
+++ b/app/api/src/forecast_optimizer.cpp
@@ -110,31 +110,30 @@ constexpr double kDefaultWeatherThresholdPercent = 5.0;
   int delay_seconds = 0;
   const double wind_speed = hour["wind_speed"].isNumeric() ? hour["wind_speed"].asDouble() : 0.0;
   const int visibility = hour["visibility"].isInt() ? hour["visibility"].asInt() : 10000;
-  if (wind_speed >= 10.0) {
-    delay_seconds += 60;
-  }
-  if (visibility < 5000) {
-    delay_seconds += 60;
-  }
-  if (hour["rain"].isObject()) {
-    delay_seconds += 90;
-  }
-  if (hour["snow"].isObject()) {
-    delay_seconds += 180;
-  }
-
+  bool has_thunder = false;
   const Json::Value& weather = hour["weather"];
   if (weather.isArray()) {
-    bool has_thunder = false;
     for (const Json::Value& condition : weather) {
       const int condition_id = condition["id"].isInt() ? condition["id"].asInt() : 0;
       if (condition_id >= 200 && condition_id < 300) {
         has_thunder = true;
       }
     }
-    if (has_thunder) {
-      delay_seconds += 240;
-    }
+  }
+
+  if (wind_speed >= 10.0) {
+    delay_seconds += 60;
+  }
+  if (visibility < 5000) {
+    delay_seconds += 60;
+  }
+  if (has_thunder) {
+    delay_seconds += 240;
+  } else if (hour["rain"].isObject()) {
+    delay_seconds += 90;
+  }
+  if (hour["snow"].isObject()) {
+    delay_seconds += 180;
   }
 
   return delay_seconds;
@@ -154,9 +153,9 @@ constexpr double kDefaultWeatherThresholdPercent = 5.0;
          forecast_time < route_start_time + std::chrono::seconds{window_seconds};
 }
 
-void SetRouteTimes(const deliveryoptimizer::api::OptimizeRequestInput& input,
+void SetRouteTimes(const std::optional<std::chrono::sys_seconds> planned_start_time,
                    deliveryoptimizer::api::WeatherImpactEstimate& impact) {
-  impact.planned_start_time = deliveryoptimizer::api::ReadRouteStartTime(input);
+  impact.planned_start_time = planned_start_time;
   if (!impact.planned_start_time.has_value()) {
     impact.estimated_finish_time = std::nullopt;
     return;
@@ -344,15 +343,16 @@ WeatherImpactEstimate EstimateRouteWeatherImpact(const WeatherForecastOptions& o
   WeatherForecastOptions effective_options = options;
   WeatherImpactEstimate impact =
       EstimateWeatherImpact(effective_options, input.jobs.size(), baseline_duration_seconds);
-  SetRouteTimes(input, impact);
+  const std::optional<std::chrono::sys_seconds> route_start_time = ReadRouteStartTime(input);
+  SetRouteTimes(route_start_time, impact);
   const OpenWeatherDelayEstimate openweather = FetchOpenWeatherDelayEstimate(
       options, Coordinate{.lon = input.depot_lon, .lat = input.depot_lat},
-      ReadRouteStartTime(input), baseline_duration_seconds);
+      route_start_time, baseline_duration_seconds);
   if (openweather.available) {
     effective_options.weather_delay_seconds_per_stop = openweather.delay_seconds_per_stop;
     impact = EstimateWeatherImpact(effective_options, input.jobs.size(), baseline_duration_seconds);
     impact.source = openweather.source;
-    SetRouteTimes(input, impact);
+    SetRouteTimes(route_start_time, impact);
   }
 
   return impact;
@@ -420,12 +420,9 @@ Json::Value BuildWeatherForecastAnnotation(const WeatherForecastOptions& options
   forecast["status"] = options.enabled ? "evaluated" : "disabled";
   forecast["provider"] = impact.source;
   forecast["stop_count"] = impact.stop_count;
-  forecast["baseline_duration_seconds"] = impact.baseline_duration_seconds;
   forecast["baseline_route_duration_seconds"] = impact.baseline_route_duration_seconds;
   forecast["weather_delay_seconds"] = impact.weather_delay_seconds;
   forecast["weather_adjusted_duration_seconds"] = impact.weather_adjusted_duration_seconds;
-  forecast["predicted_duration_seconds"] =
-      impact.baseline_duration_seconds + impact.weather_delay_seconds;
   forecast["reoptimize_threshold_seconds"] = impact.reoptimize_threshold_seconds;
   if (impact.planned_start_time.has_value()) {
     forecast["planned_start_time"] =

--- a/app/api/src/forecast_optimizer.cpp
+++ b/app/api/src/forecast_optimizer.cpp
@@ -346,8 +346,8 @@ WeatherImpactEstimate EstimateRouteWeatherImpact(const WeatherForecastOptions& o
   const std::optional<std::chrono::sys_seconds> route_start_time = ReadRouteStartTime(input);
   SetRouteTimes(route_start_time, impact);
   const OpenWeatherDelayEstimate openweather = FetchOpenWeatherDelayEstimate(
-      options, Coordinate{.lon = input.depot_lon, .lat = input.depot_lat}, route_start_time,
-      baseline_duration_seconds);
+      effective_options, Coordinate{.lon = input.depot_lon, .lat = input.depot_lat},
+      route_start_time, baseline_duration_seconds);
   if (openweather.available) {
     effective_options.weather_delay_seconds_per_stop = openweather.delay_seconds_per_stop;
     impact = EstimateWeatherImpact(effective_options, input.jobs.size(), baseline_duration_seconds);
@@ -389,6 +389,7 @@ std::optional<int> ReadVroomDuration(const Json::Value& vroom_output) {
 WeatherImpactEstimate RecalculateWeatherImpact(const WeatherForecastOptions& options,
                                                const OptimizeRequestInput& input,
                                                const Json::Value& vroom_output) {
+  // Callers choose whether OpenWeather may be queried by passing or clearing the API key.
   const std::optional<int> summary_duration = ReadVroomDuration(vroom_output);
   if (!summary_duration.has_value()) {
     return EstimateRouteWeatherImpact(options, input, 0);

--- a/app/api/src/forecast_optimizer.cpp
+++ b/app/api/src/forecast_optimizer.cpp
@@ -140,19 +140,19 @@ constexpr double kDefaultWeatherThresholdPercent = 5.0;
   return delay_seconds;
 }
 
-[[nodiscard]] int DelayFromOpenWeatherBody(const Json::Value& body) {
-  const Json::Value& hourly = body["hourly"];
-  if (!hourly.isArray()) {
-    return 0;
+[[nodiscard]] bool IsRouteHour(const Json::Value& hour,
+                               const std::optional<std::chrono::sys_seconds> route_start_time) {
+  if (!route_start_time.has_value()) {
+    return true;
+  }
+  if (!hour["dt"].isInt64() && !hour["dt"].isUInt64()) {
+    return false;
   }
 
-  int delay_seconds = 0;
-  const Json::ArrayIndex hours_to_scan = std::min<Json::ArrayIndex>(hourly.size(), 6U);
-  for (Json::ArrayIndex index = 0; index < hours_to_scan; ++index) {
-    delay_seconds = std::max(delay_seconds, DelayFromHourlyForecast(hourly[index]));
-  }
-
-  return delay_seconds;
+  const auto forecast_time =
+      std::chrono::sys_seconds{std::chrono::seconds{hour["dt"].asLargestInt()}};
+  return forecast_time >= *route_start_time &&
+         forecast_time < *route_start_time + std::chrono::hours{6};
 }
 
 void SetRouteTimes(const deliveryoptimizer::api::OptimizeRequestInput& input,
@@ -204,8 +204,9 @@ int EstimateServiceSeconds(const OptimizeRequestInput& input) {
   return static_cast<int>(total);
 }
 
-OpenWeatherDelayEstimate FetchOpenWeatherDelayEstimate(const WeatherForecastOptions& options,
-                                                       const Coordinate& coordinate) {
+OpenWeatherDelayEstimate
+FetchOpenWeatherDelayEstimate(const WeatherForecastOptions& options, const Coordinate& coordinate,
+                              const std::optional<std::chrono::sys_seconds> route_start_time) {
   if (!IsOpenWeatherConfigured(options)) {
     return OpenWeatherDelayEstimate{
         .available = false,
@@ -223,7 +224,8 @@ OpenWeatherDelayEstimate FetchOpenWeatherDelayEstimate(const WeatherForecastOpti
   auto future = promise->get_future();
   client->sendRequest(
       request,
-      [promise](const drogon::ReqResult result, const drogon::HttpResponsePtr& response) {
+      [promise, route_start_time](const drogon::ReqResult result,
+                                  const drogon::HttpResponsePtr& response) {
         if (result != drogon::ReqResult::Ok || response == nullptr ||
             response->getStatusCode() != drogon::k200OK) {
           promise->set_value(OpenWeatherDelayEstimate{
@@ -246,7 +248,7 @@ OpenWeatherDelayEstimate FetchOpenWeatherDelayEstimate(const WeatherForecastOpti
 
         promise->set_value(OpenWeatherDelayEstimate{
             .available = true,
-            .delay_seconds_per_stop = DelayFromOpenWeatherBody(*body),
+            .delay_seconds_per_stop = ReadOpenWeatherDelay(*body, route_start_time),
             .source = "openweather",
         });
       },
@@ -262,6 +264,35 @@ OpenWeatherDelayEstimate FetchOpenWeatherDelayEstimate(const WeatherForecastOpti
   }
 
   return future.get();
+}
+
+int ReadOpenWeatherDelay(const Json::Value& body,
+                         const std::optional<std::chrono::sys_seconds> route_start_time) {
+  const Json::Value& hourly = body["hourly"];
+  if (!hourly.isArray()) {
+    return 0;
+  }
+
+  int delay_seconds = 0;
+  Json::ArrayIndex matched_hours = 0U;
+  for (Json::ArrayIndex index = 0U; index < hourly.size(); ++index) {
+    if (!IsRouteHour(hourly[index], route_start_time)) {
+      continue;
+    }
+    delay_seconds = std::max(delay_seconds, DelayFromHourlyForecast(hourly[index]));
+    ++matched_hours;
+  }
+
+  if (!route_start_time.has_value() || matched_hours > 0U) {
+    return delay_seconds;
+  }
+
+  const Json::ArrayIndex hours_to_scan = std::min<Json::ArrayIndex>(hourly.size(), 6U);
+  for (Json::ArrayIndex index = 0U; index < hours_to_scan; ++index) {
+    delay_seconds = std::max(delay_seconds, DelayFromHourlyForecast(hourly[index]));
+  }
+
+  return delay_seconds;
 }
 
 WeatherImpactEstimate EstimateWeatherImpact(const WeatherForecastOptions& options,
@@ -303,7 +334,8 @@ WeatherImpactEstimate EstimateRouteWeatherImpact(const WeatherForecastOptions& o
       EstimateWeatherImpact(effective_options, input.jobs.size(), baseline_duration_seconds);
   SetRouteTimes(input, impact);
   const OpenWeatherDelayEstimate openweather = FetchOpenWeatherDelayEstimate(
-      options, Coordinate{.lon = input.depot_lon, .lat = input.depot_lat});
+      options, Coordinate{.lon = input.depot_lon, .lat = input.depot_lat},
+      ReadRouteStartTime(input));
   if (openweather.available) {
     effective_options.weather_delay_seconds_per_stop = openweather.delay_seconds_per_stop;
     impact = EstimateWeatherImpact(effective_options, input.jobs.size(), baseline_duration_seconds);

--- a/app/api/src/forecast_optimizer.cpp
+++ b/app/api/src/forecast_optimizer.cpp
@@ -296,8 +296,7 @@ WeatherImpactEstimate EstimateRouteWeatherImpact(const WeatherForecastOptions& o
   return impact;
 }
 
-std::optional<std::chrono::sys_seconds>
-ReadPlannedRouteStartTime(const OptimizeRequestInput& input) {
+std::optional<std::chrono::sys_seconds> ReadRouteStartTime(const OptimizeRequestInput& input) {
   std::optional<std::chrono::sys_seconds> planned_start;
   for (const VehicleInput& vehicle : input.vehicles) {
     if (!vehicle.time_window.has_value()) {
@@ -311,7 +310,7 @@ ReadPlannedRouteStartTime(const OptimizeRequestInput& input) {
   return planned_start;
 }
 
-std::optional<int> ReadVroomSummaryDurationSeconds(const Json::Value& vroom_output) {
+std::optional<int> ReadVroomDuration(const Json::Value& vroom_output) {
   const Json::Value& duration = vroom_output["summary"]["duration"];
   if (!duration.isNumeric()) {
     return std::nullopt;
@@ -323,6 +322,28 @@ std::optional<int> ReadVroomSummaryDurationSeconds(const Json::Value& vroom_outp
   }
 
   return static_cast<int>(std::ceil(raw_duration));
+}
+
+WeatherImpactEstimate RecalculateWeatherImpact(const WeatherForecastOptions& options,
+                                               const OptimizeRequestInput& input,
+                                               const WeatherImpactEstimate& planned_impact,
+                                               const Json::Value& vroom_output) {
+  const std::optional<int> summary_duration = ReadVroomDuration(vroom_output);
+  if (!summary_duration.has_value()) {
+    return planned_impact;
+  }
+
+  const int weather_delay_already_in_route =
+      planned_impact.should_reoptimize ? planned_impact.weather_delay_seconds : 0;
+  const int baseline_route_seconds =
+      std::max(*summary_duration - weather_delay_already_in_route, 0);
+
+  WeatherForecastOptions effective_options = options;
+  effective_options.weather_delay_seconds_per_stop = planned_impact.delay_seconds_per_stop;
+  WeatherImpactEstimate impact =
+      EstimateWeatherImpact(effective_options, input.jobs.size(), baseline_route_seconds);
+  impact.source = planned_impact.source;
+  return impact;
 }
 
 Json::Value BuildWeatherAdjustedVroomInput(const OptimizeRequestInput& input,

--- a/app/api/src/forecast_optimizer.cpp
+++ b/app/api/src/forecast_optimizer.cpp
@@ -155,6 +155,18 @@ constexpr double kDefaultWeatherThresholdPercent = 5.0;
   return delay_seconds;
 }
 
+void SetRouteTimes(const deliveryoptimizer::api::OptimizeRequestInput& input,
+                   deliveryoptimizer::api::WeatherImpactEstimate& impact) {
+  impact.planned_start_time = deliveryoptimizer::api::ReadRouteStartTime(input);
+  if (!impact.planned_start_time.has_value()) {
+    impact.estimated_finish_time = std::nullopt;
+    return;
+  }
+
+  impact.estimated_finish_time =
+      *impact.planned_start_time + std::chrono::seconds{impact.weather_adjusted_duration_seconds};
+}
+
 } // namespace
 
 namespace deliveryoptimizer::api {
@@ -271,11 +283,15 @@ WeatherImpactEstimate EstimateWeatherImpact(const WeatherForecastOptions& option
   return WeatherImpactEstimate{
       .stop_count = normalized_stop_count,
       .baseline_duration_seconds = normalized_baseline_seconds,
+      .baseline_route_duration_seconds = normalized_baseline_seconds,
       .delay_seconds_per_stop = configured_delay_per_stop,
       .weather_delay_seconds = weather_delay_seconds,
+      .weather_adjusted_duration_seconds = normalized_baseline_seconds + weather_delay_seconds,
       .reoptimize_threshold_seconds = threshold_seconds,
       .should_reoptimize = weather_delay_seconds > 0 && weather_delay_seconds >= threshold_seconds,
       .source = options.enabled ? "fixed_delay" : "disabled",
+      .planned_start_time = std::nullopt,
+      .estimated_finish_time = std::nullopt,
   };
 }
 
@@ -285,12 +301,14 @@ WeatherImpactEstimate EstimateRouteWeatherImpact(const WeatherForecastOptions& o
   WeatherForecastOptions effective_options = options;
   WeatherImpactEstimate impact =
       EstimateWeatherImpact(effective_options, input.jobs.size(), baseline_duration_seconds);
+  SetRouteTimes(input, impact);
   const OpenWeatherDelayEstimate openweather = FetchOpenWeatherDelayEstimate(
       options, Coordinate{.lon = input.depot_lon, .lat = input.depot_lat});
   if (openweather.available) {
     effective_options.weather_delay_seconds_per_stop = openweather.delay_seconds_per_stop;
     impact = EstimateWeatherImpact(effective_options, input.jobs.size(), baseline_duration_seconds);
     impact.source = openweather.source;
+    SetRouteTimes(input, impact);
   }
 
   return impact;
@@ -343,6 +361,7 @@ WeatherImpactEstimate RecalculateWeatherImpact(const WeatherForecastOptions& opt
   WeatherImpactEstimate impact =
       EstimateWeatherImpact(effective_options, input.jobs.size(), baseline_route_seconds);
   impact.source = planned_impact.source;
+  SetRouteTimes(input, impact);
   return impact;
 }
 
@@ -370,10 +389,20 @@ Json::Value BuildWeatherForecastAnnotation(const WeatherForecastOptions& options
   forecast["provider"] = impact.source;
   forecast["stop_count"] = impact.stop_count;
   forecast["baseline_duration_seconds"] = impact.baseline_duration_seconds;
+  forecast["baseline_route_duration_seconds"] = impact.baseline_route_duration_seconds;
   forecast["weather_delay_seconds"] = impact.weather_delay_seconds;
+  forecast["weather_adjusted_duration_seconds"] = impact.weather_adjusted_duration_seconds;
   forecast["predicted_duration_seconds"] =
       impact.baseline_duration_seconds + impact.weather_delay_seconds;
   forecast["reoptimize_threshold_seconds"] = impact.reoptimize_threshold_seconds;
+  if (impact.planned_start_time.has_value()) {
+    forecast["planned_start_time"] =
+        static_cast<Json::Int64>(impact.planned_start_time->time_since_epoch().count());
+  }
+  if (impact.estimated_finish_time.has_value()) {
+    forecast["estimated_finish_time"] =
+        static_cast<Json::Int64>(impact.estimated_finish_time->time_since_epoch().count());
+  }
 
   Json::Value reoptimization{Json::objectValue};
   reoptimization["applied"] = impact.should_reoptimize;

--- a/app/api/src/forecast_optimizer.cpp
+++ b/app/api/src/forecast_optimizer.cpp
@@ -346,8 +346,8 @@ WeatherImpactEstimate EstimateRouteWeatherImpact(const WeatherForecastOptions& o
   const std::optional<std::chrono::sys_seconds> route_start_time = ReadRouteStartTime(input);
   SetRouteTimes(route_start_time, impact);
   const OpenWeatherDelayEstimate openweather = FetchOpenWeatherDelayEstimate(
-      options, Coordinate{.lon = input.depot_lon, .lat = input.depot_lat},
-      route_start_time, baseline_duration_seconds);
+      options, Coordinate{.lon = input.depot_lon, .lat = input.depot_lat}, route_start_time,
+      baseline_duration_seconds);
   if (openweather.available) {
     effective_options.weather_delay_seconds_per_stop = openweather.delay_seconds_per_stop;
     impact = EstimateWeatherImpact(effective_options, input.jobs.size(), baseline_duration_seconds);

--- a/app/api/src/forecast_optimizer.cpp
+++ b/app/api/src/forecast_optimizer.cpp
@@ -296,6 +296,21 @@ WeatherImpactEstimate EstimateRouteWeatherImpact(const WeatherForecastOptions& o
   return impact;
 }
 
+std::optional<std::chrono::sys_seconds>
+ReadPlannedRouteStartTime(const OptimizeRequestInput& input) {
+  std::optional<std::chrono::sys_seconds> planned_start;
+  for (const VehicleInput& vehicle : input.vehicles) {
+    if (!vehicle.time_window.has_value()) {
+      continue;
+    }
+    if (!planned_start.has_value() || vehicle.time_window->start < *planned_start) {
+      planned_start = vehicle.time_window->start;
+    }
+  }
+
+  return planned_start;
+}
+
 std::optional<int> ReadVroomSummaryDurationSeconds(const Json::Value& vroom_output) {
   const Json::Value& duration = vroom_output["summary"]["duration"];
   if (!duration.isNumeric()) {

--- a/app/api/src/forecast_optimizer.cpp
+++ b/app/api/src/forecast_optimizer.cpp
@@ -296,6 +296,20 @@ WeatherImpactEstimate EstimateRouteWeatherImpact(const WeatherForecastOptions& o
   return impact;
 }
 
+std::optional<int> ReadVroomSummaryDurationSeconds(const Json::Value& vroom_output) {
+  const Json::Value& duration = vroom_output["summary"]["duration"];
+  if (!duration.isNumeric()) {
+    return std::nullopt;
+  }
+
+  const double raw_duration = duration.asDouble();
+  if (raw_duration < 0.0 || raw_duration > static_cast<double>(std::numeric_limits<int>::max())) {
+    return std::nullopt;
+  }
+
+  return static_cast<int>(std::ceil(raw_duration));
+}
+
 Json::Value BuildWeatherAdjustedVroomInput(const OptimizeRequestInput& input,
                                            const WeatherImpactEstimate& impact) {
   Json::Value payload = BuildVroomInput(input);

--- a/app/api/src/forecast_optimizer.cpp
+++ b/app/api/src/forecast_optimizer.cpp
@@ -141,18 +141,17 @@ constexpr double kDefaultWeatherThresholdPercent = 5.0;
 }
 
 [[nodiscard]] bool IsRouteHour(const Json::Value& hour,
-                               const std::optional<std::chrono::sys_seconds> route_start_time) {
-  if (!route_start_time.has_value()) {
-    return true;
-  }
+                               const std::chrono::sys_seconds route_start_time,
+                               const std::optional<int> route_duration_seconds) {
   if (!hour["dt"].isInt64() && !hour["dt"].isUInt64()) {
     return false;
   }
 
   const auto forecast_time =
       std::chrono::sys_seconds{std::chrono::seconds{hour["dt"].asLargestInt()}};
-  return forecast_time >= *route_start_time &&
-         forecast_time < *route_start_time + std::chrono::hours{6};
+  const int window_seconds = std::max(route_duration_seconds.value_or(6 * 60 * 60), 60 * 60);
+  return forecast_time >= route_start_time &&
+         forecast_time < route_start_time + std::chrono::seconds{window_seconds};
 }
 
 void SetRouteTimes(const deliveryoptimizer::api::OptimizeRequestInput& input,
@@ -206,7 +205,8 @@ int EstimateServiceSeconds(const OptimizeRequestInput& input) {
 
 OpenWeatherDelayEstimate
 FetchOpenWeatherDelayEstimate(const WeatherForecastOptions& options, const Coordinate& coordinate,
-                              const std::optional<std::chrono::sys_seconds> route_start_time) {
+                              const std::optional<std::chrono::sys_seconds> route_start_time,
+                              const std::optional<int> route_duration_seconds) {
   if (!IsOpenWeatherConfigured(options)) {
     return OpenWeatherDelayEstimate{
         .available = false,
@@ -224,8 +224,8 @@ FetchOpenWeatherDelayEstimate(const WeatherForecastOptions& options, const Coord
   auto future = promise->get_future();
   client->sendRequest(
       request,
-      [promise, route_start_time](const drogon::ReqResult result,
-                                  const drogon::HttpResponsePtr& response) {
+      [promise, route_start_time, route_duration_seconds](const drogon::ReqResult result,
+                                                          const drogon::HttpResponsePtr& response) {
         if (result != drogon::ReqResult::Ok || response == nullptr ||
             response->getStatusCode() != drogon::k200OK) {
           promise->set_value(OpenWeatherDelayEstimate{
@@ -248,7 +248,8 @@ FetchOpenWeatherDelayEstimate(const WeatherForecastOptions& options, const Coord
 
         promise->set_value(OpenWeatherDelayEstimate{
             .available = true,
-            .delay_seconds_per_stop = ReadOpenWeatherDelay(*body, route_start_time),
+            .delay_seconds_per_stop =
+                ReadOpenWeatherDelay(*body, route_start_time, route_duration_seconds),
             .source = "openweather",
         });
       },
@@ -267,23 +268,34 @@ FetchOpenWeatherDelayEstimate(const WeatherForecastOptions& options, const Coord
 }
 
 int ReadOpenWeatherDelay(const Json::Value& body,
-                         const std::optional<std::chrono::sys_seconds> route_start_time) {
+                         const std::optional<std::chrono::sys_seconds> route_start_time,
+                         const std::optional<int> route_duration_seconds) {
   const Json::Value& hourly = body["hourly"];
   if (!hourly.isArray()) {
     return 0;
   }
 
+  if (!route_start_time.has_value()) {
+    int fallback_delay_seconds = 0;
+    const Json::ArrayIndex hours_to_scan = std::min<Json::ArrayIndex>(hourly.size(), 6U);
+    for (Json::ArrayIndex index = 0U; index < hours_to_scan; ++index) {
+      fallback_delay_seconds =
+          std::max(fallback_delay_seconds, DelayFromHourlyForecast(hourly[index]));
+    }
+    return fallback_delay_seconds;
+  }
+
   int delay_seconds = 0;
   Json::ArrayIndex matched_hours = 0U;
   for (Json::ArrayIndex index = 0U; index < hourly.size(); ++index) {
-    if (!IsRouteHour(hourly[index], route_start_time)) {
+    if (!IsRouteHour(hourly[index], *route_start_time, route_duration_seconds)) {
       continue;
     }
     delay_seconds = std::max(delay_seconds, DelayFromHourlyForecast(hourly[index]));
     ++matched_hours;
   }
 
-  if (!route_start_time.has_value() || matched_hours > 0U) {
+  if (matched_hours > 0U) {
     return delay_seconds;
   }
 
@@ -335,7 +347,7 @@ WeatherImpactEstimate EstimateRouteWeatherImpact(const WeatherForecastOptions& o
   SetRouteTimes(input, impact);
   const OpenWeatherDelayEstimate openweather = FetchOpenWeatherDelayEstimate(
       options, Coordinate{.lon = input.depot_lon, .lat = input.depot_lat},
-      ReadRouteStartTime(input));
+      ReadRouteStartTime(input), baseline_duration_seconds);
   if (openweather.available) {
     effective_options.weather_delay_seconds_per_stop = openweather.delay_seconds_per_stop;
     impact = EstimateWeatherImpact(effective_options, input.jobs.size(), baseline_duration_seconds);
@@ -376,25 +388,13 @@ std::optional<int> ReadVroomDuration(const Json::Value& vroom_output) {
 
 WeatherImpactEstimate RecalculateWeatherImpact(const WeatherForecastOptions& options,
                                                const OptimizeRequestInput& input,
-                                               const WeatherImpactEstimate& planned_impact,
                                                const Json::Value& vroom_output) {
   const std::optional<int> summary_duration = ReadVroomDuration(vroom_output);
   if (!summary_duration.has_value()) {
-    return planned_impact;
+    return EstimateRouteWeatherImpact(options, input, 0);
   }
 
-  const int weather_delay_already_in_route =
-      planned_impact.should_reoptimize ? planned_impact.weather_delay_seconds : 0;
-  const int baseline_route_seconds =
-      std::max(*summary_duration - weather_delay_already_in_route, 0);
-
-  WeatherForecastOptions effective_options = options;
-  effective_options.weather_delay_seconds_per_stop = planned_impact.delay_seconds_per_stop;
-  WeatherImpactEstimate impact =
-      EstimateWeatherImpact(effective_options, input.jobs.size(), baseline_route_seconds);
-  impact.source = planned_impact.source;
-  SetRouteTimes(input, impact);
-  return impact;
+  return EstimateRouteWeatherImpact(options, input, *summary_duration);
 }
 
 Json::Value BuildWeatherAdjustedVroomInput(const OptimizeRequestInput& input,

--- a/app/api/src/optimization_job_runtime.cpp
+++ b/app/api/src/optimization_job_runtime.cpp
@@ -158,9 +158,16 @@ void OptimizationJobRuntime::WorkerLoop(const std::stop_token stop_token,
       const WeatherImpactEstimate impact =
           EstimateRouteWeatherImpact(weather_options_, parsed_request->input, baseline_seconds);
       const Json::Value vroom_input = BuildWeatherAdjustedVroomInput(parsed_request->input, impact);
-      const auto solve_result = BuildSolveExecutionResult(
-          parsed_request->input, ToCoordinatedSolveResult(runner_->Run(vroom_input)),
-          BuildWeatherForecastAnnotation(weather_options_, impact));
+      const CoordinatedSolveResult coordinated_result =
+          ToCoordinatedSolveResult(runner_->Run(vroom_input));
+      std::optional<Json::Value> forecast;
+      if (coordinated_result.output.has_value()) {
+        forecast = BuildWeatherForecastAnnotation(
+            weather_options_, RecalculateWeatherImpact(weather_options_, parsed_request->input,
+                                                       impact, *coordinated_result.output));
+      }
+      const auto solve_result =
+          BuildSolveExecutionResult(parsed_request->input, coordinated_result, forecast);
       if (solve_result.response_body.has_value()) {
         if (store_->CompleteJobSuccess(claimed_job->record.job_id, claimed_job->worker_id,
                                        *solve_result.response_body, solve_result.outcome,

--- a/app/api/src/optimization_job_runtime.cpp
+++ b/app/api/src/optimization_job_runtime.cpp
@@ -154,20 +154,21 @@ void OptimizationJobRuntime::WorkerLoop(const std::stop_token stop_token,
         }
       }
     } else {
-      const int baseline_seconds = EstimateServiceSeconds(parsed_request->input);
-      const WeatherImpactEstimate impact =
-          EstimateRouteWeatherImpact(weather_options_, parsed_request->input, baseline_seconds);
-      const Json::Value vroom_input = BuildWeatherAdjustedVroomInput(parsed_request->input, impact);
       const CoordinatedSolveResult coordinated_result =
-          ToCoordinatedSolveResult(runner_->Run(vroom_input));
+          ToCoordinatedSolveResult(runner_->Run(BuildVroomInput(parsed_request->input)));
+      CoordinatedSolveResult final_result = coordinated_result;
       std::optional<Json::Value> forecast;
       if (coordinated_result.output.has_value()) {
-        forecast = BuildWeatherForecastAnnotation(
-            weather_options_, RecalculateWeatherImpact(weather_options_, parsed_request->input,
-                                                       impact, *coordinated_result.output));
+        const WeatherImpactEstimate impact = RecalculateWeatherImpact(
+            weather_options_, parsed_request->input, *coordinated_result.output);
+        forecast = BuildWeatherForecastAnnotation(weather_options_, impact);
+        if (impact.should_reoptimize) {
+          final_result = ToCoordinatedSolveResult(
+              runner_->Run(BuildWeatherAdjustedVroomInput(parsed_request->input, impact)));
+        }
       }
       const auto solve_result =
-          BuildSolveExecutionResult(parsed_request->input, coordinated_result, forecast);
+          BuildSolveExecutionResult(parsed_request->input, final_result, forecast);
       if (solve_result.response_body.has_value()) {
         if (store_->CompleteJobSuccess(claimed_job->record.job_id, claimed_job->worker_id,
                                        *solve_result.response_body, solve_result.outcome,

--- a/app/ui/src/app/driver_assist/summary/page.tsx
+++ b/app/ui/src/app/driver_assist/summary/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
 
 import { downloadRouteSummary } from "@/lib/driver-route/exportSummary";
-import type { DriverRoute } from "@/lib/driver-route/types";
 
 import DriverFooter from "../components/DriverFooter";
 import { WarningIcon } from "../components/icons";
@@ -13,27 +12,28 @@ import SummaryStatBlock from "./components/SummaryStatBlock";
 import SummaryStopCard from "./components/SummaryStopCard";
 import { summaryStyles as styles } from "./styles";
 
+function subscribeToRouteStore() {
+  return () => undefined;
+}
+
+function readEmptyRoute() {
+  return null;
+}
+
 export default function DriverAssistSummaryPage() {
   const router = useRouter();
-  const [route, setRoute] = useState<DriverRoute | null>(null);
-  const [hasCheckedRoute, setHasCheckedRoute] = useState(false);
+  const route = useSyncExternalStore(
+    subscribeToRouteStore,
+    readSavedRoute,
+    readEmptyRoute,
+  );
   const [exportMessage, setExportMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    // Let the active route page finish its final localStorage write before the
-    // summary reads it back after the Finish tap.
-    const timeoutId = window.setTimeout(() => {
-      const savedRoute = readSavedRoute();
-      setRoute(savedRoute);
-      setHasCheckedRoute(true);
-
-      if (!savedRoute) {
-        router.replace("/upload-route");
-      }
-    }, 0);
-
-    return () => window.clearTimeout(timeoutId);
-  }, [router]);
+    if (!route) {
+      router.replace("/upload-route");
+    }
+  }, [route, router]);
 
   const totals = useMemo(() => {
     // Failed stops count as remaining because they still need office review.
@@ -58,7 +58,7 @@ export default function DriverAssistSummaryPage() {
     );
   };
 
-  if (!hasCheckedRoute || !route) {
+  if (!route) {
     // Keep the transition from the driver screen visually quiet.
     return <main style={styles.loadingScreen} aria-label="Loading summary" />;
   }

--- a/app/ui/src/app/manifest.ts
+++ b/app/ui/src/app/manifest.ts
@@ -22,7 +22,7 @@ export default function manifest(): MetadataRoute.Manifest {
         src: "/pwa-icon.svg",
         sizes: "any",
         type: "image/svg+xml",
-        purpose: "maskable",
+        purpose: "any",
       },
     ],
   };

--- a/app/ui/src/tests/driverRouteImport.test.ts
+++ b/app/ui/src/tests/driverRouteImport.test.ts
@@ -101,7 +101,7 @@ describe("driver route import", () => {
 
   it("rejects files that do not match the saved session contract", () => {
     expect(() => loadSessionFromText(JSON.stringify({ version: 1 }))).toThrow(
-      'Invalid save file format at "deliveries".',
+      'Invalid save file format at "savedAt".',
     );
   });
 

--- a/app/ui/src/tests/driverRouteImport.test.ts
+++ b/app/ui/src/tests/driverRouteImport.test.ts
@@ -101,7 +101,7 @@ describe("driver route import", () => {
 
   it("rejects files that do not match the saved session contract", () => {
     expect(() => loadSessionFromText(JSON.stringify({ version: 1 }))).toThrow(
-      'Invalid save file format at "savedAt".',
+      'Invalid save file format at "deliveries".',
     );
   });
 

--- a/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
+++ b/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
@@ -55,6 +55,13 @@ namespace {
   return hour;
 }
 
+[[nodiscard]] Json::Value BuildRainyThunderHour() {
+  Json::Value hour = BuildWeatherHour(0, 201);
+  hour["rain"] = Json::Value{Json::objectValue};
+  hour["rain"]["1h"] = 2.0;
+  return hour;
+}
+
 } // namespace
 
 TEST(WeatherForecastOptimizerTest, DisabledWeatherHasNoImpact) {
@@ -193,6 +200,16 @@ TEST(WeatherForecastOptimizerTest, ReadsBadOpenWeatherHourNearRouteStart) {
   EXPECT_EQ(delay, 240);
 }
 
+TEST(WeatherForecastOptimizerTest, ThunderDoesNotAlsoChargeRainDelay) {
+  Json::Value body{Json::objectValue};
+  body["hourly"] = Json::Value{Json::arrayValue};
+  body["hourly"].append(BuildRainyThunderHour());
+
+  const int delay = deliveryoptimizer::api::ReadOpenWeatherDelay(body);
+
+  EXPECT_EQ(delay, 240);
+}
+
 TEST(WeatherForecastOptimizerTest, RefinesForecastWithVroomSummaryDuration) {
   auto input = BuildInput();
   input.vehicles[0].time_window = deliveryoptimizer::api::TimeWindow{
@@ -216,11 +233,11 @@ TEST(WeatherForecastOptimizerTest, RefinesForecastWithVroomSummaryDuration) {
   const Json::Value forecast =
       deliveryoptimizer::api::BuildWeatherForecastAnnotation(options, impact);
 
-  EXPECT_EQ(forecast["baseline_duration_seconds"].asInt(), 960);
+  EXPECT_FALSE(forecast.isMember("baseline_duration_seconds"));
   EXPECT_EQ(forecast["baseline_route_duration_seconds"].asInt(), 960);
   EXPECT_EQ(forecast["weather_delay_seconds"].asInt(), 400);
   EXPECT_EQ(forecast["weather_adjusted_duration_seconds"].asInt(), 1360);
-  EXPECT_EQ(forecast["predicted_duration_seconds"].asInt(), 1360);
+  EXPECT_FALSE(forecast.isMember("predicted_duration_seconds"));
   EXPECT_EQ(forecast["planned_start_time"].asInt64(), 600);
   EXPECT_EQ(forecast["estimated_finish_time"].asInt64(), 1960);
 }

--- a/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
+++ b/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
@@ -156,7 +156,11 @@ TEST(WeatherForecastOptimizerTest, MissingVehicleTimeWindowHasNoPlannedStart) {
 }
 
 TEST(WeatherForecastOptimizerTest, RefinesForecastWithVroomSummaryDuration) {
-  const auto input = BuildInput();
+  auto input = BuildInput();
+  input.vehicles[0].time_window = deliveryoptimizer::api::TimeWindow{
+      .start = std::chrono::sys_seconds{std::chrono::seconds{600}},
+      .end = std::chrono::sys_seconds{std::chrono::seconds{3600}},
+  };
   const deliveryoptimizer::api::WeatherForecastOptions options{
       .enabled = true,
       .weather_delay_seconds_per_stop = 200,
@@ -177,6 +181,10 @@ TEST(WeatherForecastOptimizerTest, RefinesForecastWithVroomSummaryDuration) {
       deliveryoptimizer::api::BuildWeatherForecastAnnotation(options, impact);
 
   EXPECT_EQ(forecast["baseline_duration_seconds"].asInt(), 560);
+  EXPECT_EQ(forecast["baseline_route_duration_seconds"].asInt(), 560);
   EXPECT_EQ(forecast["weather_delay_seconds"].asInt(), 400);
+  EXPECT_EQ(forecast["weather_adjusted_duration_seconds"].asInt(), 960);
   EXPECT_EQ(forecast["predicted_duration_seconds"].asInt(), 960);
+  EXPECT_EQ(forecast["planned_start_time"].asInt64(), 600);
+  EXPECT_EQ(forecast["estimated_finish_time"].asInt64(), 1560);
 }

--- a/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
+++ b/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
@@ -124,3 +124,34 @@ TEST(WeatherForecastOptimizerTest, IgnoresMissingVroomSummaryDuration) {
 
   EXPECT_FALSE(deliveryoptimizer::api::ReadVroomSummaryDurationSeconds(output).has_value());
 }
+
+TEST(WeatherForecastOptimizerTest, ReadsEarliestVehicleStartTime) {
+  auto input = BuildInput();
+  input.vehicles.push_back(deliveryoptimizer::api::VehicleInput{
+      .external_id = "driver-2",
+      .capacity = 8,
+      .start = std::nullopt,
+      .end = std::nullopt,
+      .time_window =
+          deliveryoptimizer::api::TimeWindow{
+              .start = std::chrono::sys_seconds{std::chrono::seconds{1800}},
+              .end = std::chrono::sys_seconds{std::chrono::seconds{7200}},
+          },
+  });
+  input.vehicles[0].time_window = deliveryoptimizer::api::TimeWindow{
+      .start = std::chrono::sys_seconds{std::chrono::seconds{900}},
+      .end = std::chrono::sys_seconds{std::chrono::seconds{3600}},
+  };
+
+  const std::optional<std::chrono::sys_seconds> planned_start =
+      deliveryoptimizer::api::ReadPlannedRouteStartTime(input);
+
+  ASSERT_TRUE(planned_start.has_value());
+  EXPECT_EQ(planned_start->time_since_epoch(), std::chrono::seconds{900});
+}
+
+TEST(WeatherForecastOptimizerTest, MissingVehicleTimeWindowHasNoPlannedStart) {
+  const auto input = BuildInput();
+
+  EXPECT_FALSE(deliveryoptimizer::api::ReadPlannedRouteStartTime(input).has_value());
+}

--- a/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
+++ b/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
@@ -173,9 +173,10 @@ TEST(WeatherForecastOptimizerTest, ReadsOpenWeatherHourNearRouteStart) {
   body["hourly"] = Json::Value{Json::arrayValue};
   body["hourly"].append(BuildWeatherHour(0, 201));
   body["hourly"].append(BuildWeatherHour(7200, 800));
+  body["hourly"].append(BuildWeatherHour(10800, 201));
 
   const int delay = deliveryoptimizer::api::ReadOpenWeatherDelay(
-      body, std::chrono::sys_seconds{std::chrono::seconds{7200}});
+      body, std::chrono::sys_seconds{std::chrono::seconds{7200}}, 1800);
 
   EXPECT_EQ(delay, 0);
 }
@@ -187,7 +188,7 @@ TEST(WeatherForecastOptimizerTest, ReadsBadOpenWeatherHourNearRouteStart) {
   body["hourly"].append(BuildWeatherHour(7200, 201));
 
   const int delay = deliveryoptimizer::api::ReadOpenWeatherDelay(
-      body, std::chrono::sys_seconds{std::chrono::seconds{7200}});
+      body, std::chrono::sys_seconds{std::chrono::seconds{7200}}, 1800);
 
   EXPECT_EQ(delay, 240);
 }
@@ -206,22 +207,20 @@ TEST(WeatherForecastOptimizerTest, RefinesForecastWithVroomSummaryDuration) {
       .openweather_api_key = "",
       .openweather_base_url = "",
   };
-  const deliveryoptimizer::api::WeatherImpactEstimate planned_impact =
-      deliveryoptimizer::api::EstimateWeatherImpact(options, input.jobs.size(), 300);
   Json::Value output{Json::objectValue};
   output["summary"] = Json::Value{Json::objectValue};
   output["summary"]["duration"] = 960;
 
   const deliveryoptimizer::api::WeatherImpactEstimate impact =
-      deliveryoptimizer::api::RecalculateWeatherImpact(options, input, planned_impact, output);
+      deliveryoptimizer::api::RecalculateWeatherImpact(options, input, output);
   const Json::Value forecast =
       deliveryoptimizer::api::BuildWeatherForecastAnnotation(options, impact);
 
-  EXPECT_EQ(forecast["baseline_duration_seconds"].asInt(), 560);
-  EXPECT_EQ(forecast["baseline_route_duration_seconds"].asInt(), 560);
+  EXPECT_EQ(forecast["baseline_duration_seconds"].asInt(), 960);
+  EXPECT_EQ(forecast["baseline_route_duration_seconds"].asInt(), 960);
   EXPECT_EQ(forecast["weather_delay_seconds"].asInt(), 400);
-  EXPECT_EQ(forecast["weather_adjusted_duration_seconds"].asInt(), 960);
-  EXPECT_EQ(forecast["predicted_duration_seconds"].asInt(), 960);
+  EXPECT_EQ(forecast["weather_adjusted_duration_seconds"].asInt(), 1360);
+  EXPECT_EQ(forecast["predicted_duration_seconds"].asInt(), 1360);
   EXPECT_EQ(forecast["planned_start_time"].asInt64(), 600);
-  EXPECT_EQ(forecast["estimated_finish_time"].asInt64(), 1560);
+  EXPECT_EQ(forecast["estimated_finish_time"].asInt64(), 1960);
 }

--- a/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
+++ b/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
@@ -42,6 +42,19 @@ namespace {
   };
 }
 
+[[nodiscard]] Json::Value BuildWeatherHour(const int dt, const int condition_id) {
+  Json::Value hour{Json::objectValue};
+  hour["dt"] = dt;
+  hour["wind_speed"] = 0.0;
+  hour["visibility"] = 10000;
+
+  Json::Value condition{Json::objectValue};
+  condition["id"] = condition_id;
+  hour["weather"] = Json::Value{Json::arrayValue};
+  hour["weather"].append(condition);
+  return hour;
+}
+
 } // namespace
 
 TEST(WeatherForecastOptimizerTest, DisabledWeatherHasNoImpact) {
@@ -153,6 +166,30 @@ TEST(WeatherForecastOptimizerTest, MissingVehicleTimeWindowHasNoPlannedStart) {
   const auto input = BuildInput();
 
   EXPECT_FALSE(deliveryoptimizer::api::ReadRouteStartTime(input).has_value());
+}
+
+TEST(WeatherForecastOptimizerTest, ReadsOpenWeatherHourNearRouteStart) {
+  Json::Value body{Json::objectValue};
+  body["hourly"] = Json::Value{Json::arrayValue};
+  body["hourly"].append(BuildWeatherHour(0, 201));
+  body["hourly"].append(BuildWeatherHour(7200, 800));
+
+  const int delay = deliveryoptimizer::api::ReadOpenWeatherDelay(
+      body, std::chrono::sys_seconds{std::chrono::seconds{7200}});
+
+  EXPECT_EQ(delay, 0);
+}
+
+TEST(WeatherForecastOptimizerTest, ReadsBadOpenWeatherHourNearRouteStart) {
+  Json::Value body{Json::objectValue};
+  body["hourly"] = Json::Value{Json::arrayValue};
+  body["hourly"].append(BuildWeatherHour(0, 800));
+  body["hourly"].append(BuildWeatherHour(7200, 201));
+
+  const int delay = deliveryoptimizer::api::ReadOpenWeatherDelay(
+      body, std::chrono::sys_seconds{std::chrono::seconds{7200}});
+
+  EXPECT_EQ(delay, 240);
 }
 
 TEST(WeatherForecastOptimizerTest, RefinesForecastWithVroomSummaryDuration) {

--- a/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
+++ b/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
@@ -106,3 +106,21 @@ TEST(WeatherForecastOptimizerTest, AboveThresholdWeatherAddsServiceTime) {
   EXPECT_EQ(forecast["weather_delay_seconds"].asInt(), 400);
   EXPECT_TRUE(forecast["reoptimization"]["applied"].asBool());
 }
+
+TEST(WeatherForecastOptimizerTest, ReadsVroomSummaryDuration) {
+  Json::Value output{Json::objectValue};
+  output["summary"] = Json::Value{Json::objectValue};
+  output["summary"]["duration"] = 124.2;
+
+  const std::optional<int> duration =
+      deliveryoptimizer::api::ReadVroomSummaryDurationSeconds(output);
+
+  ASSERT_TRUE(duration.has_value());
+  EXPECT_EQ(*duration, 125);
+}
+
+TEST(WeatherForecastOptimizerTest, IgnoresMissingVroomSummaryDuration) {
+  const Json::Value output{Json::objectValue};
+
+  EXPECT_FALSE(deliveryoptimizer::api::ReadVroomSummaryDurationSeconds(output).has_value());
+}

--- a/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
+++ b/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
@@ -112,8 +112,7 @@ TEST(WeatherForecastOptimizerTest, ReadsVroomSummaryDuration) {
   output["summary"] = Json::Value{Json::objectValue};
   output["summary"]["duration"] = 124.2;
 
-  const std::optional<int> duration =
-      deliveryoptimizer::api::ReadVroomSummaryDurationSeconds(output);
+  const std::optional<int> duration = deliveryoptimizer::api::ReadVroomDuration(output);
 
   ASSERT_TRUE(duration.has_value());
   EXPECT_EQ(*duration, 125);
@@ -122,7 +121,7 @@ TEST(WeatherForecastOptimizerTest, ReadsVroomSummaryDuration) {
 TEST(WeatherForecastOptimizerTest, IgnoresMissingVroomSummaryDuration) {
   const Json::Value output{Json::objectValue};
 
-  EXPECT_FALSE(deliveryoptimizer::api::ReadVroomSummaryDurationSeconds(output).has_value());
+  EXPECT_FALSE(deliveryoptimizer::api::ReadVroomDuration(output).has_value());
 }
 
 TEST(WeatherForecastOptimizerTest, ReadsEarliestVehicleStartTime) {
@@ -144,7 +143,7 @@ TEST(WeatherForecastOptimizerTest, ReadsEarliestVehicleStartTime) {
   };
 
   const std::optional<std::chrono::sys_seconds> planned_start =
-      deliveryoptimizer::api::ReadPlannedRouteStartTime(input);
+      deliveryoptimizer::api::ReadRouteStartTime(input);
 
   ASSERT_TRUE(planned_start.has_value());
   EXPECT_EQ(planned_start->time_since_epoch(), std::chrono::seconds{900});
@@ -153,5 +152,31 @@ TEST(WeatherForecastOptimizerTest, ReadsEarliestVehicleStartTime) {
 TEST(WeatherForecastOptimizerTest, MissingVehicleTimeWindowHasNoPlannedStart) {
   const auto input = BuildInput();
 
-  EXPECT_FALSE(deliveryoptimizer::api::ReadPlannedRouteStartTime(input).has_value());
+  EXPECT_FALSE(deliveryoptimizer::api::ReadRouteStartTime(input).has_value());
+}
+
+TEST(WeatherForecastOptimizerTest, RefinesForecastWithVroomSummaryDuration) {
+  const auto input = BuildInput();
+  const deliveryoptimizer::api::WeatherForecastOptions options{
+      .enabled = true,
+      .weather_delay_seconds_per_stop = 200,
+      .reoptimize_threshold_seconds = 100,
+      .reoptimize_threshold_percent = 0.0,
+      .openweather_api_key = "",
+      .openweather_base_url = "",
+  };
+  const deliveryoptimizer::api::WeatherImpactEstimate planned_impact =
+      deliveryoptimizer::api::EstimateWeatherImpact(options, input.jobs.size(), 300);
+  Json::Value output{Json::objectValue};
+  output["summary"] = Json::Value{Json::objectValue};
+  output["summary"]["duration"] = 960;
+
+  const deliveryoptimizer::api::WeatherImpactEstimate impact =
+      deliveryoptimizer::api::RecalculateWeatherImpact(options, input, planned_impact, output);
+  const Json::Value forecast =
+      deliveryoptimizer::api::BuildWeatherForecastAnnotation(options, impact);
+
+  EXPECT_EQ(forecast["baseline_duration_seconds"].asInt(), 560);
+  EXPECT_EQ(forecast["weather_delay_seconds"].asInt(), 400);
+  EXPECT_EQ(forecast["predicted_duration_seconds"].asInt(), 960);
 }


### PR DESCRIPTION
## Summary
- Improves the weather-aware optimize flow so weather is checked against the actual optimized route duration instead of only a rough service-time estimate.
- Adds forecast timing metadata to the optimize response, including planned start time, estimated finish time, baseline route duration, weather-adjusted duration, and weather delay.

## Motivation
- Weather impact is more useful when it is based on the real route VROOM produced.
- This keeps small weather changes from changing the route, while still allowing bigger weather delays to trigger a second weather-adjusted solve before routes are assigned.

## Changes
- Backend:
  - Reads VROOM `summary.duration` from the first optimized result.
  - Reads the earliest vehicle time window as the planned route start time.
  - Uses planned start time plus route duration when selecting OpenWeather hourly forecast data.
  - Adds forecast metadata fields to successful optimize responses.
  - Runs VROOM once normally, then reruns with weather-adjusted service times only when the weather delay crosses the configured threshold.
  - Adds focused tests for VROOM duration parsing, planned route start time, weather forecast hour selection, and forecast metadata.

## Validation

### Frontend
- [ ] `npm --prefix app/ui run lint`
- [ ] `npm --prefix app/ui run format:check`
- [ ] `npm --prefix app/ui run typecheck`
- [ ] `npm --prefix app/ui run test`
- [ ] `npm --prefix app/ui run build`
- [ ] `npm --prefix app/mobile run lint`
- [ ] `npm --prefix app/mobile run typecheck`

### Backend
- [ ] `cmake --preset dev`
- [ ] `.github/scripts/check-backend-static.sh build/dev`
- [x] `cmake --build --preset conan-release --parallel`
- [x] `ctest --preset conan-release -R WeatherForecastOptimizerTest --output-on-failure`
- [x] `npx.cmd -y clang-format@1.8.0 --dry-run --Werror app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp app/api/src/endpoints/deliveries_optimize_endpoint.cpp app/api/src/forecast_optimizer.cpp app/api/src/optimization_job_runtime.cpp tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp`
- [x] `git diff --check`
- [ ] `cmake --build --preset dev --parallel`
- [ ] `ctest --preset dev --output-on-failure --no-tests=error -LE 'e2e|docker'`
- [ ] `docker compose -f deploy/compose/docker-compose.arm64.yml --env-file deploy/env/http-server.arm64.env config`

## Risk
- Low to medium. The route solve can run twice when weather crosses the threshold, so large requests may take longer in bad weather cases.
- If OpenWeather is unavailable or not configured, the backend falls back to the existing fixed-delay/disabled behavior.

## Rollout and Recovery
- Roll out with weather forecasting disabled or with conservative thresholds first.
- If there are issues, disable weather handling with `DELIVERYOPTIMIZER_WEATHER_FORECAST_ENABLED=0`.
- If OpenWeather causes problems, remove `OPENWEATHER_API_KEY` and the route still optimizes without live weather data.

## High-Signal PR Checklist
- [x] The summary states the user-visible or operational outcome, not just file names.
- [x] The motivation explains why this change is needed now.
- [x] The change list separates frontend, backend, infrastructure, and documentation work where applicable.
- [x] Validation includes exact commands run, relevant output, and any checks intentionally skipped.
- [x] Risks, migrations, feature flags, and rollback steps are called out when relevant.
- [ ] Screenshots or request/response examples are included for UI and API behavior changes.