### PR TITLE
Fix save session

### DIFF
--- a/app/mobile/eslint.config.js
+++ b/app/mobile/eslint.config.js
@@ -5,6 +5,19 @@ const expoConfig = require('eslint-config-expo/flat');
 module.exports = defineConfig([
   expoConfig,
   {
+    settings: {
+      'import/resolver': {
+        node: {
+          paths: [__dirname],
+          extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        },
+        typescript: {
+          project: './tsconfig.json',
+        },
+      },
+    },
+  },
+  {
     ignores: ['dist/*'],
   },
 ]);

--- a/app/ui/src/app/edit/page.tsx
+++ b/app/ui/src/app/edit/page.tsx
@@ -46,7 +46,7 @@ import {
   loadEditPageDraft,
 } from "@/lib/session/editPageDraft";
 import {
-  mapEditStateToOptimizeRequest,
+  mapEditStateToSessionSave,
   mapOptimizeRequestToEditState,
 } from "@/app/edit/utils/sessionMapper";
 import AddressOverlay, {
@@ -191,7 +191,7 @@ export default function Page() {
   const handleExportSession = useCallback(async () => {
     setSessionError(null);
     try {
-      const request = await mapEditStateToOptimizeRequest(
+      const request = await mapEditStateToSessionSave(
         vehicleState.vehicles,
         addressState.addresses,
       );

--- a/app/ui/src/app/edit/utils/sessionMapper.ts
+++ b/app/ui/src/app/edit/utils/sessionMapper.ts
@@ -1,9 +1,13 @@
 import { geocodeAddress } from "@/app/components/AddressGeocoder/utils/nominatim";
-import { secondsToTimeAMPM } from "@/app/components/AddressGeocoder/utils/timeConversion";
+import {
+  secondsToTimeAMPM,
+  timeToSeconds,
+} from "@/app/components/AddressGeocoder/utils/timeConversion";
 import { bufferSecondsToMinutes } from "@/app/edit/utils/csvParserUtils";
 import type { DeliveryInput } from "@/lib/types/delivery.types";
 import type { OptimizeRequest } from "@/lib/types/optimize.types";
 import type { VehicleInput } from "@/lib/types/vehicle.types";
+import type { SessionSaveData } from "@/lib/validation/session.schema";
 
 import {
   addressCardToDeliveryInput,
@@ -24,6 +28,55 @@ export async function mapEditStateToOptimizeRequest(
   vehicles: VehicleRow[],
   addresses: AddressCard[],
 ): Promise<OptimizeRequest> {
+  const { lockedVehicles, demandType } = validateExportableEditState(
+    vehicles,
+    addresses,
+  );
+  const vehicleInputs: VehicleInput[] = [];
+
+  for (const vehicle of lockedVehicles) {
+    const location =
+      vehicle.cachedLocation ?? (await geocodeAddress(vehicle.startLocation));
+
+    if (!location) {
+      throw new Error(
+        `Could not geocode vehicle start location "${vehicle.startLocation}".`,
+      );
+    }
+
+    vehicleInputs.push(vehicleRowToVehicleInput(vehicle, location));
+  }
+
+  const deliveryInputs = await mapAddressesToDeliveryInputs(
+    addresses,
+    demandType,
+  );
+
+  return {
+    vehicles: vehicleInputs,
+    deliveries: deliveryInputs,
+  };
+}
+
+export async function mapEditStateToSessionSave(
+  vehicles: VehicleRow[],
+  addresses: AddressCard[],
+): Promise<SessionSaveData> {
+  const { lockedVehicles, demandType } = validateExportableEditState(
+    vehicles,
+    addresses,
+  );
+
+  return {
+    vehicles: lockedVehicles.map(vehicleRowToSessionVehicleInput),
+    deliveries: await mapAddressesToDeliveryInputs(addresses, demandType),
+  };
+}
+
+function validateExportableEditState(
+  vehicles: VehicleRow[],
+  addresses: AddressCard[],
+): { lockedVehicles: LockedVehicleRow[]; demandType: CapacityUnit } {
   const unlockedVehicle = vehicles.find((vehicle) => !vehicle.locked);
   const unlockedAddress = addresses.find((address) => !address.locked);
 
@@ -58,21 +111,14 @@ export async function mapEditStateToOptimizeRequest(
   }
 
   const demandType = units[0] as CapacityUnit;
-  const vehicleInputs: VehicleInput[] = [];
 
-  for (const vehicle of lockedVehicles) {
-    const location =
-      vehicle.cachedLocation ?? (await geocodeAddress(vehicle.startLocation));
+  return { lockedVehicles, demandType };
+}
 
-    if (!location) {
-      throw new Error(
-        `Could not geocode vehicle start location "${vehicle.startLocation}".`,
-      );
-    }
-
-    vehicleInputs.push(vehicleRowToVehicleInput(vehicle, location));
-  }
-
+async function mapAddressesToDeliveryInputs(
+  addresses: AddressCard[],
+  demandType: CapacityUnit,
+): Promise<DeliveryInput[]> {
   const deliveryInputs: DeliveryInput[] = [];
 
   for (const address of addresses) {
@@ -91,13 +137,33 @@ export async function mapEditStateToOptimizeRequest(
     );
   }
 
+  return deliveryInputs;
+}
+
+function vehicleRowToSessionVehicleInput(
+  vehicle: LockedVehicleRow,
+): SessionSaveData["vehicles"][number] {
+  const departureSeconds = vehicle.departureTime
+    ? timeToSeconds(vehicle.departureTime)
+    : undefined;
+
   return {
-    vehicles: vehicleInputs,
-    deliveries: deliveryInputs,
+    id: vehicle.id,
+    vehicleType: vehicle.type,
+    driverName: vehicle.name || undefined,
+    ...(vehicle.cachedLocation && { startLocation: vehicle.cachedLocation }),
+    capacity: {
+      type: vehicle.capacityUnit,
+      value: vehicle.capacity,
+    },
+    ...(departureSeconds !== undefined && {
+      departureTime: departureSeconds,
+      returnTime: 86400,
+    }),
   };
 }
 
-export function mapOptimizeRequestToEditState(request: OptimizeRequest): {
+export function mapOptimizeRequestToEditState(request: SessionSaveData): {
   vehicles: VehicleRow[];
   addresses: AddressCard[];
 } {
@@ -115,21 +181,26 @@ export function mapOptimizeRequestToEditState(request: OptimizeRequest): {
   };
 }
 
-function mapVehicleInputToRow(vehicle: VehicleInput): VehicleRow {
+function mapVehicleInputToRow(
+  vehicle: SessionSaveData["vehicles"][number],
+): VehicleRow {
+  const startLocation = vehicle.startLocation
+    ? formatLocation(vehicle.startLocation.lat, vehicle.startLocation.lng)
+    : "";
+
   return {
     id: vehicle.id,
     locked: true,
     editingExisting: false,
     name: vehicle.driverName ?? "",
-    startLocation: formatLocation(
-      vehicle.startLocation.lat,
-      vehicle.startLocation.lng,
-    ),
-    cachedLocation: {
-      lat: vehicle.startLocation.lat,
-      lng: vehicle.startLocation.lng,
-      state: null,
-    },
+    startLocation,
+    ...(vehicle.startLocation && {
+      cachedLocation: {
+        lat: vehicle.startLocation.lat,
+        lng: vehicle.startLocation.lng,
+        state: null,
+      },
+    }),
     type: vehicle.vehicleType,
     capacityUnit: vehicle.capacity.type,
     capacity: vehicle.capacity.value,

--- a/app/ui/src/app/globals.css
+++ b/app/ui/src/app/globals.css
@@ -3,6 +3,9 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --font-geist-sans: Arial, Helvetica, sans-serif;
+  --font-geist-mono: "Courier New", Consolas, monospace;
+  --font-manrope: Arial, Helvetica, sans-serif;
 
   /* Edit / results design tokens (global so portaled modals and menus resolve them) */
   --edit-teal-300: #57ac91;

--- a/app/ui/src/app/layout.tsx
+++ b/app/ui/src/app/layout.tsx
@@ -1,23 +1,6 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import { Manrope } from "next/font/google";
 import ServiceWorkerRegistration from "@/app/components/ServiceWorkerRegistration";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
-
-const manrope = Manrope({
-  subsets: ["latin"],
-  variable: "--font-manrope",
-});
 
 export const metadata: Metadata = {
   title: {
@@ -43,9 +26,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} ${manrope.variable} antialiased`}
-      >
+      <body className="antialiased">
         <ServiceWorkerRegistration />
         {children}
       </body>

--- a/app/ui/src/lib/driver-route/importSession.ts
+++ b/app/ui/src/lib/driver-route/importSession.ts
@@ -1,6 +1,7 @@
 import { ZodError, z } from "zod";
 
 import type { DriverRoute, OptimizeRequestLike } from "./types";
+import { migrateSessionSaveFile } from "@/lib/validation/session.schema";
 
 const MAX_SESSION_FILE_BYTES = 1_000_000;
 
@@ -34,12 +35,6 @@ const optimizeRequestSchema = z.object({
   vehicles: z.array(vehicleSchema),
 });
 
-const sessionSaveV1Schema = z.object({
-  version: z.literal(1),
-  savedAt: z.string().datetime(),
-  data: optimizeRequestSchema,
-});
-
 const persistedStopSchema = z.object({
   id: z.string(),
   stopNumber: z.number(),
@@ -67,7 +62,6 @@ const persistedRouteStateSchema = z.object({
   route: persistedRouteSchema,
 });
 
-type SessionSaveFile = z.infer<typeof sessionSaveV1Schema>;
 type PersistedRouteState = z.infer<typeof persistedRouteStateSchema>;
 
 // Guard the browser import path before we spend time parsing a file.
@@ -104,7 +98,7 @@ export function loadSessionFromText(text: string): OptimizeRequestLike {
 
   try {
     // Preferred route-manager save file shape.
-    return parseSessionSaveFile(parsed).data;
+    return migrateSessionSaveFile(parsed).data;
   } catch (error) {
     try {
       // Also accept the raw optimize request shape for test fixtures and
@@ -131,10 +125,6 @@ export function createPersistedRouteState(
 
 export function parsePersistedRouteState(input: unknown): PersistedRouteState {
   return persistedRouteStateSchema.parse(input);
-}
-
-function parseSessionSaveFile(input: unknown): SessionSaveFile {
-  return sessionSaveV1Schema.parse(input);
 }
 
 function formatValidationError(error: unknown): string | null {

--- a/app/ui/src/lib/driver-route/importSession.ts
+++ b/app/ui/src/lib/driver-route/importSession.ts
@@ -1,39 +1,12 @@
 import { ZodError, z } from "zod";
 
 import type { DriverRoute, OptimizeRequestLike } from "./types";
-import { migrateSessionSaveFile } from "@/lib/validation/session.schema";
+import {
+  migrateSessionSaveFile,
+  sessionSaveDataSchema,
+} from "@/lib/validation/session.schema";
 
 const MAX_SESSION_FILE_BYTES = 1_000_000;
-
-const locationSchema = z.object({
-  lat: z.number(),
-  lng: z.number(),
-});
-
-const demandSchema = z.object({
-  value: z.number().optional(),
-});
-
-const deliverySchema = z.object({
-  id: z.number(),
-  recipientName: z.string().optional(),
-  phoneNumber: z.string().optional(),
-  address: z.string().optional(),
-  notes: z.string().optional(),
-  location: locationSchema.optional(),
-  demand: demandSchema.optional(),
-});
-
-const vehicleSchema = z.object({
-  id: z.number(),
-  driverName: z.string().optional(),
-  vehicleType: z.string().optional(),
-});
-
-const optimizeRequestSchema = z.object({
-  deliveries: z.array(deliverySchema),
-  vehicles: z.array(vehicleSchema),
-});
 
 const persistedStopSchema = z.object({
   id: z.string(),
@@ -101,9 +74,8 @@ export function loadSessionFromText(text: string): OptimizeRequestLike {
     return migrateSessionSaveFile(parsed).data;
   } catch (error) {
     try {
-      // Also accept the raw optimize request shape for test fixtures and
-      // simple hand-authored JSON files.
-      return optimizeRequestSchema.parse(parsed);
+      // Also accept the same data shape without the version/savedAt envelope.
+      return sessionSaveDataSchema.parse(parsed);
     } catch {
       throw new Error(
         formatValidationError(error) ?? "Invalid save file format.",

--- a/app/ui/src/lib/driver-route/transformSession.ts
+++ b/app/ui/src/lib/driver-route/transformSession.ts
@@ -4,8 +4,8 @@ export function transformSessionToDriverRoute(
   input: OptimizeRequestLike,
 ): DriverRoute {
   // The driver PWA only needs the ordered stops and the first assigned driver.
-  const deliveries = input.deliveries || [];
-  const firstVehicle = input.vehicles?.[0];
+  const deliveries = input.deliveries;
+  const firstVehicle = input.vehicles[0];
 
   const stops: DeliveryStop[] = deliveries.map((delivery, index) => {
     return {

--- a/app/ui/src/lib/driver-route/types.ts
+++ b/app/ui/src/lib/driver-route/types.ts
@@ -1,3 +1,5 @@
+import type { SessionSaveData } from "@/lib/validation/session.schema";
+
 export type DeliveryStatus = "pending" | "completed" | "failed";
 
 export type DeliveryStop = {
@@ -21,24 +23,4 @@ export type DriverRoute = {
   stops: DeliveryStop[];
 };
 
-export type OptimizeRequestLike = {
-  deliveries?: {
-    id: number;
-    recipientName?: string;
-    phoneNumber?: string;
-    address?: string;
-    notes?: string;
-    location?: {
-      lat: number;
-      lng: number;
-    };
-    demand?: {
-      value?: number;
-    };
-  }[];
-  vehicles?: {
-    id: number;
-    driverName?: string;
-    vehicleType?: string;
-  }[];
-};
+export type OptimizeRequestLike = SessionSaveData;

--- a/app/ui/src/lib/session/exportSession.ts
+++ b/app/ui/src/lib/session/exportSession.ts
@@ -1,6 +1,6 @@
-import type { OptimizeRequest } from "@/lib/types/optimize.types";
 import {
   sessionSaveSchema,
+  type SessionSaveData,
   type SessionSaveFile,
 } from "@/lib/validation/session.schema";
 
@@ -48,7 +48,7 @@ export function downloadJsonFile(
 }
 
 export function buildSessionSave(
-  state: OptimizeRequest,
+  state: SessionSaveData,
   now: Date = new Date(),
 ): SessionSaveFile {
   const saveFile = {
@@ -62,7 +62,7 @@ export function buildSessionSave(
 }
 
 export function downloadSessionSave(
-  state: OptimizeRequest,
+  state: SessionSaveData,
 ): SessionExportResult {
   try {
     const now = new Date();

--- a/app/ui/src/lib/session/importSession.ts
+++ b/app/ui/src/lib/session/importSession.ts
@@ -1,13 +1,15 @@
 import { ZodError } from "zod";
 
-import type { OptimizeRequest } from "@/lib/types/optimize.types";
-import { migrateSessionSaveFile } from "@/lib/validation/session.schema";
+import {
+  migrateSessionSaveFile,
+  type SessionSaveData,
+} from "@/lib/validation/session.schema";
 
 const MAX_SESSION_FILE_BYTES = 1_000_000;
 
 export async function loadSessionFromFile(
   file: File,
-): Promise<OptimizeRequest> {
+): Promise<SessionSaveData> {
   const isJson =
     file.type === "application/json" ||
     file.name.toLowerCase().endsWith(".json");

--- a/app/ui/src/lib/validation/session.schema.ts
+++ b/app/ui/src/lib/validation/session.schema.ts
@@ -1,11 +1,63 @@
 import { z } from "zod";
 
-import { optimizeRequestSchema } from "./optimize.schema";
+import { deliveriesSchema } from "./delivery.schema";
+import { locationSchema, loadSchema } from "./common.schema";
+
+const sessionVehicleSchema = z
+  .object({
+    id: z.number().int().nonnegative(),
+    vehicleType: z.enum(["truck", "car", "bicycle"]),
+    driverName: z.string().min(1).optional(),
+    startLocation: locationSchema.optional(),
+    endLocation: locationSchema.optional(),
+    capacity: loadSchema,
+    departureTime: z.number().int().nonnegative().optional(),
+    returnTime: z.number().int().nonnegative().optional(),
+  })
+  .refine(
+    (data) =>
+      (data.departureTime == null && data.returnTime == null) ||
+      (data.departureTime != null && data.returnTime != null),
+    {
+      message: "departureTime and returnTime must both be set or both omitted",
+      path: ["returnTime"],
+    },
+  )
+  .refine(
+    (data) =>
+      data.departureTime == null ||
+      data.returnTime == null ||
+      data.returnTime > data.departureTime,
+    { message: "returnTime must be after departureTime", path: ["returnTime"] },
+  );
+
+const sessionVehiclesSchema = z
+  .array(sessionVehicleSchema)
+  .superRefine((vehicles, ctx) => {
+    const seen = new Set<number>();
+
+    vehicles.forEach((vehicle, index) => {
+      if (seen.has(vehicle.id)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Duplicate vehicle id: ${vehicle.id}`,
+          path: [index, "id"],
+        });
+      }
+
+      seen.add(vehicle.id);
+    });
+  });
+
+export const sessionSaveDataSchema = z.object({
+  deliveries: deliveriesSchema.min(1),
+  vehicles: sessionVehiclesSchema.min(1),
+});
 
 export const sessionSaveV1Schema = z.object({
   version: z.literal(1),
   savedAt: z.string().datetime(),
-  data: optimizeRequestSchema,
+  data: sessionSaveDataSchema,
 });
 
 export type SessionSaveV1 = z.infer<typeof sessionSaveV1Schema>;
@@ -15,6 +67,7 @@ export const sessionSaveSchema = z.discriminatedUnion("version", [
 ]);
 
 export type SessionSaveFile = z.infer<typeof sessionSaveSchema>;
+export type SessionSaveData = z.infer<typeof sessionSaveDataSchema>;
 
 export function migrateSessionSaveFile(input: unknown): SessionSaveFile {
   const parsed = sessionSaveSchema.parse(input);

--- a/app/ui/src/tests/driverRouteImport.test.ts
+++ b/app/ui/src/tests/driverRouteImport.test.ts
@@ -2,28 +2,37 @@ import { describe, expect, it } from "vitest";
 
 import { loadSessionFromText } from "@/lib/driver-route/importSession";
 import { transformSessionToDriverRoute } from "@/lib/driver-route/transformSession";
+import { buildSessionSave } from "@/lib/session/exportSession";
 
 describe("driver route import", () => {
   it("loads a saved route-manager session into the driver_assist route shape", () => {
     const session = loadSessionFromText(
-      JSON.stringify({
-        version: 1,
-        savedAt: "2026-05-16T12:00:00.000Z",
-        data: {
-          deliveries: [
-            {
-              id: 42,
-              recipientName: "Recipient 1",
-              phoneNumber: "555-0100",
-              address: "12 Compiler Way",
-              notes: "Leave near side door",
-              location: { lat: 37.1, lng: -122.2 },
-              demand: { value: 3 },
-            },
-          ],
-          vehicles: [{ id: 7, driverName: "driver1" }],
-        },
-      }),
+      JSON.stringify(
+        buildSessionSave(
+          {
+            deliveries: [
+              {
+                id: 42,
+                recipientName: "Recipient 1",
+                phoneNumber: "555-555-0100",
+                address: "12 Compiler Way",
+                notes: "Leave near side door",
+                location: { lat: 37.1, lng: -122.2 },
+                demand: { type: "units", value: 3 },
+              },
+            ],
+            vehicles: [
+              {
+                id: 7,
+                driverName: "driver1",
+                vehicleType: "car",
+                capacity: { type: "units", value: 10 },
+              },
+            ],
+          },
+          new Date("2026-05-16T12:00:00.000Z"),
+        ),
+      ),
     );
 
     expect(transformSessionToDriverRoute(session)).toEqual({
@@ -35,7 +44,7 @@ describe("driver route import", () => {
           stopNumber: 1,
           address: "12 Compiler Way",
           customerName: "Recipient 1",
-          phoneNumber: "555-0100",
+          phoneNumber: "555-555-0100",
           packageCount: 3,
           notes: "Leave near side door",
           status: "pending",
@@ -43,6 +52,48 @@ describe("driver route import", () => {
           lng: -122.2,
           completedAt: undefined,
           failureReason: undefined,
+        },
+      ],
+    });
+  });
+
+  it("loads the same saved session shape when vehicle start location is absent", () => {
+    const session = loadSessionFromText(
+      JSON.stringify(
+        buildSessionSave(
+          {
+            deliveries: [
+              {
+                id: 11,
+                recipientName: "Recipient 3",
+                address: "500 Save St",
+                location: { lat: 34.1, lng: -118.2 },
+                demand: { type: "units", value: 2 },
+              },
+            ],
+            vehicles: [
+              {
+                id: 3,
+                driverName: "driver3",
+                vehicleType: "truck",
+                capacity: { type: "units", value: 20 },
+              },
+            ],
+          },
+          new Date("2026-05-16T12:00:00.000Z"),
+        ),
+      ),
+    );
+
+    expect(transformSessionToDriverRoute(session)).toMatchObject({
+      driverName: "driver3",
+      routeLabel: "Route 3 - 1 stops",
+      stops: [
+        {
+          id: "11",
+          customerName: "Recipient 3",
+          address: "500 Save St",
+          packageCount: 2,
         },
       ],
     });

--- a/app/ui/src/tests/driverRouteImport.test.ts
+++ b/app/ui/src/tests/driverRouteImport.test.ts
@@ -105,7 +105,7 @@ describe("driver route import", () => {
     );
   });
 
-  it("also accepts a direct optimize request JSON file", () => {
+  it("also accepts the same session data shape without the save envelope", () => {
     const session = loadSessionFromText(
       JSON.stringify({
         deliveries: [
@@ -114,9 +114,17 @@ describe("driver route import", () => {
             recipientName: "Recipient 2",
             address: "620 G St, Davis, CA 95616",
             location: { lat: 38.5464, lng: -121.7446 },
+            demand: { type: "units", value: 1 },
           },
         ],
-        vehicles: [{ id: 2, driverName: "driver2" }],
+        vehicles: [
+          {
+            id: 2,
+            driverName: "driver2",
+            vehicleType: "car",
+            capacity: { type: "units", value: 10 },
+          },
+        ],
       }),
     );
 

--- a/app/ui/src/tests/sessionMapper.test.ts
+++ b/app/ui/src/tests/sessionMapper.test.ts
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   mapEditStateToOptimizeRequest,
+  mapEditStateToSessionSave,
   mapOptimizeRequestToEditState,
 } from "@/app/edit/utils/sessionMapper";
 import { geocodeAddress } from "@/app/components/AddressGeocoder/utils/nominatim";
+import { buildSessionSave } from "@/lib/session/exportSession";
 import { loadSessionFromFile } from "@/lib/session/importSession";
 import type { OptimizeRequest } from "@/lib/types/optimize.types";
 
@@ -110,6 +112,95 @@ describe("mapOptimizeRequestToEditState", () => {
       lat: 36.1,
       lng: -115.1,
       state: "Nevada",
+    });
+  });
+
+  it("exports a save session without requiring vehicle start locations", async () => {
+    mockGeocodeAddress.mockResolvedValueOnce({
+      lat: 36.1,
+      lng: -115.1,
+      state: "Nevada",
+    });
+
+    const session = await mapEditStateToSessionSave(
+      [
+        {
+          id: 1,
+          locked: true,
+          editingExisting: false,
+          name: "Driver 1",
+          startLocation: "",
+          type: "car",
+          capacityUnit: "units",
+          capacity: 10,
+          available: true,
+          departureTime: "",
+        },
+      ],
+      [
+        {
+          id: 2,
+          locked: true,
+          editingExisting: false,
+          recipientName: "",
+          phoneNumber: "",
+          recipientAddress: "456 Delivery Ave",
+          timeBuffer: 0,
+          deliveryTimeStart: "",
+          deliveryTimeEnd: "",
+          deliveryQuantity: 3,
+          notes: "",
+        },
+      ],
+    );
+
+    expect(mockGeocodeAddress).toHaveBeenCalledTimes(1);
+    expect(mockGeocodeAddress).toHaveBeenCalledWith("456 Delivery Ave");
+    expect(session.vehicles[0]).not.toHaveProperty("startLocation");
+    expect(session.deliveries[0].location).toEqual({
+      lat: 36.1,
+      lng: -115.1,
+      state: "Nevada",
+    });
+  });
+
+  it("re-imports a saved session that omits vehicle start locations", async () => {
+    const saveFile = buildSessionSave(
+      {
+        vehicles: [
+          {
+            id: 1,
+            vehicleType: "car",
+            driverName: "Driver 1",
+            capacity: { type: "units", value: 10 },
+          },
+        ],
+        deliveries: [
+          {
+            id: 2,
+            address: "456 Delivery Ave",
+            location: { lat: 36.1, lng: -115.1 },
+            demand: { type: "units", value: 3 },
+          },
+        ],
+      },
+      new Date("2026-04-25T18:00:00.000Z"),
+    );
+    const file = new File([JSON.stringify(saveFile)], "session.json", {
+      type: "application/json",
+    });
+
+    const loaded = await loadSessionFromFile(file);
+    const state = mapOptimizeRequestToEditState(loaded);
+
+    expect(state.vehicles[0]).toMatchObject({
+      name: "Driver 1",
+      startLocation: "",
+    });
+    expect(state.vehicles[0].cachedLocation).toBeUndefined();
+    expect(state.addresses[0]).toMatchObject({
+      recipientAddress: "456 Delivery Ave",
+      cachedLocation: { lat: 36.1, lng: -115.1, state: null },
     });
   });
 


### PR DESCRIPTION
## Summary
- Root managers can now save a Manage page session even if they have not entered a route starting location yet.
- Saved session JSON now imports consistently in Manage and Driver Assist.

## Motivation
- Saving work should not require the same start-location data needed for optimization.
- Before this change, Save reused the optimize mapper, so it tried to geocode empty vehicle start locations and blocked session export.

## Changes
- Frontend:
   - Added a save-specific session mapper for /edit so Save no longer requires vehicle start locations.
   - Kept the optimize path strict, so Optimize still prompts for a starting location.
   - Updated the session save schema so vehicles[].startLocation can be absent in saved JSON.
   - Updated Manage import to restore sessions with missing vehicle start locations as blank fields.
   - Updated Driver Assist import to use the shared session JSON schema instead of its own looser copy.
   - Added regression coverage for saving and importing sessions without a start location.

- Backend: No backend changes.

## Validation

### Frontend

- [x] `npm --prefix app/ui run lint`
- [x] `npm --prefix app/ui run format:check`
- [x] `npm --prefix app/ui run typecheck`
- [x] `npm --prefix app/ui run test`
- [x] `npm --prefix app/ui run build`
- [x] `npm --prefix app/mobile run lint`
- [x] `npm --prefix app/mobile run typecheck`

### Backend

- [ ] `cmake --preset dev`
- [ ] `.github/scripts/check-backend-static.sh build/dev`
- [ ] `cmake --build --preset dev --parallel`
- [ ] `ctest --preset dev --output-on-failure --no-tests=error -LE 'e2e|docker'`
- [ ] `docker compose -f deploy/compose/docker-compose.arm64.yml --env-file deploy/env/http-server.arm64.env config`

## Risk
- Main behavior change is limited to session save/import JSON handling.
- Optimization still uses the strict optimize schema and still requires a starting location before submitting.

## Rollout and Recovery
- Roll out normally with the frontend deploy.
- If anything looks wrong, revert this PR. Existing optimize behavior should be unaffected.

## High-Signal PR Checklist
- [x] The summary states the user-visible or operational outcome, not just file names.
- [x] The motivation explains why this change is needed now.
- [x] The change list separates frontend, backend, infrastructure, and documentation work where applicable.
- [x] Validation includes exact commands run, relevant output, and any checks intentionally skipped.
- [x] Risks, migrations, feature flags, and rollback steps are called out when relevant.
- [ ] Screenshots or request/response examples are included for UI and API behavior changes.

## Releated Issues
https://github.com/benevolentbandwidth/delivery-optimizer/issues/197
- [x] Saving from the Manage page with all info filled but no starting location succeeds and no longer shows the "starting location not entered" error.
- [x] A session saved without a start location can be re-imported on the Manage page.
- [x] Optimization still prompts for / requires a starting location (unchanged behavior).
- [x] Regression test added covering save without a start location.