### PR TITLE
Fixing Path Between Destinations

### DIFF
--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -129,11 +129,12 @@ function extractRoadPath(
   }
 
   const path: google.maps.LatLng[] = [];
-  for (const leg of route.legs ?? []) {
-    for (const [i, step] of (leg.steps ?? []).entries()) {
-      if (step.path?.length) {
-        path.push(...(i === 0 ? step.path : step.path.slice(1)));
-      }
+  for (const [legIndex, leg] of (route.legs ?? []).entries()) {
+    for (const [stepIndex, step] of (leg.steps ?? []).entries()) {
+      if (!step.path?.length) continue;
+      // Skip the shared boundary point between consecutive steps and legs.
+      const skipFirst = legIndex > 0 || stepIndex > 0;
+      path.push(...(skipFirst ? step.path.slice(1) : step.path));
     }
   }
   return path;
@@ -343,29 +344,13 @@ function RoutePolylinesOverlay({
     }
 
     for (const route of routes) {
+      const poly = byVehicle[route.vehicleId];
+      // Effect 1 owns polyline creation; skip until it has written a polyline.
+      if (!poly) continue;
       const committed = buildRoutePath(route, null);
       if (committed.length < 2) continue;
       const key = routeCacheKey(committed);
       const cached = directionsCacheRef.current.get(key);
-      const routeIndex = routes.findIndex(
-        (r) => r.vehicleId === route.vehicleId,
-      );
-      const strokeColor = routeColorHex(routeIndex);
-
-      let poly = byVehicle[route.vehicleId];
-      if (!poly) {
-        // Effect 1 may have cleared refs before this runs; show a path immediately.
-        const path =
-          cached && cached.path.length >= 2 ? cached.path : committed;
-        poly = new google.maps.Polyline({
-          map,
-          path,
-          ...routePolylineOptions(strokeColor),
-        });
-        byVehicle[route.vehicleId] = poly;
-        continue;
-      }
-
       if (cached && cached.path.length >= 2) {
         poly.setPath(cached.path);
       } else {

--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -129,11 +129,12 @@ function extractRoadPath(
   }
 
   const path: google.maps.LatLng[] = [];
-  for (const [legIndex, leg] of (route.legs ?? []).entries()) {
-    for (const [stepIndex, step] of (leg.steps ?? []).entries()) {
+  for (const leg of route.legs ?? []) {
+    for (const step of leg.steps ?? []) {
       if (!step.path?.length) continue;
-      // Skip the shared boundary point between consecutive steps and legs.
-      const skipFirst = legIndex > 0 || stepIndex > 0;
+      // Skip the shared boundary point only after something has been pushed,
+      // so an empty prior leg does not drop the next leg's first vertex.
+      const skipFirst = path.length > 0;
       path.push(...(skipFirst ? step.path.slice(1) : step.path));
     }
   }
@@ -307,6 +308,35 @@ function RoutePolylinesOverlay({
     };
 
     void (async () => {
+      // Immediate visual feedback for every route (cached road path or
+      // straight-line placeholder) before sequential Directions fetches resolve.
+      // Effect 1 owns creation; setRoutePolyline disposes the prior entry when
+      // the road-following polyline arrives.
+      for (
+        let routeIndex = 0;
+        routeIndex < routesSnapshot.length;
+        routeIndex += 1
+      ) {
+        if (cancelled) return;
+        const route = routesSnapshot[routeIndex]!;
+        const strokeColor = routeColorHex(routeIndex);
+        const path = buildRoutePath(route, null);
+        if (path.length < 2) continue;
+        const cached = directionsCacheRef.current.get(routeCacheKey(path));
+        if (cached && cached.path.length >= 2) {
+          setRoutePolyline(
+            route.vehicleId,
+            new google.maps.Polyline({
+              map,
+              path: cached.path,
+              ...routePolylineOptions(strokeColor),
+            }),
+          );
+        } else {
+          drawFallback(route, strokeColor);
+        }
+      }
+
       // Request one route at a time to avoid Directions API rate-limit failures.
       for (
         let routeIndex = 0;


### PR DESCRIPTION
## Summary

- Draws an immediate cached or straight-line placeholder for every route in the directions effect before sequential Google Directions fetches resolve, so multi-vehicle maps are not blank while roads load.
- Hardens `extractRoadPath` step/leg boundary dedup (`skipFirst = path.length > 0`) so empty prior legs do not drop the next leg’s first vertex.
- Keeps Effect 2 update-only (no polyline creation); Effect 1 owns creation and `setRoutePolyline` still disposes the prior line when the road-following polyline arrives.

## Motivation

- Sequential Directions requests (already on `main`) can leave later vehicles without a path for several seconds on multi-route loads.
- Review feedback asked to keep immediate visual feedback rather than removing Effect 2’s create-fallback without a replacement.
- The previous `legIndex`/`stepIndex` dedup condition could drop a real vertex after an empty-path leg; `path.length > 0` is more robust.

## Changes

### Frontend (`app/ui`)

- **`Map.tsx` only** (this PR’s full scope vs `main`)
  - Sync pass in the directions effect: for each route, draw cached road path or straight-line placeholder before the sequential `await` loop.
  - Effect 2 no longer creates polylines when the ref is empty; it only `setPath`s existing ones.
  - `extractRoadPath`: skip the shared first point of each subsequent step using `path.length > 0`.

**Out of scope / already on `main` (do not review as part of this PR)**

- `requestDrivingDirections` / native `directionsService.route()`, sequential rate-limiting, marker anchoring, `page.tsx` mock-fallback removal, `.env.example` Directions API docs, client-validation store, Save-edits pin-commit behavior.

### Backend / mobile app / infra

- No backend, mobile app, or infrastructure changes in this PR.

## Validation

### Frontend

- [x] `npm --prefix app/ui run lint`
- [x] `npm --prefix app/ui run format:check`
- [x] `npm --prefix app/ui run typecheck`
- [x] `npm --prefix app/ui run test`
- [x] `npm --prefix app/ui run build`
- [ ] `npm --prefix app/ui run test:e2e`
- [ ] `npm --prefix app/mobile run lint`
- [ ] `npm --prefix app/mobile run typecheck`

### Backend

- [ ] `cmake --preset dev`
- [ ] `.github/scripts/check-backend-static.sh build/dev`
- [ ] `cmake --build --preset dev --parallel`
- [ ] `ctest --preset dev --output-on-failure --no-tests=error -LE 'e2e|docker'`
- [ ] `docker compose -f deploy/compose/docker-compose.arm64.yml --env-file deploy/env/http-server.arm64.env config`

**Manual checks**

1. Load `/results` with multiple vehicles: every route shows a polyline immediately (straight or cached), then upgrades to road-following as Directions resolve.
2. No stacked/ghost straight lines under road polylines after fetches complete.
3. Pin drag + Save edits still updates the existing polyline path.
4. Cold cache / Directions timeout: straight-line placeholder remains via existing fallback.

## Risk

- **Low:** Single-file Map.tsx change; stop coordinates and solver output unchanged.
- Placeholder pass may briefly show straight lines before road paths replace them (intentional UX).
- `setRoutePolyline` already disposes the prior polyline on replace, so placeholders should not leak when road paths arrive.

## Rollout and Recovery

- Frontend-only deploy of `app/ui`; no migrations or feature flags.
- Roll back by reverting this PR; map returns to prior Effect 2 create-on-empty-ref behavior without the sync placeholder pass / hardened dedup.

## High-Signal PR Checklist

- [x] The summary states the user-visible or operational outcome, not just file names.
- [x] The motivation explains why this change is needed now.
- [x] The change list separates frontend, backend, infrastructure, and documentation work where applicable.
- [x] Validation includes exact commands run, relevant output, and any checks intentionally skipped.
- [x] Risks, migrations, feature flags, and rollback steps are called out when relevant.
- [ ] Screenshots or request/response examples are included for UI and API behavior changes.