### PR TITLE
fix(cloud-run): increase request timeout to survive cold starts

### DIFF
--- a/infra/cloud-run/service.yaml
+++ b/infra/cloud-run/service.yaml
@@ -11,7 +11,7 @@ spec:
         autoscaling.knative.dev/maxScale: "4"
     spec:
       containerConcurrency: 80
-      timeoutSeconds: 60
+      timeoutSeconds: 300
       serviceAccountName: SERVICE_ACCOUNT
       containers:
         - name: api


### PR DESCRIPTION
## Summary
- Raises `timeoutSeconds` from 60s to 300s in `infra/cloud-run/service.yaml`
- Cold starts take ~99s observed (up to 260s worst-case based on probe config: OSRM 160s + API 100s), so the previous 60s timeout caused requests to fail with 404 before the instance was ever ready

## Test plan
- [ ] Merge and trigger Cloud Build from `main`
- [ ] Hit the optimize route immediately after a scale-to-zero cold start and confirm it succeeds instead of returning 404