### PR TITLE
feat(edit): hi-fi redesign with CSV drag-and-drop import flow

### DIFF
--- a/app/ui/src/app/edit/components/address/CSVUploadOverlay.tsx
+++ b/app/ui/src/app/edit/components/address/CSVUploadOverlay.tsx
@@ -52,11 +52,15 @@ export default function CSVUploadOverlay({
 }: CSVUploadOverlayProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(
-    initialFile ?? null,
+    initialFile && initialFile.size <= MAX_CSV_BYTES ? initialFile : null,
   );
   const [isUploading, setIsUploading] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
-  const [fileSizeError, setFileSizeError] = useState<string | null>(null);
+  const [fileSizeError, setFileSizeError] = useState<string | null>(
+    initialFile && initialFile.size > MAX_CSV_BYTES
+      ? "Your file exceeds 10 MB. Please use a smaller file."
+      : null,
+  );
 
   function handleClose() {
     setIsUploading(false);


### PR DESCRIPTION
## Summary
This PR completes the high-fidelity redesign of the `/edit` page, migrating all components from the mid-fi `formStyles.ts` token system to the new `formStyles.v2.ts` / `edit.module.css` design token system. It also delivers a fully redesigned CSV import flow — including a new `CSVUploadOverlay`, a two-step `CSVImportModal`, drag-and-drop support at both the overlay level and the page level via `DragDropOverlay`, and hardened file-type validation with user-facing error feedback.

## Motivation

The edit page components were still rendering with mid-fi styles and an outdated, fragile CSV import path (`AddressSection` owned a hidden `<input>` and passed a raw change event up to the page). This made the import experience inconsistent, blocked the hi-fi visual rollout, and left no room for the drag-and-drop upload pattern called out in the Figma designs. A full token migration and CSV flow rewrite were needed to ship the page in its intended state.

## Changes

- `formStyles.v2.ts` / `edit.module.css`
  - Added all hi-fi design tokens for the CSV upload overlay, drag-drop overlay, optimizing modal, error overlay, manage section header, and address/vehicle sections.
  - Introduced `PAGE_V2_MAIN_OUTER` wrapper token so `DragDropOverlay` positions against a fixed-height ancestor rather than the scroll container.

- `CSVUploadOverlay.tsx` (new)
  - Hi-fi modal with a dashed drop zone, file chip, 10 MB size guard, drag-over visual state (`CSV_UPLOAD_DROP_ZONE_ACTIVE`), and `initialFile` prop so a page-level drop pre-selects the file on open.

- `CSVImportModal.tsx` (new)
  - Two-step import flow — column mapper (Step 1) and row selector (Step 2) — supporting both in-page import and navigate-and-import modes.
  - Replaces the previous single-step modal.

- `DragDropOverlay.tsx` (new hi-fi)
  - Full-body drag indicator rendered in `PAGE_V2_MAIN_OUTER` (outside the scroll container) with pointer events disabled so drag events still reach `<main>`.

- `page.tsx`
  - Wired page-level `dragenter` / `dragleave` / `dragover` / `drop` listeners on `<main>` with a `dragCount` counter (flicker-free), `pendingDropFile` state, and a `useEffect` to clear pending state when the overlay closes.
  - Non-CSV drops trigger the `uploadError` popup.
  - Added four `ErrorOverlay` instances covering optimize, parse, session, and upload errors.

- `ErrorOverlay.tsx` (new) / `ErrorPopup.tsx` (deleted)
  - Renamed and migrated from mid-fi `formStyles` tokens to hi-fi `formStyles.v2` tokens.

- `OptimizingModal.tsx`
  - Migrated to hi-fi tokens.
  - Replaced ad-hoc spinner markup with the shared `SpinnerIcon` component.

- `AddressSection.tsx`
  - Removed the hidden `<input>` file picker and raw `onCSVUpload` prop.
  - Replaced with `onOpenUploadOverlay` callback that delegates to `page.tsx`.

- `useCSVImport.ts` (new)
  - Custom RFC-4180 parser hook with JSON fallback, 10 MB size validation, and minimum-row check.
  - Replaces the removed `useCSVUpload.ts`.

- `Sidebar`, `Navbar`, `MobileNavbar`, `MobileBottomBar`, `MobileSidebar`
  - Moved outside `/edit` so both `/edit` and `/results` can share the same components.
  - Updated to hi-fi tokens.

- `vroomToRoutes.ts` / `results/types.ts` / `Map.tsx` / `Sidebar.tsx`
  - Fixed start location being silently dropped on the results page.
  - `vroomToRoutes` now accepts a `depotAddress` parameter and maps the VROOM start step into a `startLocation` field on each `Route`.
  - The results `Map` prepends the depot to each route polyline and renders a non-draggable `"S"` marker (included in `fitBounds`).
  - The results `Sidebar` renders a `"Starting point"` entry at the top of each expanded route's stop list.

## Validation

- [x] `npm --prefix app/ui run lint`
- [x] `npm --prefix app/ui run build`

Manually verified:

- Dragging a `.csv` file onto the main edit page body shows `DragDropOverlay`; on drop, `CSVUploadOverlay` opens with the file chip pre-populated.
- Dragging a non-CSV file (`.png`, `.pdf`) onto the page dismisses the overlay and shows the "This file type is not accepted" error popup.
- Clicking "Import" on the address toolbar opens `CSVUploadOverlay` with no pre-selected file; browse-file path still respects `.csv` accept filter.
- Drag-active state on the drop zone inside `CSVUploadOverlay` turns teal on hover and reverts on leave without flickering over child elements.
- `DragDropOverlay` covers the full visible main area on large screens, including below scrolled content, without covering the navbar or sidebar.
- Two-step `CSVImportModal` (column mapper → row selector) completes import and populates address cards correctly.
- `OptimizingModal` and all four error overlays render and dismiss correctly.

## Risk

Scope is large — the entire edit page rendering path has been rewritten. The core logic in `useAddresses`, `useVehicles`, `useOptimize`, and the C++ API proxy is unchanged, which limits blast radius. The main regression risk is in the CSV import flow (new hook, new two-step modal, new overlay) and in the shared sidebar/navbar components now used by `/results` as well as `/edit`. The `PAGE_V2_MAIN_OUTER` layout restructure is a targeted CSS containment change and should be safe, but deserves a layout pass on mobile.

## Rollout and Recovery

No feature flags or environment variable changes are required. The old mid-fi `formStyles.ts` can be access via the git history.