### PR TITLE
Saving Marker Location After Edit

### DIFF
--- a/app/ui/.env.example
+++ b/app/ui/.env.example
@@ -1,4 +1,5 @@
 # Copy to .env.local and fill in your values (get key + Map ID from Google Cloud Console)
+# Enable "Maps JavaScript API" and "Directions API" for the key used below.
 NEXT_PUBLIC_GOOGLE_MAPS_KEY=
 NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=
 # DELIVERYOPTIMIZER_API_URL=  # Cloud Run URL — only needed in production (leave unset for local dev)

--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -98,6 +98,52 @@ function routeCacheKey(path: google.maps.LatLngLiteral[]): string {
   return path.map((p) => `${p.lat.toFixed(6)},${p.lng.toFixed(6)}`).join("|");
 }
 
+function routePathsKey(routes: Route[]): string {
+  return routes
+    .map((route) => {
+      const path = buildRoutePath(route, null);
+      return `${route.vehicleId}:${routeCacheKey(path)}`;
+    })
+    .join("|");
+}
+
+function requestDrivingDirections(
+  service: google.maps.DirectionsService,
+  request: google.maps.DirectionsRequest,
+): Promise<google.maps.DirectionsResult> {
+  return new Promise((resolve, reject) => {
+    service.route(request, (result, status) => {
+      if (status === google.maps.DirectionsStatus.OK && result) {
+        resolve(result);
+        return;
+      }
+      reject(new Error(`Directions request failed: ${status}`));
+    });
+  });
+}
+
+/** Prefer overview_path; fall back to leg step paths when overview is missing. */
+function extractRoadPath(
+  result: google.maps.DirectionsResult,
+): google.maps.LatLng[] {
+  const route = result.routes[0];
+  if (!route) return [];
+
+  if (route.overview_path && route.overview_path.length >= 2) {
+    return route.overview_path;
+  }
+
+  const path: google.maps.LatLng[] = [];
+  for (const leg of route.legs ?? []) {
+    for (const step of leg.steps ?? []) {
+      if (step.path?.length) {
+        path.push(...step.path);
+      }
+    }
+  }
+  return path;
+}
+
 function buildRoutePath(
   route: Route,
   pendingPinMove: PendingPinMove | null,
@@ -135,10 +181,22 @@ function RoutePolylinesOverlay({
     {},
   );
   const directionsCacheRef = useRef(new Map<string, CachedDirections>());
+  const onRouteDistanceUpdateRef = useRef(onRouteDistanceUpdate);
+  const routesRef = useRef(routes);
+  const routesPathKey = useMemo(() => routePathsKey(routes), [routes]);
+
+  useEffect(() => {
+    routesRef.current = routes;
+  }, [routes]);
+
+  useEffect(() => {
+    onRouteDistanceUpdateRef.current = onRouteDistanceUpdate;
+  }, [onRouteDistanceUpdate]);
 
   useEffect(() => {
     if (!map || typeof google === "undefined") return;
 
+    const routesSnapshot = routesRef.current;
     Object.values(polylinesByVehicleRef.current).forEach((p) => p.setMap(null));
     polylinesByVehicleRef.current = {};
 
@@ -157,87 +215,96 @@ function RoutePolylinesOverlay({
       polylinesByVehicleRef.current[route.vehicleId] = fallbackPoly;
     };
 
-    void Promise.allSettled(
-      routes.map(async (route, routeIndex) => {
-        const strokeColor = routeColorHex(routeIndex);
-        const path = buildRoutePath(route, null);
-        if (path.length < 2) return;
-        const origin = path[0]!;
-        const destination = path[path.length - 1]!;
+    const drawRoutePolyline = async (route: Route, routeIndex: number) => {
+      const strokeColor = routeColorHex(routeIndex);
+      const path = buildRoutePath(route, null);
+      if (path.length < 2) return;
 
-        const waypoints = path
-          .slice(1, -1)
-          .map((location) => ({ location, stopover: true }));
-        if (waypoints.length > 25) {
-          drawFallback(route, strokeColor);
-          return;
+      const origin = path[0]!;
+      const destination = path[path.length - 1]!;
+      const waypoints = path
+        .slice(1, -1)
+        .map((location) => ({ location, stopover: true }));
+
+      if (waypoints.length > 25) {
+        drawFallback(route, strokeColor);
+        return;
+      }
+
+      const cacheKey = routeCacheKey(path);
+      const cached = directionsCacheRef.current.get(cacheKey);
+      if (cached && cached.path.length >= 2) {
+        if (cancelled) return;
+        const cachedPoly = new google.maps.Polyline({
+          map,
+          path: cached.path,
+          ...routePolylineOptions(strokeColor),
+        });
+        polylinesByVehicleRef.current[route.vehicleId] = cachedPoly;
+        if (cached.meters > 0 && onRouteDistanceUpdateRef.current) {
+          const distanceMi = Number((cached.meters / 1609.344).toFixed(1));
+          onRouteDistanceUpdateRef.current(route.vehicleId, distanceMi);
         }
+        return;
+      }
 
-        const cacheKey = routeCacheKey(path);
-        const cached = directionsCacheRef.current.get(cacheKey);
-        if (cached && cached.path.length >= 2) {
-          if (cancelled) return;
-          const cachedPoly = new google.maps.Polyline({
-            map,
-            path: cached.path,
-            ...routePolylineOptions(strokeColor),
-          });
-          polylinesByVehicleRef.current[route.vehicleId] = cachedPoly;
-          if (cancelled) return;
-          if (cached.meters > 0 && onRouteDistanceUpdate) {
-            const distanceMi = Number((cached.meters / 1609.344).toFixed(1));
-            onRouteDistanceUpdate(route.vehicleId, distanceMi);
-          }
-          return;
-        }
+      try {
+        const result = await requestDrivingDirections(directionsService, {
+          origin,
+          destination,
+          waypoints,
+          optimizeWaypoints: false,
+          travelMode: google.maps.TravelMode.DRIVING,
+        });
+        if (cancelled) return;
 
-        try {
-          const result = await directionsService.route({
-            origin,
-            destination,
-            waypoints,
-            optimizeWaypoints: false,
-            travelMode: google.maps.TravelMode.DRIVING,
-          });
-          if (cancelled) return;
-
-          const roadPath = result.routes[0]?.overview_path;
-          if (!roadPath || roadPath.length < 2) {
-            drawFallback(route, strokeColor);
-            return;
-          }
-
-          const totalMeters = (result.routes[0]?.legs ?? []).reduce(
-            (sum, leg) => sum + (leg.distance?.value ?? 0),
-            0,
-          );
-          if (cancelled) return;
-          if (totalMeters > 0 && onRouteDistanceUpdate) {
-            const distanceMi = Number((totalMeters / 1609.344).toFixed(1));
-            onRouteDistanceUpdate(route.vehicleId, distanceMi);
-          }
-          if (cancelled) return;
-
-          rememberDirections(directionsCacheRef.current, cacheKey, {
-            path: roadPath,
-            meters: totalMeters,
-          });
-
-          const roadPoly = new google.maps.Polyline({
-            map,
-            path: roadPath,
-            ...routePolylineOptions(strokeColor),
-          });
-          polylinesByVehicleRef.current[route.vehicleId] = roadPoly;
-        } catch (err) {
+        const roadPath = extractRoadPath(result);
+        if (roadPath.length < 2) {
           console.warn(
-            "[Map] DirectionsService failed, falling back to straight line:",
-            err,
+            `[Map] Directions returned no road path for vehicle ${route.vehicleId}; falling back to straight line.`,
           );
           drawFallback(route, strokeColor);
+          return;
         }
-      }),
-    );
+
+        const totalMeters = (result.routes[0]?.legs ?? []).reduce(
+          (sum, leg) => sum + (leg.distance?.value ?? 0),
+          0,
+        );
+        if (cancelled) return;
+
+        rememberDirections(directionsCacheRef.current, cacheKey, {
+          path: roadPath,
+          meters: totalMeters,
+        });
+
+        const roadPoly = new google.maps.Polyline({
+          map,
+          path: roadPath,
+          ...routePolylineOptions(strokeColor),
+        });
+        polylinesByVehicleRef.current[route.vehicleId] = roadPoly;
+
+        if (totalMeters > 0 && onRouteDistanceUpdateRef.current) {
+          const distanceMi = Number((totalMeters / 1609.344).toFixed(1));
+          onRouteDistanceUpdateRef.current(route.vehicleId, distanceMi);
+        }
+      } catch (err) {
+        console.warn(
+          `[Map] DirectionsService failed for vehicle ${route.vehicleId}, falling back to straight line:`,
+          err,
+        );
+        drawFallback(route, strokeColor);
+      }
+    };
+
+    void (async () => {
+      // Request one route at a time to avoid Directions API rate-limit failures.
+      for (let routeIndex = 0; routeIndex < routesSnapshot.length; routeIndex += 1) {
+        if (cancelled) return;
+        await drawRoutePolyline(routesSnapshot[routeIndex]!, routeIndex);
+      }
+    })();
 
     return () => {
       cancelled = true;
@@ -246,7 +313,7 @@ function RoutePolylinesOverlay({
       );
       polylinesByVehicleRef.current = {};
     };
-  }, [map, routes, onRouteDistanceUpdate]);
+  }, [map, routesPathKey]);
 
   useEffect(() => {
     if (!map || typeof google === "undefined") return;
@@ -268,13 +335,10 @@ function RoutePolylinesOverlay({
       const poly = byVehicle[route.vehicleId];
       if (!poly) continue;
       const committed = buildRoutePath(route, null);
-      if (committed.length < 2) continue;
       const key = routeCacheKey(committed);
       const cached = directionsCacheRef.current.get(key);
       if (cached && cached.path.length >= 2) {
         poly.setPath(cached.path);
-      } else {
-        poly.setPath(committed);
       }
     }
   }, [map, routes, pendingPinMove]);

--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -135,9 +135,9 @@ function extractRoadPath(
 
   const path: google.maps.LatLng[] = [];
   for (const leg of route.legs ?? []) {
-    for (const step of leg.steps ?? []) {
+    for (const [i, step] of (leg.steps ?? []).entries()) {
       if (step.path?.length) {
-        path.push(...step.path);
+        path.push(...(i === 0 ? step.path : step.path.slice(1)));
       }
     }
   }
@@ -336,13 +336,33 @@ function RoutePolylinesOverlay({
     }
 
     for (const route of routes) {
-      const poly = byVehicle[route.vehicleId];
-      if (!poly) continue;
       const committed = buildRoutePath(route, null);
+      if (committed.length < 2) continue;
       const key = routeCacheKey(committed);
       const cached = directionsCacheRef.current.get(key);
+      const routeIndex = routes.findIndex(
+        (r) => r.vehicleId === route.vehicleId,
+      );
+      const strokeColor = routeColorHex(routeIndex);
+
+      let poly = byVehicle[route.vehicleId];
+      if (!poly) {
+        // Effect 1 may have cleared refs before this runs; show a path immediately.
+        const path =
+          cached && cached.path.length >= 2 ? cached.path : committed;
+        poly = new google.maps.Polyline({
+          map,
+          path,
+          ...routePolylineOptions(strokeColor),
+        });
+        byVehicle[route.vehicleId] = poly;
+        continue;
+      }
+
       if (cached && cached.path.length >= 2) {
         poly.setPath(cached.path);
+      } else {
+        poly.setPath(committed); // straight-line until async fetch fills the cache
       }
     }
   }, [map, routes, pendingPinMove]);

--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -80,6 +80,16 @@ function routePolylineOptions(
 type CachedDirections = { path: google.maps.LatLng[]; meters: number };
 
 const MAX_DIRECTIONS_CACHE_SIZE = 100;
+const DIRECTIONS_REQUEST_TIMEOUT_MS = 10_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error("Directions request timed out")), ms),
+    ),
+  ]);
+}
 
 function rememberDirections(
   cache: Map<string, CachedDirections>,
@@ -105,21 +115,6 @@ function routePathsKey(routes: Route[]): string {
       return `${route.vehicleId}:${routeCacheKey(path)}`;
     })
     .join("|");
-}
-
-function requestDrivingDirections(
-  service: google.maps.DirectionsService,
-  request: google.maps.DirectionsRequest,
-): Promise<google.maps.DirectionsResult> {
-  return new Promise((resolve, reject) => {
-    service.route(request, (result, status) => {
-      if (status === google.maps.DirectionsStatus.OK && result) {
-        resolve(result);
-        return;
-      }
-      reject(new Error(`Directions request failed: ${status}`));
-    });
-  });
 }
 
 /** Prefer overview_path; fall back to leg step paths when overview is missing. */
