### PR TITLE
feat(edit): show an "Optimized" badge on delivery cards

### DIFF
--- a/app/ui/src/app/edit/components/address/AddressCard.tsx
+++ b/app/ui/src/app/edit/components/address/AddressCard.tsx
@@ -585,9 +585,7 @@ export default function AddressCard({
                   Recipient
                 </span>
                 {isOptimized && (
-                  <span className={ADDRESS_ROW_OPTIMIZED_BADGE}>
-                    Optimized
-                  </span>
+                  <span className={ADDRESS_ROW_OPTIMIZED_BADGE}>Optimized</span>
                 )}
               </div>
               <div className={MOBILE_ADDR_LOCKED_RECIPIENT_LINES}>

--- a/app/ui/src/app/edit/components/address/AddressCard.tsx
+++ b/app/ui/src/app/edit/components/address/AddressCard.tsx
@@ -201,6 +201,10 @@ function StepperInput({
   );
 }
 
+function OptimizedBadge() {
+  return <span className={ADDRESS_ROW_OPTIMIZED_BADGE}>Optimized</span>;
+}
+
 function AutoResizeNotesTextarea({
   value,
   onChange,
@@ -285,11 +289,7 @@ export default function AddressCard({
                 <>
                   {/* Recipient column — locked */}
                   <div className={ADDRESS_ROW_LOCKED_RECIPIENT_COL}>
-                    {isOptimized && (
-                      <span className={ADDRESS_ROW_OPTIMIZED_BADGE}>
-                        Optimized
-                      </span>
-                    )}
+                    {isOptimized && <OptimizedBadge />}
                     {hasRecipientContact(a) && (
                       <button
                         type="button"
@@ -584,9 +584,7 @@ export default function AddressCard({
                 <span className={MOBILE_ADDR_EDIT_SECTION_LABEL}>
                   Recipient
                 </span>
-                {isOptimized && (
-                  <span className={ADDRESS_ROW_OPTIMIZED_BADGE}>Optimized</span>
-                )}
+                {isOptimized && <OptimizedBadge />}
               </div>
               <div className={MOBILE_ADDR_LOCKED_RECIPIENT_LINES}>
                 {hasRecipientContact(a) && (
@@ -645,11 +643,7 @@ export default function AddressCard({
                     <span className={MOBILE_ADDR_EDIT_SECTION_LABEL}>
                       Recipient
                     </span>
-                    {isOptimized && (
-                      <span className={ADDRESS_ROW_OPTIMIZED_BADGE}>
-                        Optimized
-                      </span>
-                    )}
+                    {isOptimized && <OptimizedBadge />}
                   </div>
                   <button
                     type="button"

--- a/app/ui/src/app/edit/components/address/AddressCard.tsx
+++ b/app/ui/src/app/edit/components/address/AddressCard.tsx
@@ -49,6 +49,8 @@ import {
   ADDRESS_ROW_LOCKED_NOTES_BTN,
   ADDRESS_ROW_LOCKED_NOTES_TEXT,
   ADDRESS_ROW_GEOCODE_ERROR_LOCKED,
+  ADDRESS_ROW_OPTIMIZED_BADGE,
+  MOBILE_ADDR_RECIPIENT_LABEL_ROW,
   MOBILE_ADDR_CARD_EDIT_CONTENT,
   MOBILE_ADDR_EDIT_SECTION,
   MOBILE_ADDR_EDIT_SECTION_LABEL,
@@ -110,6 +112,7 @@ type AddressCardProps = {
   addressTouched: boolean;
   geocodeFailed: boolean;
   outOfRegionFailed: boolean;
+  isOptimized: boolean;
 };
 
 function StepperInput({
@@ -255,6 +258,7 @@ export default function AddressCard({
   addressTouched,
   geocodeFailed,
   outOfRegionFailed,
+  isOptimized,
 }: AddressCardProps) {
   const [manualExpanded, setManualExpanded] = useState(false);
   const [overlayOpen, setOverlayOpen] = useState(false);
@@ -281,6 +285,11 @@ export default function AddressCard({
                 <>
                   {/* Recipient column — locked */}
                   <div className={ADDRESS_ROW_LOCKED_RECIPIENT_COL}>
+                    {isOptimized && (
+                      <span className={ADDRESS_ROW_OPTIMIZED_BADGE}>
+                        Optimized
+                      </span>
+                    )}
                     {hasRecipientContact(a) && (
                       <button
                         type="button"
@@ -571,7 +580,16 @@ export default function AddressCard({
           /* Summarized state (Figma 8325:7892) */
           <div className={MOBILE_ADDR_SUMMARY_CONTENT}>
             <div className={MOBILE_ADDR_SUMMARY_SECTION}>
-              <span className={MOBILE_ADDR_EDIT_SECTION_LABEL}>Recipient</span>
+              <div className={MOBILE_ADDR_RECIPIENT_LABEL_ROW}>
+                <span className={MOBILE_ADDR_EDIT_SECTION_LABEL}>
+                  Recipient
+                </span>
+                {isOptimized && (
+                  <span className={ADDRESS_ROW_OPTIMIZED_BADGE}>
+                    Optimized
+                  </span>
+                )}
+              </div>
               <div className={MOBILE_ADDR_LOCKED_RECIPIENT_LINES}>
                 {hasRecipientContact(a) && (
                   <span className={MOBILE_ADDR_LOCKED_VALUE}>
@@ -625,9 +643,16 @@ export default function AddressCard({
               <div className={MOBILE_ADDR_CARD_EDIT_CONTENT}>
                 {/* Recipient */}
                 <div className={MOBILE_ADDR_EDIT_SECTION}>
-                  <span className={MOBILE_ADDR_EDIT_SECTION_LABEL}>
-                    Recipient
-                  </span>
+                  <div className={MOBILE_ADDR_RECIPIENT_LABEL_ROW}>
+                    <span className={MOBILE_ADDR_EDIT_SECTION_LABEL}>
+                      Recipient
+                    </span>
+                    {isOptimized && (
+                      <span className={ADDRESS_ROW_OPTIMIZED_BADGE}>
+                        Optimized
+                      </span>
+                    )}
+                  </div>
                   <button
                     type="button"
                     onClick={() => unlockAddress(a.id)}

--- a/app/ui/src/app/edit/components/address/AddressSection.tsx
+++ b/app/ui/src/app/edit/components/address/AddressSection.tsx
@@ -51,6 +51,7 @@ type AddressSectionProps = {
   searchQuery: string;
   setSearchQuery: (q: string) => void;
   outOfRegionIds: number[];
+  optimizedIds: number[];
   onOpenUploadOverlay: () => void;
 };
 
@@ -69,6 +70,7 @@ export default function AddressSection({
   searchQuery,
   setSearchQuery,
   outOfRegionIds,
+  optimizedIds,
   onOpenUploadOverlay,
 }: AddressSectionProps) {
   const [addressToDeleteId, setAddressToDeleteId] = useState<number | null>(
@@ -181,6 +183,7 @@ export default function AddressSection({
                   addressTouched={touchedIds.has(a.id)}
                   geocodeFailed={geocodeFailedIds.includes(a.id)}
                   outOfRegionFailed={outOfRegionIds.includes(a.id)}
+                  isOptimized={a.locked && optimizedIds.includes(a.id)}
                 />
               ))
             )}

--- a/app/ui/src/app/edit/formStyles.v2.ts
+++ b/app/ui/src/app/edit/formStyles.v2.ts
@@ -175,10 +175,6 @@ export const VEHICLE_ROW_STATUS_TEXT_AVAILABLE =
 export const VEHICLE_ROW_STATUS_TEXT_IN_USE =
   "font-semibold text-[16px] leading-[22px] text-[var(--edit-text-secondary)] whitespace-nowrap";
 
-// "Optimized" badge on delivery cards whose stop was included in the last optimize run.
-export const ADDRESS_ROW_OPTIMIZED_BADGE =
-  "self-start bg-[var(--edit-container-active)] px-2 py-[3px] rounded-[4px] font-semibold text-[12px] leading-[16px] text-[var(--edit-text-primary)] whitespace-nowrap";
-
 // Segmented toggle for Available / In use (Figma 8724:4604)
 export const STATUS_TOGGLE_WRAPPER =
   "bg-[var(--edit-stone-50)] flex gap-[4px] items-center p-[2px] rounded-[6px] w-fit";
@@ -458,6 +454,10 @@ export const ADDRESS_ROW_LOCKED_NOTES_BTN = `${ADDRESS_ROW_LOCKED_PLAIN_TEXT} ${
 
 export const ADDRESS_ROW_LOCKED_NOTES_TEXT =
   "overflow-hidden [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:3]";
+
+// "Optimized" badge on delivery cards whose stop was included in the last optimize run.
+export const ADDRESS_ROW_OPTIMIZED_BADGE =
+  "self-start bg-[var(--edit-container-active)] px-2 py-[3px] rounded-[4px] font-semibold text-[12px] leading-[16px] text-[var(--edit-text-primary)] whitespace-nowrap";
 
 export const MOBILE_LOCKED_CLICKABLE =
   "cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--edit-teal-300)]";

--- a/app/ui/src/app/edit/formStyles.v2.ts
+++ b/app/ui/src/app/edit/formStyles.v2.ts
@@ -175,6 +175,10 @@ export const VEHICLE_ROW_STATUS_TEXT_AVAILABLE =
 export const VEHICLE_ROW_STATUS_TEXT_IN_USE =
   "font-semibold text-[16px] leading-[22px] text-[var(--edit-text-secondary)] whitespace-nowrap";
 
+// "Optimized" badge on delivery cards whose stop was included in the last optimize run.
+export const ADDRESS_ROW_OPTIMIZED_BADGE =
+  "self-start bg-[var(--edit-container-active)] px-2 py-[3px] rounded-[4px] font-semibold text-[12px] leading-[16px] text-[var(--edit-text-primary)] whitespace-nowrap";
+
 // Segmented toggle for Available / In use (Figma 8724:4604)
 export const STATUS_TOGGLE_WRAPPER =
   "bg-[var(--edit-stone-50)] flex gap-[4px] items-center p-[2px] rounded-[6px] w-fit";
@@ -702,6 +706,8 @@ export const MOBILE_ADDR_EDIT_SECTION = "flex flex-col gap-2";
 
 export const MOBILE_ADDR_EDIT_SECTION_LABEL =
   "font-semibold text-[16px] leading-[1.5] text-[var(--edit-text-primary)]";
+
+export const MOBILE_ADDR_RECIPIENT_LABEL_ROW = "flex items-center gap-2";
 
 export const MOBILE_ADDR_EDIT_NAME_ROW = "flex items-center gap-2";
 

--- a/app/ui/src/app/edit/hooks/useAddresses.ts
+++ b/app/ui/src/app/edit/hooks/useAddresses.ts
@@ -2,7 +2,7 @@
  * Address list state: paged stops, lock/edit workflow, and validation for "add next".
  */
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import type { AddressCard } from "@/app/edit/types/delivery";
 import Fuse from "fuse.js";
 
@@ -10,6 +10,20 @@ export const ADDRESS_PAGE_SIZE_OPTIONS = [5, 10, 20, 30] as const;
 
 export function useAddresses() {
   const [addresses, setAddresses] = useState<AddressCard[]>([]);
+
+  // Monotonic high-water mark for address ids: never reissue an id that's
+  // already appeared, even after its address is deleted (deleted addresses
+  // can still be referenced by a stale optimize-results snapshot).
+  const highestIdRef = useRef(0);
+  useEffect(() => {
+    for (const a of addresses) {
+      if (a.id > highestIdRef.current) highestIdRef.current = a.id;
+    }
+  }, [addresses]);
+  const reserveId = useCallback(() => {
+    highestIdRef.current += 1;
+    return highestIdRef.current;
+  }, []);
 
   // Search: fuzzy filter across name, phone, address, and notes.
   const [searchQuery, _setSearchQuery] = useState("");
@@ -100,7 +114,7 @@ export function useAddresses() {
     if (addresses.length === 0) {
       setAddresses([
         {
-          id: 1,
+          id: reserveId(),
           locked: false,
           editingExisting: false,
           recipientName: "",
@@ -131,13 +145,12 @@ export function useAddresses() {
       return;
     }
 
-    const newId = addresses.reduce((max, a) => Math.max(max, a.id), 0) + 1;
     setAddresses([
       ...addresses.map((a) =>
         a.locked ? a : { ...a, locked: true, editingExisting: false },
       ),
       {
-        id: newId,
+        id: reserveId(),
         locked: false,
         editingExisting: false,
         recipientName: "",
@@ -154,7 +167,7 @@ export function useAddresses() {
     setTouchedIds(new Set());
     _setSearchQuery("");
     setAddressPage(Math.ceil((addresses.length + 1) / addressesPerPage));
-  }, [addresses, addressesPerPage]);
+  }, [addresses, addressesPerPage, reserveId]);
 
   const deleteAddress = useCallback(
     (id: number) => {
@@ -275,6 +288,7 @@ export function useAddresses() {
     unlockAddress,
     confirmAddress,
     importAddresses,
+    reserveId,
     touchedIds,
     addressPage,
     setAddressPage,

--- a/app/ui/src/app/edit/hooks/useOptimizedAddressIds.ts
+++ b/app/ui/src/app/edit/hooks/useOptimizedAddressIds.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { readOptimizedAddressIds } from "../utils/hasOptimizeResults";
+
+const emptyIds: number[] = [];
+
+/** Address ids included in the last completed optimize run (client only). */
+export function useOptimizedAddressIds(): number[] {
+  return useSyncExternalStore(
+    (onChange) => {
+      window.addEventListener("storage", onChange);
+      window.addEventListener("optimize-results-updated", onChange);
+      return () => {
+        window.removeEventListener("storage", onChange);
+        window.removeEventListener("optimize-results-updated", onChange);
+      };
+    },
+    readOptimizedAddressIds,
+    () => emptyIds,
+  );
+}

--- a/app/ui/src/app/edit/page.tsx
+++ b/app/ui/src/app/edit/page.tsx
@@ -55,13 +55,6 @@ import type { AddressCard } from "@/app/edit/types/delivery";
 
 type StoredUploadFile = { name: string; content: string };
 
-function reindexAddresses(addresses: AddressCard[]): AddressCard[] {
-  return addresses.map((address, index) => ({
-    ...address,
-    id: index + 1,
-  }));
-}
-
 export default function Page() {
   const vehicleState = useVehicles();
   const addressState = useAddresses();
@@ -281,9 +274,10 @@ export default function Page() {
             setPendingCSVFile(null);
           }}
           importAddresses={(cards: AddressCard[]) =>
-            addressState.importAddresses(
-              reindexAddresses([...addressState.addresses, ...cards]),
-            )
+            addressState.importAddresses([
+              ...addressState.addresses,
+              ...cards.map((c) => ({ ...c, id: addressState.reserveId() })),
+            ])
           }
           onInvalidFile={() => {
             setIsUploadOverlayOpen(false);

--- a/app/ui/src/app/edit/page.tsx
+++ b/app/ui/src/app/edit/page.tsx
@@ -36,6 +36,7 @@ import DragDropOverlay from "@/app/edit/components/shared/DragDropOverlay";
 import { useVehicles } from "@/app/edit/hooks/useVehicles";
 import { useAddresses } from "@/app/edit/hooks/useAddresses";
 import { useOptimize } from "@/app/edit/hooks/useOptimize";
+import { useOptimizedAddressIds } from "@/app/edit/hooks/useOptimizedAddressIds";
 import { useCallback, useEffect, useState } from "react";
 import { loadSessionFromFile } from "@/lib/session/importSession";
 import { downloadSessionSave } from "@/lib/session/exportSession";
@@ -96,6 +97,8 @@ export default function Page() {
     vehicleState.setVehiclesStartLocation,
     addressState.cacheAddressLocation,
   );
+
+  const optimizedAddressIds = useOptimizedAddressIds();
 
   const [isHydrated, setIsHydrated] = useState(false);
 
@@ -358,6 +361,7 @@ export default function Page() {
                 {...addressState}
                 geocodeFailedIds={geocodeFailedAddressIds}
                 outOfRegionIds={outOfRegionAddressIds}
+                optimizedIds={optimizedAddressIds}
                 onOpenUploadOverlay={() => setIsUploadOverlayOpen(true)}
               />
               <AddressPagination {...addressState} />

--- a/app/ui/src/app/edit/utils/hasOptimizeResults.ts
+++ b/app/ui/src/app/edit/utils/hasOptimizeResults.ts
@@ -26,3 +26,27 @@ export function clearOptimizeResults(): void {
   sessionStorage.removeItem("optimizeResults");
   window.dispatchEvent(new Event("optimize-results-updated"));
 }
+
+let cachedRaw: string | null = null;
+let cachedIds: number[] = [];
+
+/** Address ids that appear as a stop in the last completed optimize run. */
+export function readOptimizedAddressIds(): number[] {
+  if (typeof window === "undefined") return cachedIds;
+
+  const stored = sessionStorage.getItem("optimizeResults");
+  if (stored === cachedRaw) return cachedIds;
+  cachedRaw = stored;
+
+  try {
+    const parsed: unknown = stored ? JSON.parse(stored) : [];
+    cachedIds = Array.isArray(parsed)
+      ? (parsed as Route[])
+          .flatMap((r) => (r.stops ?? []).map((s) => Number(s.id)))
+          .filter((n) => !Number.isNaN(n))
+      : [];
+  } catch {
+    cachedIds = [];
+  }
+  return cachedIds;
+}

--- a/app/ui/src/tests/hasOptimizeResults.test.ts
+++ b/app/ui/src/tests/hasOptimizeResults.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { readOptimizedAddressIds } from "@/app/edit/utils/hasOptimizeResults";
+import type { Route } from "@/app/results/types";
+
+const sessionStore = new Map<string, string>();
+
+const sessionStorageMock = {
+  getItem: vi.fn((key: string) => sessionStore.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    sessionStore.set(key, value);
+  }),
+  removeItem: vi.fn((key: string) => {
+    sessionStore.delete(key);
+  }),
+};
+
+function makeRoute(stopIds: string[]): Route {
+  return {
+    vehicleId: "1",
+    driverName: "Driver 1",
+    stops: stopIds.map((id, i) => ({
+      id,
+      address: `${id} Main St`,
+      lat: 0,
+      lng: 0,
+      sequence: i,
+      capacityUsed: 1,
+      timeWindow: { kind: "by", time: "" },
+      note: "",
+    })),
+  };
+}
+
+describe("readOptimizedAddressIds", () => {
+  beforeEach(() => {
+    sessionStore.clear();
+    vi.clearAllMocks();
+    vi.stubGlobal("window", { sessionStorage: sessionStorageMock });
+    vi.stubGlobal("sessionStorage", sessionStorageMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns an empty array when there are no cached results", () => {
+    expect(readOptimizedAddressIds()).toEqual([]);
+  });
+
+  it("returns an empty array when the stored value is not valid JSON", () => {
+    sessionStore.set("optimizeResults", "{not json");
+
+    expect(readOptimizedAddressIds()).toEqual([]);
+  });
+
+  it("returns an empty array when the stored value is not an array", () => {
+    sessionStore.set("optimizeResults", JSON.stringify({ oops: true }));
+
+    expect(readOptimizedAddressIds()).toEqual([]);
+  });
+
+  it("extracts numeric ids from every stop across all routes", () => {
+    sessionStore.set(
+      "optimizeResults",
+      JSON.stringify([makeRoute(["1", "2"]), makeRoute(["3"])]),
+    );
+
+    expect(readOptimizedAddressIds().sort()).toEqual([1, 2, 3]);
+  });
+
+  it("drops stop ids that aren't numeric", () => {
+    sessionStore.set(
+      "optimizeResults",
+      JSON.stringify([makeRoute(["1", "not-a-number"])]),
+    );
+
+    expect(readOptimizedAddressIds()).toEqual([1]);
+  });
+
+  it("returns a reference-stable array when sessionStorage hasn't changed", () => {
+    sessionStore.set("optimizeResults", JSON.stringify([makeRoute(["1"])]));
+
+    const first = readOptimizedAddressIds();
+    const second = readOptimizedAddressIds();
+
+    expect(second).toBe(first);
+  });
+
+  it("returns fresh ids once sessionStorage changes", () => {
+    sessionStore.set("optimizeResults", JSON.stringify([makeRoute(["1"])]));
+    const first = readOptimizedAddressIds();
+
+    sessionStore.set("optimizeResults", JSON.stringify([makeRoute(["2"])]));
+    const second = readOptimizedAddressIds();
+
+    expect(first).toEqual([1]);
+    expect(second).toEqual([2]);
+  });
+});


### PR DESCRIPTION
## Summary

Delivery cards on the edit page now show a small "Optimized" badge once their stop was included in a completed optimize run, so users returning from the results page can see at a glance which deliveries are already accounted for.

## Motivation

After optimizing a route and viewing the results, users who navigate back to the edit page previously saw every delivery card in an identical state, with no way to tell which addresses were part of the optimized route and which were added afterward or never included. This made it easy to lose track of coverage when iterating on a route across multiple edit/optimize cycles.

## Changes

- Added `readOptimizedAddressIds()` in `hasOptimizeResults.ts`, deriving the set of optimized address ids from `sessionStorage['optimizeResults']` by matching `Route.stops[].id` back to `AddressCard.id`, with reference-stable caching for `useSyncExternalStore`.
- Added the `useOptimizedAddressIds` hook, reactive to the existing `storage` and `optimize-results-updated` events so the badge updates live without a page reload.
- Threaded an `optimizedIds` / `isOptimized` prop through `page.tsx` -> `AddressSection` -> `AddressCard`, following the existing `geocodeFailedIds` / `outOfRegionIds` pattern; the badge only shows on locked (confirmed) rows.
- Added the `ADDRESS_ROW_OPTIMIZED_BADGE` and `MOBILE_ADDR_RECIPIENT_LABEL_ROW` tokens to `formStyles.v2.ts`, matching the existing teal "In use" status-pill styling, and rendered the badge in all three `AddressCard` layout branches (desktop, mobile summarized, mobile expanded).

## Validation

- [x] `npm --prefix app/ui run lint`
- [x] `npm --prefix app/ui run typecheck`
- [x] `npm --prefix app/ui run test`
- [x] `npm --prefix app/ui run build`
- Manually verified in-browser at desktop and mobile widths: seeded `sessionStorage['optimizeResults']` with one included and one excluded address, confirmed the badge rendered only on the included card in all three layout branches, and confirmed it disappeared reactively when results were cleared (no reload needed).

## Risk

Low: the change is additive UI only, gated on a derived boolean that defaults to `false` when `sessionStorage` is empty or unparseable, so existing edit-page behavior is unaffected if no optimize run has happened yet. No changes to the optimize request/response shape or to persisted data.

## Rollout and Recovery

Ships with the normal frontend deploy; no migration, flag, or backend change is involved. If the badge needs to be pulled, reverting this PR removes the prop threading and new tokens cleanly since nothing else depends on `isOptimized`/`optimizedIds`.
