### PR TITLE
fix(ui): link navbar brand to landing page

### DIFF
--- a/app/ui/src/app/components/ShellNavbar.tsx
+++ b/app/ui/src/app/components/ShellNavbar.tsx
@@ -1,12 +1,30 @@
 // app/components/ShellNavbar.tsx
 "use client";
 
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
 /**
  * Minimal top bar for onboarding flow pages.
  * Uses overflow: hidden + text-overflow: ellipsis so the brand name
  * clips gracefully on narrow screens instead of overflowing.
  */
 export default function ShellNavbar() {
+  const pathname = usePathname();
+  const isLandingPage = pathname === "/";
+  const brandStyles = {
+    fontSize: "12px",
+    fontWeight: 700,
+    letterSpacing: "0.08em",
+    color: "#111",
+    textTransform: "uppercase" as const,
+    fontFamily: "inherit",
+    whiteSpace: "nowrap" as const,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    minWidth: 0,
+  };
+
   return (
     <header
       style={{
@@ -24,22 +42,17 @@ export default function ShellNavbar() {
         overflow: "hidden",
       }}
     >
-      <span
-        style={{
-          fontSize: "12px",
-          fontWeight: 700,
-          letterSpacing: "0.08em",
-          color: "#111",
-          textTransform: "uppercase",
-          fontFamily: "inherit",
-          whiteSpace: "nowrap",
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          minWidth: 0,
-        }}
-      >
-        Delivery Optimizer
-      </span>
+      {isLandingPage ? (
+        <span style={brandStyles}>Delivery Optimizer</span>
+      ) : (
+        <Link
+          href="/"
+          aria-label="Return to the Delivery Optimizer landing page"
+          style={{ ...brandStyles, textDecoration: "none" }}
+        >
+          Delivery Optimizer
+        </Link>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## Summary

- Make the navbar brand a home link on every non-landing page so users can return to the start of the delivery workflow.
- Keep the brand as non-interactive text on the landing page.

## Motivation

- Onboarding and route workflow pages did not provide a consistent way to return to the landing page from the top navigation.

## Changes

- Frontend: use the current pathname to distinguish the landing page from internal routes.
- Frontend: render an accessible Next.js link to `/` on internal routes while preserving the existing brand typography and overflow behavior.
- UI before/after: previously the brand was static text on every route; it now links home on internal routes with no visual styling change. No screenshot is included because the rendered appearance is unchanged.
- Backend, infrastructure, and documentation: no changes.

## Validation

### Frontend

- [x] `npm --prefix app/ui run lint` — passed with zero warnings.
- [x] `npm --prefix app/ui run format:check` — passed; all files match Prettier formatting.
- [x] `npm --prefix app/ui run typecheck` — passed.
- [x] `npm --prefix app/ui run test` — passed; 24 test files and 115 tests.
- [x] `npm --prefix app/ui run build` — passed; Next.js compiled and generated all 16 static pages.
- [ ] `npm --prefix app/mobile run lint` — not run; mobile is unchanged.
- [ ] `npm --prefix app/mobile run typecheck` — not run; mobile is unchanged.

Playwright end-to-end tests were not run; the focused frontend checks and production build cover this scoped navigation change.

### Backend

- [ ] `cmake --preset dev`
- [ ] `.github/scripts/check-backend-static.sh build/dev`
- [ ] `cmake --build --preset dev --parallel`
- [ ] `ctest --preset dev --output-on-failure --no-tests=error -LE 'e2e|docker'`
- [ ] `docker compose -f deploy/compose/docker-compose.arm64.yml --env-file deploy/env/http-server.arm64.env config`

Backend checks were not run because this change only affects the UI navbar component.

## Risk

- Low. The change is limited to navbar rendering and client-side navigation; it does not alter APIs, stored data, styling, or workflow state.
- The landing page intentionally remains non-interactive to avoid a self-link.

## Rollout and Recovery

- Deploy through the normal frontend release process; no migration or feature flag is required.
- Revert commit `63d383d4955b1e2349b3d0508b237f4b41f6c669` to restore the prior static brand behavior.

## High-Signal PR Checklist

- [x] The summary states the user-visible or operational outcome, not just file names.
- [x] The motivation explains why this change is needed now.
- [x] The change list separates frontend, backend, infrastructure, and documentation work where applicable.
- [x] Validation includes exact commands run, relevant output, and any checks intentionally skipped.
- [x] Risks, migrations, feature flags, and rollback steps are called out when relevant.
- [x] Screenshots, request/response examples, or before/after notes are included for behavior changes.

