### PR TITLE
feat(infra): wire WhatsApp secrets into Cloud Run deploy config

### DIFF
--- a/infra/cloud-run/service.yaml
+++ b/infra/cloud-run/service.yaml
@@ -9,6 +9,7 @@ spec:
         run.googleapis.com/container-dependencies: '{"api":["osrm","postgres"]}'
         autoscaling.knative.dev/minScale: "0"
         autoscaling.knative.dev/maxScale: "4"
+        run.googleapis.com/secrets: WHATSAPP_ACCESS_TOKEN:projects/926978903214/secrets/WHATSAPP_ACCESS_TOKEN,WHATSAPP_PHONE_NUMBER_ID:projects/926978903214/secrets/WHATSAPP_PHONE_NUMBER_ID
     spec:
       containerConcurrency: 80
       timeoutSeconds: 300
@@ -31,6 +32,21 @@ spec:
               value: osrm
             - name: DELIVERYOPTIMIZER_PG_DSN
               value: host=localhost port=5432 dbname=deliveryoptimizer user=deliveryoptimizer password=deliveryoptimizer
+            - name: WHATSAPP_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: WHATSAPP_ACCESS_TOKEN
+                  key: latest
+            - name: WHATSAPP_PHONE_NUMBER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: WHATSAPP_PHONE_NUMBER_ID
+                  key: latest
+            - name: WHATSAPP_SEND_ROUTE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: WHATSAPP_SEND_ROUTE_SECRET
+                  key: latest
           resources:
             limits:
               memory: 1Gi


### PR DESCRIPTION
## Summary

Wires `WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, and `WHATSAPP_SEND_ROUTE_SECRET` into the Cloud Run `service.yaml` so the backend endpoint added in #215 actually receives credentials at runtime.

## Motivation

#215 added `POST /api/whatsapp/send-route` to the C++ backend, but the live Cloud Run service has zero secret-backed env vars — confirmed via `gcloud run services describe`. The endpoint reads `WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, and `WHATSAPP_SEND_ROUTE_SECRET` via `getenv`, and not a single one of those reaches the container today, so every call currently 503s. See #205.

## Changes

- `infra/cloud-run/service.yaml`: add the three env vars as `secretKeyRef`s on the `api` container.
- `WHATSAPP_ACCESS_TOKEN` / `WHATSAPP_PHONE_NUMBER_ID` live in the `benevolent-bandwidth` project (per Nurtekin), so they're wired cross-project via a `run.googleapis.com/secrets` alias annotation — `gcloud run services replace` rejects a full `projects/.../secrets/...` path directly in `secretKeyRef.name` (only alphanumeric/hyphen/underscore allowed), so the annotation aliases the cross-project secret to a short name first.
- `WHATSAPP_SEND_ROUTE_SECRET` lives in `b2-delivery-optimizer` and is referenced directly by short name (same-project, no alias needed).
- Also granted `do-app-service@b2-delivery-optimizer.iam.gserviceaccount.com` `roles/secretmanager.secretAccessor` on `WHATSAPP_SEND_ROUTE_SECRET` (previously only the frontend App Hosting SA had access) — done directly in Secret Manager IAM, not part of this diff.

## Validation

- [x] `python3 -c "import yaml; yaml.safe_load(open('infra/cloud-run/service.yaml'))"`
- Live deploy not yet run against this exact YAML — an earlier attempt with the pre-alias version (full `projects/.../secrets/...` path) failed with `ERROR: (gcloud.run.services.replace) ... should have only alphanumeric characters, hyphens, or underscores`, which is what prompted the annotation-based fix here. Plan is to redeploy immediately after merge and confirm the new revision comes up healthy.

## Risk

- Low: additive env vars only, no changes to existing env vars, ports, or resource limits. Worst case if the secret refs are still wrong: the new Cloud Run revision fails health checks and Cloud Run keeps serving the previous healthy revision (no traffic impact).
- Depends on `do-app-service` actually having `secretAccessor` on `WHATSAPP_ACCESS_TOKEN`/`WHATSAPP_PHONE_NUMBER_ID` in `benevolent-bandwidth` — Nurtekin confirmed this by email but it hasn't been independently verified (no access to that project's IAM from this account).

## Rollout and Recovery

- Deploy via the normal `gcloud builds submit --config=cloudbuild.yaml --substitutions=COMMIT_SHA=$(git rev-parse HEAD)` after merge.
- If the new revision fails to come up, Cloud Run automatically keeps routing traffic to the last healthy revision — no manual rollback needed. If it comes up but WhatsApp sends still fail, check `WHATSAPP_ACCESS_TOKEN`/`WHATSAPP_PHONE_NUMBER_ID` IAM in `benevolent-bandwidth` first.
