### PR TITLE
chore(feedback): make reCAPTCHA optional; add CI/CD + feedback setup runbook

### DIFF
--- a/app/ui/apphosting.yaml
+++ b/app/ui/apphosting.yaml
@@ -27,15 +27,18 @@ env:
     secret: FEEDBACK_GITHUB_PRIVATE_KEY
   - variable: FEEDBACK_SCREENSHOT_BUCKET
     secret: FEEDBACK_SCREENSHOT_BUCKET
-  - variable: NEXT_PUBLIC_FEEDBACK_RECAPTCHA_SITE_KEY
-    secret: FEEDBACK_RECAPTCHA_SITE_KEY
-    availability:
-      - BUILD
-      - RUNTIME
-  - variable: FEEDBACK_RECAPTCHA_SECRET
-    secret: FEEDBACK_RECAPTCHA_SECRET
-  - variable: FEEDBACK_RECAPTCHA_MIN_SCORE
-    value: "0.5"
+  # reCAPTCHA is optional and OFF by default. The server disables verification
+  # when FEEDBACK_RECAPTCHA_SECRET is unset (see lib/feedback/security.ts).
+  # To enable: create reCAPTCHA v3 keys, put them in the FEEDBACK_RECAPTCHA_SITE_KEY
+  # and FEEDBACK_RECAPTCHA_SECRET secrets, then re-add:
+  #   - variable: NEXT_PUBLIC_FEEDBACK_RECAPTCHA_SITE_KEY
+  #     secret: FEEDBACK_RECAPTCHA_SITE_KEY
+  #     availability: [BUILD, RUNTIME]
+  #   - variable: FEEDBACK_RECAPTCHA_SECRET
+  #     secret: FEEDBACK_RECAPTCHA_SECRET
+  #   - variable: FEEDBACK_RECAPTCHA_MIN_SCORE
+  #     value: "0.5"
+  # Do NOT map these to placeholder secrets — every submission would fail with 403.
   - variable: FEEDBACK_RATE_LIMIT_WINDOW_MS
     value: "600000"
   - variable: FEEDBACK_RATE_LIMIT_MAX