@@ -249,13 +244,16 @@ function RoutePolylinesOverlay({
       }
 
       try {
-        const result = await requestDrivingDirections(directionsService, {
-          origin,
-          destination,
-          waypoints,
-          optimizeWaypoints: false,
-          travelMode: google.maps.TravelMode.DRIVING,
-        });
+        const result = await withTimeout(
+          directionsService.route({
+            origin,
+            destination,
+            waypoints,
+            optimizeWaypoints: false,
+            travelMode: google.maps.TravelMode.DRIVING,
+          }),
+          DIRECTIONS_REQUEST_TIMEOUT_MS,
+        );
         if (cancelled) return;
 
         const roadPath = extractRoadPath(result);

--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -300,7 +300,11 @@ function RoutePolylinesOverlay({
 
     void (async () => {
       // Request one route at a time to avoid Directions API rate-limit failures.
-      for (let routeIndex = 0; routeIndex < routesSnapshot.length; routeIndex += 1) {
+      for (
+        let routeIndex = 0;
+        routeIndex < routesSnapshot.length;
+        routeIndex += 1
+      ) {
         if (cancelled) return;
         await drawRoutePolyline(routesSnapshot[routeIndex]!, routeIndex);
       }

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -77,11 +77,7 @@ function readInitialRoutes(): RouteLoadResult {
 
   if (!stored) {
     cachedRouteLoadKey = cacheKey;
-    cachedRouteLoadResult = {
-      routes: [],
-      error:
-        "No optimized routes found. Please run optimize from the edit page.",
-    };
+    cachedRouteLoadResult = EMPTY_ROUTE_LOAD_RESULT;
     return cachedRouteLoadResult;
   }
 
@@ -92,11 +88,7 @@ function readInitialRoutes(): RouteLoadResult {
     return cachedRouteLoadResult;
   } catch {
     cachedRouteLoadKey = cacheKey;
-    cachedRouteLoadResult = {
-      routes: [],
-      error:
-        "Could not read saved route data. Please run optimize again from the edit page.",
-    };
+    cachedRouteLoadResult = EMPTY_ROUTE_LOAD_RESULT;
     return cachedRouteLoadResult;
   }
 }

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -225,12 +225,6 @@ export default function ResultsPage() {
     [setRoutes],
   );
 
-  const handleEditModeChange = useCallback((value: boolean) => {
-    setIsEditMode(value);
-    if (!value) setPendingPinMove(null);
-    if (value) setIsSheetExpanded(true);
-  }, []);
-
   const savePendingPinMove = useCallback(() => {
     if (!pendingPinMove) return;
     setRoutes((prev) =>
@@ -249,6 +243,18 @@ export default function ResultsPage() {
     );
     setPendingPinMove(null);
   }, [pendingPinMove, setRoutes]);
+
+  const handleEditModeChange = useCallback(
+    (value: boolean) => {
+      if (!value) {
+        savePendingPinMove();
+        setPendingPinMove(null);
+      }
+      setIsEditMode(value);
+      if (value) setIsSheetExpanded(true);
+    },
+    [savePendingPinMove],
+  );
 
   const handlePendingPinMove = useCallback(
     (vehicleId: string, stopId: string, lat: number, lng: number) => {

--- a/app/ui/src/app/results/page.tsx
+++ b/app/ui/src/app/results/page.tsx
@@ -102,18 +102,67 @@ function subscribeToRouteStorage(onChange: () => void): () => void {
   };
 }
 
+let clientValidationPending = true;
+
+function readClientValidationError(): string | null {
+  if (typeof window === "undefined" || clientValidationPending) {
+    return null;
+  }
+
+  const forceMock = MOCK_DATA_ENABLED
+    ? new URLSearchParams(window.location.search).get("mock")
+    : null;
+  if (forceMock === "1") return null;
+
+  const stored = sessionStorage.getItem("optimizeResults");
+  if (!stored) {
+    return "No optimized routes found. Please run optimize from the edit page.";
+  }
+
+  try {
+    JSON.parse(stored);
+    return null;
+  } catch {
+    return "Could not read saved route data. Please run optimize again from the edit page.";
+  }
+}
+
+function subscribeToClientValidation(onChange: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  clientValidationPending = true;
+  const hydrationId = requestAnimationFrame(() => {
+    clientValidationPending = false;
+    onChange();
+  });
+
+  window.addEventListener("storage", onChange);
+  window.addEventListener("optimize-results-updated", onChange);
+
+  return () => {
+    cancelAnimationFrame(hydrationId);
+    window.removeEventListener("storage", onChange);
+    window.removeEventListener("optimize-results-updated", onChange);
+  };
+}
+
 export default function ResultsPage() {
   const routeLoadResult = useSyncExternalStore(
     subscribeToRouteStorage,
     readInitialRoutes,
     () => EMPTY_ROUTE_LOAD_RESULT,
   );
+  const clientValidationError = useSyncExternalStore(
+    subscribeToClientValidation,
+    readClientValidationError,
+    () => null,
+  );
   const [draftRoutes, setDraftRoutes] = useState<DraftRoutesState | null>(null);
   const routes =
     draftRoutes?.source === routeLoadResult
       ? draftRoutes.routes
       : routeLoadResult.routes;
-  const error = routeLoadResult.error;
+  const error = clientValidationError;
   const routesRef = useRef(routes);
   useEffect(() => {
     routesRef.current = routes;


### PR DESCRIPTION
## Summary

- Fixes a bug where dragging a route marker and clicking **Save edits** discarded the move and snapped the marker back to its original position.
- Exiting edit mode now commits any pending pin drag to in-session `routes` state before clearing `pendingPinMove`.
- **Cancel** still discards a pending drag without saving (unchanged).

## Motivation

- **Save edits** is the primary exit-edit affordance in the sidebar/bottom sheet, but it only toggled edit mode off and called `setPendingPinMove(null)`, throwing away the drag.
- The only path that persisted a move was the contextual header **Save** button shown while a drag was pending — easy to miss.
- Users expect **Save edits** to keep their marker change; this aligns behavior with that expectation without redesigning the edit/save UX.

## Changes

### Frontend (`app/ui`)

- **`page.tsx`**
  - Reorder handlers so `savePendingPinMove` is defined before `handleEditModeChange`.
  - On exit edit mode (`value === false`), call `savePendingPinMove()` then clear `pendingPinMove`.
  - Cancel paths (`cancelPendingPinMove`, mobile Cancel with pending drag) unchanged — still discard without committing.

### Backend / mobile app / infra

- No backend, mobile app, or infrastructure changes in this PR.

## Validation

### Frontend

- [x] `npm --prefix app/ui run lint`
- [x] `npm --prefix app/ui run format:check`
- [ ] `npm --prefix app/ui run typecheck`
- [ ] `npm --prefix app/ui run test`
- [ ] `npm --prefix app/ui run build`
- [ ] `npm --prefix app/ui run test:e2e`
- [ ] `npm --prefix app/mobile run lint`
- [ ] `npm --prefix app/mobile run typecheck`

### Backend

- [ ] `cmake --preset dev`
- [ ] `.github/scripts/check-backend-static.sh build/dev`
- [ ] `cmake --build --preset dev --parallel`
- [ ] `ctest --preset dev --output-on-failure --no-tests=error -LE 'e2e|docker'`
- [ ] `docker compose -f deploy/compose/docker-compose.arm64.yml --env-file deploy/env/http-server.arm64.env config`

**Manual checks**

1. Optimize → open `/results` → **Edit** → drag a marker → **Save edits** → marker stays at new location; route polyline updates.
2. **Edit** → drag a marker → **Cancel** (header or mobile) → marker snaps back; coordinates unchanged.
3. **Edit** → drag a marker → header **Save** (contextual) → still works as before.
4. **Edit** → drag a marker → **Done editing** from export warning → pending move is committed (same exit-edit path).

## Risk

- **Low:** Single handler change in `page.tsx`; no API or persistence layer changes.
- Exiting edit mode via any `handleEditModeChange(false)` path (Save edits, export flow) now commits a pending drag — intentional and consistent with “save” semantics.
- In-session only; coordinates are not persisted to backend (out of scope).

## Rollout and Recovery

- Frontend-only deploy of `app/ui`; no migrations or feature flags.
- **Suggested base branch:** `fixing-road-path` (this branch adds one commit on top).
- Roll back by reverting this PR; Save edits will again discard pending drags.

## High-Signal PR Checklist

- [x] The summary states the user-visible or operational outcome, not just file names.
- [x] The motivation explains why this change is needed now.
- [x] The change list separates frontend, backend, infrastructure, and documentation work where applicable.
- [x] Validation includes exact commands run, relevant output, and any checks intentionally skipped.
- [x] Risks, migrations, feature flags, and rollback steps are called out when relevant.
- [ ] Screenshots or request/response examples are included for UI and API behavior changes.

Closes #196 