### PR TITLE
Displaying Return To Start Path on Route Map

### DIFF
--- a/app/ui/src/app/results/components/Map.tsx
+++ b/app/ui/src/app/results/components/Map.tsx
@@ -153,13 +153,19 @@ function buildRoutePath(
     }
     return { lat: s.lat, lng: s.lng };
   });
-  if (route.startLocation) {
-    return [
-      { lat: route.startLocation.lat, lng: route.startLocation.lng },
-      ...deliveryPoints,
-    ];
+  const points = route.startLocation
+    ? [
+        { lat: route.startLocation.lat, lng: route.startLocation.lng },
+        ...deliveryPoints,
+      ]
+    : deliveryPoints;
+  // Close the loop so the map shows the drive back home: the last stop connects
+  // to the starting point (depot, or the first stop when no depot is provided),
+  // even though the optimizer output does not include the return leg.
+  if (points.length >= 2) {
+    points.push({ ...points[0]! });
   }
-  return deliveryPoints;
+  return points;
 }
 
 function RoutePolylinesOverlay({


### PR DESCRIPTION
## Summary

- Closes each route loop on the results map so the last stop connects back to the starting point, showing the drive home even though optimizer output omits the return leg.
- Applies to road-following polylines via Google DirectionsService (return segment follows roads, not a straight line).
- With a depot/start location, the route is `depot → stops → depot`; without a depot, the first stop acts as home.

## Motivation

- Optimized routes end at the last delivery stop, but drivers need to return to the start/depot.
- The results map previously drew only the outbound path, which made routes look incomplete and understated total distance.
- Users expect the map to reflect the full round trip for planning and review.

## Changes

### Frontend (`app/ui`)

- **`Map.tsx` — `buildRoutePath`**
  - Build route points (depot + stops, or stops only when no depot).
  - Append the first point to the end of the path to close the loop.
  - All existing polyline consumers (directions fetch, cache key, straight-line fallback, pin-drag draft/committed paths) use this shared path builder, so the return leg is consistent everywhere.

### Backend / mobile app / infra

- No backend, mobile app, or infrastructure changes in this PR.

## Validation

### Frontend

- [x] `npm --prefix app/ui run lint`
- [x] `npm --prefix app/ui run format:check`
- [x] `npm --prefix app/ui run typecheck`
- [x] `npm --prefix app/ui run test`
- [x] `npm --prefix app/ui run build`
- [ ] `npm --prefix app/ui run test:e2e`
- [ ] `npm --prefix app/mobile run lint`
- [ ] `npm --prefix app/mobile run typecheck`

### Backend

- [ ] `cmake --preset dev`
- [ ] `.github/scripts/check-backend-static.sh build/dev`
- [ ] `cmake --build --preset dev --parallel`
- [ ] `ctest --preset dev --output-on-failure --no-tests=error -LE 'e2e|docker'`
- [ ] `docker compose -f deploy/compose/docker-compose.arm64.yml --env-file deploy/env/http-server.arm64.env config`

**Manual checks**

1. Optimize → open `/results`: each route polyline returns to the depot/start along roads.
2. Routes without a depot: polyline returns to the first stop.
3. Multiple vehicles: each route closes its own loop independently.
4. Edit mode pin drag: draft and committed paths still include the return leg.
5. Route distance updates reflect the added return segment.

## Risk

- **Low–medium (map rendering):** Single change in shared path builder; stop coordinates and solver output unchanged.
- **Directions API:** Return leg is included in the same directions request; may slightly increase API usage per route (one additional leg in the round trip).
- **Waypoint limit:** Routes with many stops may still hit the existing >25-waypoint straight-line fallback (unchanged behavior).
- **Distance display:** Reported route distance will increase to include the return leg (intentional).

## Rollout and Recovery

- Frontend-only deploy of `app/ui`; no migrations or feature flags.
- **Suggested base branch:** `saving-marker-location` (this branch adds one commit on top).
- Roll back by reverting this PR; polylines will end at the last stop again.

## High-Signal PR Checklist

- [x] The summary states the user-visible or operational outcome, not just file names.
- [x] The motivation explains why this change is needed now.
- [x] The change list separates frontend, backend, infrastructure, and documentation work where applicable.
- [x] Validation includes exact commands run, relevant output, and any checks intentionally skipped.
- [x] Risks, migrations, feature flags, and rollback steps are called out when relevant.
- [ ] Screenshots or request/response examples are included for UI and API behavior changes.