--- a/docs/ci-cd-domain-feedback-setup.md
+++ b/docs/ci-cd-domain-feedback-setup.md
@@ -1,0 +1,143 @@
+# CI/CD, Custom Domain & Feedback — Setup Runbook
+
+Operator guide for the three enhancements requested for the Delivery Optimizer.
+Everything that can be done from the app/GCP data-plane is already in place; the
+steps below require **`benevolentbandwidth` org-owner rights** (GitHub app/repo
+authorization) or resources this repo's contributors can't create directly.
+
+## Environment (discovered)
+
+| Thing | Value |
+|---|---|
+| GCP project | `b2-delivery-optimizer` (Firebase-enabled) |
+| Backend (C++ API) | Cloud Run `deliveryoptimizer` @ `us-east1` → `https://deliveryoptimizer-5ts7ho5rla-ue.a.run.app` |
+| Frontend (Next.js) | Firebase **App Hosting** backend `delivery-optimizer` @ `us-east4` → `delivery-optimizer--b2-delivery-optimizer.us-east4.hosted.app`, root dir `app/ui` |
+| Build SA | `do-app-service@b2-delivery-optimizer.iam.gserviceaccount.com` |
+| App Hosting compute SA | `firebase-app-hosting-compute@b2-delivery-optimizer.iam.gserviceaccount.com` |
+| Cloud Build GitHub connections (exist, COMPLETE) | `B2-Delivery-Optimizer`, `Delivery_Optimizer` @ `us-east1` |
+| Backend build/deploy recipe | `cloudbuild.yaml` (repo root) — builds+pushes API & OSRM images, `gcloud run services replace` |
+
+---
+
+## 1) CI/CD
+
+Today both sides are deployed **manually**. There are **0 Cloud Build triggers**, and
+the App Hosting backend has **no connected repo** (deploys were `cli-firebase`).
+
+### 1a. Backend → Cloud Build trigger (recommended)
+
+The heavy C++ build already works via `cloudbuild.yaml` on Cloud Build's 8-CPU
+machine. It just needs a push trigger. The GitHub↔GCP connection already exists
+and is `COMPLETE`; the only missing piece is **repo authorization** (linking the
+repo needs GitHub *admin*, which the connection's authorizing user lacks).
+
+**Owner step (one-time, ~2 min):** authorize the repo on the existing connection:
+Cloud Build → Repositories → connection `B2-Delivery-Optimizer` →
+*Link repository* → grant the Google Cloud Build GitHub app access to
+`benevolentbandwidth/delivery-optimizer`.
+(Console: `https://console.cloud.google.com/cloud-build/repositories/2nd-gen?project=b2-delivery-optimizer`)
+
+**Then (someone with `cloudbuild.builds.editor` + `cloudbuild.connectionAdmin`, e.g. me):**
+
+```bash
+gcloud builds repositories create delivery-optimizer \
+  --remote-uri=https://github.com/benevolentbandwidth/delivery-optimizer.git \
+  --connection=B2-Delivery-Optimizer --region=us-east1 --project=b2-delivery-optimizer
+
+gcloud builds triggers create github \
+  --name=deploy-backend-main --region=us-east1 --project=b2-delivery-optimizer \
+  --repository=projects/b2-delivery-optimizer/locations/us-east1/connections/B2-Delivery-Optimizer/repositories/delivery-optimizer \
+  --branch-pattern='^main$' \
+  --build-config=cloudbuild.yaml
+```
+
+`cloudbuild.yaml` already pins `serviceAccount: do-app-service@…` and
+`logging: CLOUD_LOGGING_ONLY`, so no extra trigger flags are needed.
+
+> Shortcut: grant `eman-cickusic` **Admin** on the repo and the entire link +
+> trigger creation can be scripted with no console step.
+
+### 1b. Frontend → App Hosting auto-deploy
+
+App Hosting deploys on push once the repo is connected.
+
+**Owner step (one-time):** Firebase Console → App Hosting → backend
+`delivery-optimizer` → **Connect to GitHub** → repo
+`benevolentbandwidth/delivery-optimizer`, live branch `main`, root directory
+`app/ui`. Every push to `main` then auto-creates a rollout.
+
+---
+
+## 2) Custom domain — DEFERRED (blocked)
+
+`delivery-optimizer.benevolentbandwidth.com` can't be configured yet:
+**`benevolentbandwidth.com` is not registered/delegated** (NXDOMAIN at the `.com`
+registry as of 2026-07-13). A custom domain requires the apex domain to resolve first.
+
+When the domain is live:
+1. Firebase Console → App Hosting → `delivery-optimizer` → **Add custom domain** →
+   `delivery-optimizer.benevolentbandwidth.com`.
+2. App Hosting shows the required **A/AAAA** records + a **TXT** ownership record.
+3. Add those at whatever controls `benevolentbandwidth.com` DNS, then click Verify.
+
+---
+
+## 3) Feedback → GitHub issue
+
+Code is complete and shipped (`app/ui/src/lib/feedback/*`, API `app/ui/src/app/api/feedback/route.ts`,
+UI `FeedbackLauncher` mounted in `layout.tsx`). It uses a **GitHub App** (JWT →
+installation token → create issue), with honeypot, per-IP rate limiting, and a
+daily-shutdown guard already active. Only real credentials/secrets are missing —
+all `FEEDBACK_*` secrets currently hold the literal `"placeholder"`.
+
+Already done in this change:
+- `FEEDBACK_GITHUB_REPO` secret set to `benevolentbandwidth/delivery-optimizer`.
+- reCAPTCHA env vars removed from `apphosting.yaml` (they were mapped to placeholder
+  secrets → would 403 **every** submission). reCAPTCHA is optional; re-enable per the
+  comment left in `apphosting.yaml`.
+
+### 3a. Create + install the GitHub App (org owner)
+
+1. `https://github.com/organizations/benevolentbandwidth/settings/apps/new`
+   - **Permissions → Repository → Issues: Read and write** (that's the only one needed).
+   - Uncheck "Webhook → Active". Homepage URL can be the app URL.
+2. Create it → note the **App ID**.
+3. **Generate a private key** → downloads a `.pem`.
+4. **Install App** → only `benevolentbandwidth/delivery-optimizer` → note the
+   **Installation ID** (the number in the install settings URL, or
+   `gh api /orgs/benevolentbandwidth/installations`).
+
+### 3b. Populate secrets (needs `secretmanager.versions.add` — I have it)
+
+```bash
+P=b2-delivery-optimizer
+printf '<APP_ID>'          | gcloud secrets versions add FEEDBACK_GITHUB_APP_ID          --data-file=- --project=$P
+printf '<INSTALLATION_ID>' | gcloud secrets versions add FEEDBACK_GITHUB_INSTALLATION_ID --data-file=- --project=$P
+gcloud secrets versions add FEEDBACK_GITHUB_PRIVATE_KEY --data-file=./your-app.private-key.pem --project=$P
+```
+
+### 3c. Screenshots (optional — needs `storage.buckets.create`, owner)
+
+Text + browser diagnostics work without this. To also accept screenshot uploads:
+
+```bash
+P=b2-delivery-optimizer; B=b2-delivery-optimizer-feedback-screenshots
+gcloud storage buckets create gs://$B --project=$P --location=us-east4 --uniform-bucket-level-access
+gcloud storage buckets add-iam-policy-binding gs://$B \
+  --member=serviceAccount:firebase-app-hosting-compute@$P.iam.gserviceaccount.com \
+  --role=roles/storage.objectAdmin
+printf "$B" | gcloud secrets versions add FEEDBACK_SCREENSHOT_BUCKET --data-file=- --project=$P
+```
+
+### 3d. Roll out
+
+Ensure the compute SA can read the secrets, then redeploy so new values load:
+
+```bash
+firebase apphosting:secrets:grantaccess FEEDBACK_GITHUB_APP_ID,FEEDBACK_GITHUB_INSTALLATION_ID,FEEDBACK_GITHUB_PRIVATE_KEY,FEEDBACK_GITHUB_REPO,FEEDBACK_SCREENSHOT_BUCKET \
+  --backend delivery-optimizer --project b2-delivery-optimizer
+firebase apphosting:rollouts:create delivery-optimizer --git-branch main --project b2-delivery-optimizer
+```
+
+**Verify:** open the app → "Report bug / feedback" → submit → a new issue appears
+in `benevolentbandwidth/delivery-optimizer/issues` and the panel links to it.


### PR DESCRIPTION
Part of finishing the three Delivery Optimizer enhancements (CI/CD, custom domain, feedback → GitHub issue).

## In this PR
- **`app/ui/apphosting.yaml`** — unmap the reCAPTCHA env vars. They pointed at placeholder secrets, so every feedback submission would fail Google `siteverify` and return **403**. reCAPTCHA is optional (the server disables verification when `FEEDBACK_RECAPTCHA_SECRET` is unset — see `lib/feedback/security.ts`); inline comment documents how to re-enable.
- **`docs/ci-cd-domain-feedback-setup.md`** — operator runbook with exact commands/URLs for the remaining owner-only steps.

## Already done outside this PR (GCP)
- `FEEDBACK_GITHUB_REPO` secret set to `benevolentbandwidth/delivery-optimizer`.

## Still needs a `benevolentbandwidth` org owner (details in the runbook)
- **Backend CI/CD** — authorize this repo on the existing (COMPLETE) Cloud Build connection `B2-Delivery-Optimizer`, then create a `deploy-backend-main` trigger that runs `cloudbuild.yaml` on push to `main`.
- **Frontend CI/CD** — connect the App Hosting backend `delivery-optimizer` to this repo (branch `main`, root `app/ui`) for auto-deploy.
- **Feedback** — create + install a GitHub App (Issues: Read/Write), then populate `FEEDBACK_GITHUB_APP_ID` / `FEEDBACK_GITHUB_INSTALLATION_ID` / `FEEDBACK_GITHUB_PRIVATE_KEY` and roll out.
- **Custom domain** — deferred: `benevolentbandwidth.com` is not registered/delegated yet (NXDOMAIN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
