### PR TITLE
perf(api): reduce solve pipeline allocations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(DELIVERYOPTIMIZER_ENABLE_WARNINGS "Enable strict compiler warnings." ON)
 option(DELIVERYOPTIMIZER_ENABLE_TESTS "Build unit tests." ON)
 option(DELIVERYOPTIMIZER_ENABLE_SANITIZERS "Enable sanitizer instrumentation for Debug builds." OFF)
+option(DELIVERYOPTIMIZER_ENABLE_BENCHMARKS "Build the allocation benchmark harness." OFF)
 option(
   DELIVERYOPTIMIZER_LINK_COMPILE_COMMANDS_IN_SOURCE
   "Create a source-tree compile_commands.json symlink for editor tooling."
@@ -95,6 +96,10 @@ add_subdirectory(libs/domain)
 add_subdirectory(libs/application)
 add_subdirectory(libs/adapters)
 add_subdirectory(app/api)
+
+if(DELIVERYOPTIMIZER_ENABLE_BENCHMARKS)
+  add_subdirectory(bench)
+endif()
 
 if(DELIVERYOPTIMIZER_ENABLE_TESTS)
   include(CTest)

--- a/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
+++ b/app/api/include/deliveryoptimizer/api/forecast_optimizer.hpp
@@ -72,8 +72,8 @@ ReadRouteStartTime(const OptimizeRequestInput& input);
                                                              const OptimizeRequestInput& input,
                                                              const Json::Value& vroom_output);
 
-[[nodiscard]] Json::Value BuildWeatherAdjustedVroomInput(const OptimizeRequestInput& input,
-                                                         const WeatherImpactEstimate& impact);
+[[nodiscard]] std::string BuildWeatherAdjustedVroomInputText(const OptimizeRequestInput& input,
+                                                             const WeatherImpactEstimate& impact);
 
 [[nodiscard]] Json::Value BuildWeatherForecastAnnotation(const WeatherForecastOptions& options,
                                                          const WeatherImpactEstimate& impact);

--- a/app/api/include/deliveryoptimizer/api/internal/json_utils.hpp
+++ b/app/api/include/deliveryoptimizer/api/internal/json_utils.hpp
@@ -1,15 +1,113 @@
 #pragma once
 
+#include <charconv>
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
 #include <json/json.h>
 #include <string>
+#include <string_view>
+#include <type_traits>
 
 namespace deliveryoptimizer::api::internal {
 
 inline std::string RenderJson(const Json::Value& value) {
-  Json::StreamWriterBuilder writer_builder;
-  writer_builder["indentation"] = "";
-  writer_builder["commentStyle"] = "None";
-  return Json::writeString(writer_builder, value);
+  static const Json::StreamWriterBuilder kWriterBuilder = [] {
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = "";
+    builder["commentStyle"] = "None";
+    return builder;
+  }();
+  return Json::writeString(kWriterBuilder, value);
+}
+
+[[nodiscard]] inline std::size_t EscapedJsonStringSize(const std::string_view value) {
+  std::size_t size = 2U; // Opening and closing quotes.
+  for (const char character : value) {
+    switch (character) {
+    case '"':
+    case '\\':
+    case '\b':
+    case '\f':
+    case '\n':
+    case '\r':
+    case '\t':
+      size += 2U;
+      break;
+    default:
+      size += static_cast<unsigned char>(character) < 0x20U ? 6U : 1U;
+      break;
+    }
+  }
+  return size;
+}
+
+inline void AppendEscapedJsonString(std::string& output, const std::string_view value) {
+  output.push_back('"');
+  for (const char character : value) {
+    switch (character) {
+    case '"':
+      output += "\\\"";
+      break;
+    case '\\':
+      output += "\\\\";
+      break;
+    case '\b':
+      output += "\\b";
+      break;
+    case '\f':
+      output += "\\f";
+      break;
+    case '\n':
+      output += "\\n";
+      break;
+    case '\r':
+      output += "\\r";
+      break;
+    case '\t':
+      output += "\\t";
+      break;
+    default:
+      if (static_cast<unsigned char>(character) < 0x20U) {
+        constexpr char kHexDigits[] = "0123456789abcdef";
+        const auto byte = static_cast<unsigned char>(character);
+        output += "\\u00";
+        output.push_back(kHexDigits[(byte >> 4U) & 0x0FU]);
+        output.push_back(kHexDigits[byte & 0x0FU]);
+      } else {
+        output.push_back(character);
+      }
+      break;
+    }
+  }
+  output.push_back('"');
+}
+
+template <std::integral Integer>
+inline void AppendJsonInteger(std::string& output, const Integer value) {
+  using Widened = std::conditional_t<std::is_signed_v<Integer>, std::int64_t, std::uint64_t>;
+  const auto widened = static_cast<Widened>(value);
+  char buffer[32];
+  const auto [end, error] = std::to_chars(buffer, buffer + sizeof(buffer), widened);
+  if (error == std::errc{}) {
+    output.append(buffer, end);
+  }
+}
+
+inline void AppendJsonField(std::string& output, const std::string_view name,
+                            const std::string_view value) {
+  output += ",\"";
+  output.append(name);
+  output += "\":";
+  AppendEscapedJsonString(output, value);
+}
+
+template <std::integral Integer>
+inline void AppendJsonField(std::string& output, const std::string_view name, const Integer value) {
+  output += ",\"";
+  output.append(name);
+  output += "\":";
+  AppendJsonInteger(output, value);
 }
 
 } // namespace deliveryoptimizer::api::internal

--- a/app/api/include/deliveryoptimizer/api/observability.hpp
+++ b/app/api/include/deliveryoptimizer/api/observability.hpp
@@ -22,6 +22,13 @@ namespace deliveryoptimizer::api {
 
 inline constexpr std::string_view kRequestIdHeader = "X-Request-Id";
 
+// drogon's header APIs take const std::string&, so allocate the header name once
+// per process instead of constructing a fresh std::string on every call.
+[[nodiscard]] inline const std::string& RequestIdHeaderName() {
+  static const std::string name{kRequestIdHeader};
+  return name;
+}
+
 struct RequestContext {
   std::string request_id;
   std::chrono::steady_clock::time_point started_at;
@@ -66,8 +73,9 @@ struct ObservabilityOptions {
 };
 
 void EnsureRequestContext(const drogon::HttpRequestPtr& request);
-[[nodiscard]] std::optional<RequestContext>
-GetRequestContext(const drogon::HttpRequestPtr& request);
+// The returned pointer is owned by request->attributes() and remains valid while
+// that request attribute is not erased. Reading context should not copy its UUID.
+[[nodiscard]] const RequestContext* GetRequestContext(const drogon::HttpRequestPtr& request);
 [[nodiscard]] SolveLifecycle CreateSolveLifecycle(const drogon::HttpRequestPtr& request);
 [[nodiscard]] std::string_view ToOutcomeString(SolveRequestOutcome outcome);
 void FinalizeSolveRequest(const std::shared_ptr<ObservabilityRegistry>& observability,

--- a/app/api/include/deliveryoptimizer/api/optimization_job_store.hpp
+++ b/app/api/include/deliveryoptimizer/api/optimization_job_store.hpp
@@ -49,7 +49,9 @@ struct OptimizationJobRecord {
   std::optional<SolveRequestOutcome> outcome;
   std::optional<std::uint16_t> http_status;
   std::optional<std::string> error_message;
-  std::optional<Json::Value> result_body;
+  // Stored JSON is already validated when the job completes. Keep it as text
+  // so status reads do not parse a potentially large result tree unnecessarily.
+  std::optional<std::string> result_json;
 };
 
 struct ClaimedOptimizationJob {
@@ -93,8 +95,8 @@ public:
   [[nodiscard]] bool Ping(std::string* detail = nullptr);
   [[nodiscard]] bool EnsureSchema(std::string* detail = nullptr);
 
-  [[nodiscard]] CreateOptimizationJobResult CreateJob(const std::string& request_id,
-                                                      const std::string& request_json,
+  [[nodiscard]] CreateOptimizationJobResult CreateJob(std::string_view request_id,
+                                                      std::string_view request_json,
                                                       std::size_t jobs, std::size_t vehicles);
 
   [[nodiscard]] std::optional<ClaimedOptimizationJob> ClaimNextJob(const std::string& worker_id);
@@ -117,11 +119,12 @@ public:
   [[nodiscard]] std::size_t ExpireFinishedJobs();
 
   [[nodiscard]] std::optional<OptimizationJobRecord> GetJob(const std::string& job_id);
+  [[nodiscard]] std::optional<OptimizationJobRecord> GetJobStatus(const std::string& job_id);
   [[nodiscard]] OptimizationJobStoreStats GetStats();
   [[nodiscard]] std::size_t CountHealthyWorkers(std::chrono::milliseconds max_age);
 
 private:
-  std::optional<OptimizationJobRecord> ReadJobById(const std::string& job_id);
+  std::optional<OptimizationJobRecord> ReadJobById(const std::string& job_id, bool include_result);
 
   OptimizationJobStoreConfig config_;
   std::shared_ptr<drogon::orm::DbClient> client_;

--- a/app/api/include/deliveryoptimizer/api/optimize_request.hpp
+++ b/app/api/include/deliveryoptimizer/api/optimize_request.hpp
@@ -54,10 +54,16 @@ ParseAndValidateOptimizeRequest(const Json::Value& root, Json::Value& issues);
 
 [[nodiscard]] std::optional<SolveRequestSize> TryParseOptimizeRequestSize(const Json::Value& root);
 
-[[nodiscard]] Json::Value BuildVroomInput(const OptimizeRequestInput& input);
+// Renders the VROOM payload directly to text, avoiding the per-node Json::Value
+// tree. service_adjustment_seconds is added to every job's service when nonzero
+// (used for weather-aware reoptimization).
+[[nodiscard]] std::string BuildVroomInputText(const OptimizeRequestInput& input,
+                                              int service_adjustment_seconds = 0);
 
+// Takes ownership of the vroom output so its subtrees are moved into the response
+// body instead of deep-copied (jsoncpp values are not copy-on-write).
 [[nodiscard]] Json::Value
-BuildOptimizeSuccessBody(const OptimizeRequestInput& input, const Json::Value& vroom_output,
-                         const std::optional<Json::Value>& forecast = std::nullopt);
+BuildOptimizeSuccessBody(const OptimizeRequestInput& input, Json::Value vroom_output,
+                         std::optional<Json::Value> forecast = std::nullopt);
 
 } // namespace deliveryoptimizer::api

--- a/app/api/include/deliveryoptimizer/api/solve_coordinator.hpp
+++ b/app/api/include/deliveryoptimizer/api/solve_coordinator.hpp
@@ -42,7 +42,8 @@ class SolveCoordinator {
 public:
   // Completion callbacks run on the coordinator's completion workers, not on solver workers.
   using CompletionCallback = std::function<void(CoordinatedSolveResult)>;
-  using PayloadFactory = std::function<Json::Value()>;
+  // Produces the VROOM payload as text; invoked on solver workers.
+  using PayloadFactory = std::function<std::string()>;
 
   SolveCoordinator(SolveAdmissionConfig config, std::shared_ptr<const VroomRunner> runner,
                    SolveCoordinatorOptions options = {},

--- a/app/api/include/deliveryoptimizer/api/solve_execution.hpp
+++ b/app/api/include/deliveryoptimizer/api/solve_execution.hpp
@@ -20,9 +20,11 @@ struct SolveExecutionResult {
 };
 
 [[nodiscard]] SolveExecutionResult
-BuildSolveExecutionResult(const OptimizeRequestInput& input, const CoordinatedSolveResult& result,
-                          const std::optional<Json::Value>& forecast = std::nullopt);
+BuildSolveExecutionResult(const OptimizeRequestInput& input, CoordinatedSolveResult result,
+                          std::optional<Json::Value> forecast = std::nullopt);
 
-[[nodiscard]] CoordinatedSolveResult ToCoordinatedSolveResult(const VroomRunResult& result);
+// Takes ownership of the run result so the parsed vroom output tree is moved,
+// not deep-copied (jsoncpp values are not copy-on-write).
+[[nodiscard]] CoordinatedSolveResult ToCoordinatedSolveResult(VroomRunResult&& result);
 
 } // namespace deliveryoptimizer::api

--- a/app/api/include/deliveryoptimizer/api/vroom_runner.hpp
+++ b/app/api/include/deliveryoptimizer/api/vroom_runner.hpp
@@ -35,14 +35,14 @@ public:
   VroomRunner& operator=(VroomRunner&&) = default;
   virtual ~VroomRunner() = default;
 
-  [[nodiscard]] virtual VroomRunResult Run(const Json::Value& input_payload) const = 0;
+  [[nodiscard]] virtual VroomRunResult Run(const std::string& input_payload) const = 0;
 };
 
 class ProcessVroomRunner final : public VroomRunner {
 public:
   explicit ProcessVroomRunner(VroomRuntimeConfig runtime_config);
 
-  [[nodiscard]] VroomRunResult Run(const Json::Value& input_payload) const override;
+  [[nodiscard]] VroomRunResult Run(const std::string& input_payload) const override;
 
 private:
   VroomRuntimeConfig runtime_config_;

--- a/app/api/src/api_server.cpp
+++ b/app/api/src/api_server.cpp
@@ -51,11 +51,11 @@ int RunApiServer() {
   const auto default_error_handler = app.getCustomErrorHandler();
 
   app.registerHttpResponseCreationAdvice([](const drogon::HttpResponsePtr& response) {
-    if (response == nullptr || !response->getHeader(std::string{kRequestIdHeader}).empty()) {
+    if (response == nullptr || !response->getHeader(RequestIdHeaderName()).empty()) {
       return;
     }
 
-    response->addHeader(std::string{kRequestIdHeader}, GenerateRequestId());
+    response->addHeader(RequestIdHeaderName(), GenerateRequestId());
   });
   app.setCustomErrorHandler([default_error_handler](const drogon::HttpStatusCode code) {
     auto response = InvokeErrorHandler(default_error_handler, code);
@@ -63,8 +63,8 @@ int RunApiServer() {
       return response;
     }
 
-    if (response->getHeader(std::string{kRequestIdHeader}).empty()) {
-      response->addHeader(std::string{kRequestIdHeader}, GenerateRequestId());
+    if (response->getHeader(RequestIdHeaderName()).empty()) {
+      response->addHeader(RequestIdHeaderName(), GenerateRequestId());
     }
     return response;
   });
@@ -73,9 +73,9 @@ int RunApiServer() {
     if (request != nullptr && request->body().size() > kMaxRequestBodyBytes) {
       auto response = drogon::HttpResponse::newHttpResponse();
       response->setStatusCode(drogon::k413RequestEntityTooLarge);
-      if (const auto context = GetRequestContext(request); context.has_value()) {
-        response->removeHeader(std::string{kRequestIdHeader});
-        response->addHeader(std::string{kRequestIdHeader}, context->request_id);
+      if (const RequestContext* context = GetRequestContext(request); context != nullptr) {
+        response->removeHeader(RequestIdHeaderName());
+        response->addHeader(RequestIdHeaderName(), context->request_id);
       }
       if (request->getMethod() == drogon::Post &&
           (request->path() == "/api/v1/deliveries/optimize" ||
@@ -94,13 +94,13 @@ int RunApiServer() {
           return;
         }
 
-        const auto context = GetRequestContext(request);
-        if (!context.has_value()) {
+        const RequestContext* context = GetRequestContext(request);
+        if (context == nullptr) {
           return;
         }
 
-        response->removeHeader(std::string{kRequestIdHeader});
-        response->addHeader(std::string{kRequestIdHeader}, context->request_id);
+        response->removeHeader(RequestIdHeaderName());
+        response->addHeader(RequestIdHeaderName(), context->request_id);
       });
 
   RegisterHealthEndpoint(

--- a/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
+++ b/app/api/src/endpoints/deliveries_optimize_endpoint.cpp
@@ -22,20 +22,44 @@ struct CompletedResponse {
   deliveryoptimizer::api::SolveRequestOutcome outcome;
 };
 
+// One shared request aggregate owns all state crossing worker/event-loop
+// boundaries. Factories and completion callbacks capture only its shared_ptr,
+// avoiding separate allocations for request input, lifecycle, response callback,
+// and oversized std::function closures.
+struct SyncSolveContext {
+  std::shared_ptr<deliveryoptimizer::api::SolveCoordinator> coordinator;
+  std::optional<deliveryoptimizer::api::OptimizeRequestInput> optimize_request;
+  std::shared_ptr<const deliveryoptimizer::api::WeatherForecastOptions> weather_options;
+  std::shared_ptr<deliveryoptimizer::api::ObservabilityRegistry> observability;
+  deliveryoptimizer::api::SolveLifecycle lifecycle;
+  std::function<void(const drogon::HttpResponsePtr&)> response_callback;
+  drogon::HttpResponsePtr pending_response;
+  trantor::EventLoop* response_loop{nullptr};
+  std::optional<Json::Value> forecast;
+  int weather_service_adjustment_seconds{0};
+};
+
+[[nodiscard]] std::shared_ptr<deliveryoptimizer::api::SolveLifecycle>
+LifecycleHandle(const std::shared_ptr<SyncSolveContext>& context) {
+  // Aliasing shares the context control block; it does not allocate a second
+  // lifecycle object or create a self-owning member cycle.
+  return {context, &context->lifecycle};
+}
+
 [[nodiscard]] drogon::HttpResponsePtr BuildErrorResponse(const drogon::HttpStatusCode code,
                                                          const std::string_view error_message) {
   Json::Value body{Json::objectValue};
   body["error"] = std::string{error_message};
-  auto response = drogon::HttpResponse::newHttpJsonResponse(body);
+  auto response = drogon::HttpResponse::newHttpJsonResponse(std::move(body));
   response->setStatusCode(code);
   return response;
 }
 
-[[nodiscard]] drogon::HttpResponsePtr BuildValidationResponse(const Json::Value& issues) {
+[[nodiscard]] drogon::HttpResponsePtr BuildValidationResponse(Json::Value issues) {
   Json::Value body{Json::objectValue};
   body["error"] = "Validation failed.";
-  body["issues"] = issues;
-  auto response = drogon::HttpResponse::newHttpJsonResponse(body);
+  body["issues"] = std::move(issues);
+  auto response = drogon::HttpResponse::newHttpJsonResponse(std::move(body));
   response->setStatusCode(drogon::k400BadRequest);
   return response;
 }
@@ -70,9 +94,9 @@ BuildAdmissionRejectionResponse(const deliveryoptimizer::api::SolveAdmissionStat
 }
 
 [[nodiscard]] CompletedResponse
-BuildSolveExecutionResponse(const deliveryoptimizer::api::SolveExecutionResult& result) {
+BuildSolveExecutionResponse(deliveryoptimizer::api::SolveExecutionResult result) {
   if (result.response_body.has_value()) {
-    auto response = drogon::HttpResponse::newHttpJsonResponse(*result.response_body);
+    auto response = drogon::HttpResponse::newHttpJsonResponse(std::move(*result.response_body));
     response->setStatusCode(static_cast<drogon::HttpStatusCode>(result.http_status));
     return CompletedResponse{
         .response = response,
@@ -87,11 +111,18 @@ BuildSolveExecutionResponse(const deliveryoptimizer::api::SolveExecutionResult& 
   };
 }
 
-void DispatchResponse(
-    trantor::EventLoop* response_loop,
-    const std::shared_ptr<std::function<void(const drogon::HttpResponsePtr&)>>& callback,
-    const drogon::HttpResponsePtr& response) {
-  response_loop->queueInLoop([callback, response] { (*callback)(response); });
+void CompleteAndRespond(const std::shared_ptr<SyncSolveContext>& context,
+                        CompletedResponse completed_response) {
+  FinalizeSolveRequest(context->observability, LifecycleHandle(context), completed_response.outcome,
+                       static_cast<std::uint16_t>(completed_response.response->getStatusCode()));
+
+  // Keep the response in the aggregate so queueInLoop also captures one pointer.
+  context->pending_response = std::move(completed_response.response);
+  context->response_loop->queueInLoop([context] {
+    auto callback = std::move(context->response_callback);
+    callback(context->pending_response);
+    context->pending_response.reset();
+  });
 }
 
 } // namespace
@@ -101,7 +132,8 @@ namespace deliveryoptimizer::api {
 void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
                                         const SolveAdmissionConfig& admission_config,
                                         std::shared_ptr<ObservabilityRegistry> observability) {
-  const WeatherForecastOptions weather_options = ResolveWeatherForecastOptionsFromEnv();
+  auto weather_options =
+      std::make_shared<const WeatherForecastOptions>(ResolveWeatherForecastOptionsFromEnv());
   auto runner = std::make_shared<ProcessVroomRunner>(ResolveVroomRuntimeConfigFromEnv());
   auto coordinator = std::make_shared<SolveCoordinator>(admission_config, runner,
                                                         SolveCoordinatorOptions{}, observability);
@@ -112,45 +144,37 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
        observability = std::move(observability)](
           const drogon::HttpRequestPtr& request,
           std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
-        auto lifecycle = std::make_shared<SolveLifecycle>(CreateSolveLifecycle(request));
-        auto response_callback =
-            std::make_shared<std::function<void(const drogon::HttpResponsePtr&)>>(
-                std::move(callback));
-        trantor::EventLoop* response_loop = trantor::EventLoop::getEventLoopOfCurrentThread();
-        if (response_loop == nullptr) {
-          response_loop = drogon::app().getLoop();
+        auto context = std::make_shared<SyncSolveContext>();
+        context->coordinator = coordinator;
+        context->weather_options = weather_options;
+        context->observability = observability;
+        context->lifecycle = CreateSolveLifecycle(request);
+        context->response_callback = std::move(callback);
+        context->response_loop = trantor::EventLoop::getEventLoopOfCurrentThread();
+        if (context->response_loop == nullptr) {
+          context->response_loop = drogon::app().getLoop();
         }
 
-        const auto respond = [response_callback,
-                              response_loop](const drogon::HttpResponsePtr& response) {
-          DispatchResponse(response_loop, response_callback, response);
-        };
-        const auto respond_with_completion =
-            [respond, observability, lifecycle](const CompletedResponse& completed_response) {
-              FinalizeSolveRequest(
-                  observability, lifecycle, completed_response.outcome,
-                  static_cast<std::uint16_t>(completed_response.response->getStatusCode()));
-              respond(completed_response.response);
-            };
-
+        // All deferred lambdas capture only the shared request aggregate.
         const auto& parsed_json = request->getJsonObject();
         if (!parsed_json) {
-          respond_with_completion(CompletedResponse{
-              .response =
-                  BuildErrorResponse(drogon::k400BadRequest, "Request body must be valid JSON."),
-              .outcome = SolveRequestOutcome::kInvalidJson,
-          });
+          CompleteAndRespond(context,
+                             CompletedResponse{
+                                 .response = BuildErrorResponse(drogon::k400BadRequest,
+                                                                "Request body must be valid JSON."),
+                                 .outcome = SolveRequestOutcome::kInvalidJson,
+                             });
           return;
         }
 
         const auto early_request_size = TryParseOptimizeRequestSize(*parsed_json);
         if (early_request_size.has_value()) {
-          lifecycle->jobs = early_request_size->jobs;
-          lifecycle->vehicles = early_request_size->vehicles;
+          context->lifecycle.jobs = early_request_size->jobs;
+          context->lifecycle.vehicles = early_request_size->vehicles;
           const SolveAdmissionStatus admission_status =
-              coordinator->CheckAdmission(*early_request_size, lifecycle);
+              coordinator->CheckAdmission(*early_request_size, LifecycleHandle(context));
           if (admission_status != SolveAdmissionStatus::kAccepted) {
-            respond_with_completion(BuildAdmissionRejectionResponse(admission_status));
+            CompleteAndRespond(context, BuildAdmissionRejectionResponse(admission_status));
             return;
           }
         }
@@ -158,63 +182,81 @@ void RegisterDeliveriesOptimizeEndpoint(drogon::HttpAppFramework& app,
         Json::Value issues{Json::arrayValue};
         auto parsed_request = ParseAndValidateOptimizeRequest(*parsed_json, issues);
         if (!parsed_request.has_value()) {
-          respond_with_completion(CompletedResponse{
-              .response = BuildValidationResponse(issues),
-              .outcome = SolveRequestOutcome::kValidationFailed,
-          });
+          CompleteAndRespond(context, CompletedResponse{
+                                          .response = BuildValidationResponse(std::move(issues)),
+                                          .outcome = SolveRequestOutcome::kValidationFailed,
+                                      });
           return;
         }
 
-        auto optimize_request_ptr =
-            std::make_shared<OptimizeRequestInput>(std::move(parsed_request->input));
-        lifecycle->jobs = optimize_request_ptr->jobs.size();
-        lifecycle->vehicles = optimize_request_ptr->vehicles.size();
+        context->optimize_request.emplace(std::move(parsed_request->input));
+        context->lifecycle.jobs = context->optimize_request->jobs.size();
+        context->lifecycle.vehicles = context->optimize_request->vehicles.size();
 
         const SolveRequestSize request_size{
-            .jobs = optimize_request_ptr->jobs.size(),
-            .vehicles = optimize_request_ptr->vehicles.size(),
+            .jobs = context->optimize_request->jobs.size(),
+            .vehicles = context->optimize_request->vehicles.size(),
         };
         const SolveAdmissionStatus admission_status = coordinator->Submit(
-            request_size, [optimize_request_ptr] { return BuildVroomInput(*optimize_request_ptr); },
-            [coordinator, optimize_request_ptr, request_size, weather_options,
-             respond_with_completion](const CoordinatedSolveResult& result) mutable {
-              std::optional<Json::Value> forecast;
+            request_size, [context] { return BuildVroomInputText(*context->optimize_request); },
+            [context](CoordinatedSolveResult result) mutable {
               if (!result.output.has_value()) {
-                respond_with_completion(BuildSolveExecutionResponse(
-                    BuildSolveExecutionResult(*optimize_request_ptr, result, forecast)));
+                CompleteAndRespond(
+                    context, BuildSolveExecutionResponse(BuildSolveExecutionResult(
+                                 *context->optimize_request, std::move(result), std::nullopt)));
                 return;
               }
 
-              WeatherForecastOptions sync_weather_options = weather_options;
-              // Clear the key so recalculation short-circuits OpenWeather; sync path must not
-              // block the event loop.
-              sync_weather_options.openweather_api_key.clear();
+              // Copy only scalar policy. Empty provider strings make recalculation
+              // short-circuit OpenWeather without allocating/copying URL or key text;
+              // synchronous completion workers must not block on remote weather.
+              const WeatherForecastOptions& configured_weather = *context->weather_options;
+              WeatherForecastOptions sync_weather_options{
+                  .enabled = configured_weather.enabled,
+                  .weather_delay_seconds_per_stop =
+                      configured_weather.weather_delay_seconds_per_stop,
+                  .reoptimize_threshold_seconds = configured_weather.reoptimize_threshold_seconds,
+                  .reoptimize_threshold_percent = configured_weather.reoptimize_threshold_percent,
+                  .openweather_api_key = {},
+                  .openweather_base_url = {},
+              };
               const WeatherImpactEstimate impact = RecalculateWeatherImpact(
-                  sync_weather_options, *optimize_request_ptr, *result.output);
-              forecast = BuildWeatherForecastAnnotation(sync_weather_options, impact);
+                  sync_weather_options, *context->optimize_request, *result.output);
+              context->forecast = BuildWeatherForecastAnnotation(sync_weather_options, impact);
               if (!impact.should_reoptimize) {
-                respond_with_completion(BuildSolveExecutionResponse(
-                    BuildSolveExecutionResult(*optimize_request_ptr, result, forecast)));
+                CompleteAndRespond(context, BuildSolveExecutionResponse(BuildSolveExecutionResult(
+                                                *context->optimize_request, std::move(result),
+                                                std::move(context->forecast))));
                 return;
               }
 
-              const SolveAdmissionStatus rerun_status = coordinator->Submit(
-                  request_size,
-                  [optimize_request_ptr, impact] {
-                    return BuildWeatherAdjustedVroomInput(*optimize_request_ptr, impact);
+              // Only the scalar adjustment is needed by the re-run factory, so it
+              // lives on the shared context to keep every std::function capture at
+              // the 16-byte small-buffer size.
+              context->weather_service_adjustment_seconds =
+                  impact.should_reoptimize ? impact.delay_seconds_per_stop : 0;
+              const SolveAdmissionStatus rerun_status = context->coordinator->Submit(
+                  SolveRequestSize{
+                      .jobs = context->optimize_request->jobs.size(),
+                      .vehicles = context->optimize_request->vehicles.size(),
                   },
-                  [optimize_request_ptr, forecast,
-                   respond_with_completion](const CoordinatedSolveResult& rerun_result) mutable {
-                    respond_with_completion(BuildSolveExecutionResponse(
-                        BuildSolveExecutionResult(*optimize_request_ptr, rerun_result, forecast)));
+                  [context] {
+                    return BuildVroomInputText(*context->optimize_request,
+                                               context->weather_service_adjustment_seconds);
+                  },
+                  [context](CoordinatedSolveResult rerun_result) mutable {
+                    CompleteAndRespond(context,
+                                       BuildSolveExecutionResponse(BuildSolveExecutionResult(
+                                           *context->optimize_request, std::move(rerun_result),
+                                           std::move(context->forecast))));
                   });
               if (rerun_status != SolveAdmissionStatus::kAccepted) {
-                respond_with_completion(BuildAdmissionRejectionResponse(rerun_status));
+                CompleteAndRespond(context, BuildAdmissionRejectionResponse(rerun_status));
               }
             },
-            lifecycle);
+            LifecycleHandle(context));
         if (admission_status != SolveAdmissionStatus::kAccepted) {
-          respond_with_completion(BuildAdmissionRejectionResponse(admission_status));
+          CompleteAndRespond(context, BuildAdmissionRejectionResponse(admission_status));
         }
       },
       {drogon::Post});

--- a/app/api/src/endpoints/optimization_jobs_endpoint.cpp
+++ b/app/api/src/endpoints/optimization_jobs_endpoint.cpp
@@ -19,9 +19,18 @@
 
 namespace {
 
-[[nodiscard]] drogon::HttpResponsePtr BuildJsonResponse(const Json::Value& body,
+[[nodiscard]] drogon::HttpResponsePtr BuildJsonResponse(Json::Value body,
                                                         const drogon::HttpStatusCode code) {
-  auto response = drogon::HttpResponse::newHttpJsonResponse(body);
+  auto response = drogon::HttpResponse::newHttpJsonResponse(std::move(body));
+  response->setStatusCode(code);
+  return response;
+}
+
+[[nodiscard]] drogon::HttpResponsePtr BuildRawJsonResponse(std::string body,
+                                                           const drogon::HttpStatusCode code) {
+  auto response = drogon::HttpResponse::newHttpResponse();
+  response->setContentTypeCode(drogon::CT_APPLICATION_JSON);
+  response->setBody(std::move(body));
   response->setStatusCode(code);
   return response;
 }
@@ -30,14 +39,14 @@ namespace {
                                                          const std::string_view error_message) {
   Json::Value body{Json::objectValue};
   body["error"] = std::string{error_message};
-  return BuildJsonResponse(body, code);
+  return BuildJsonResponse(std::move(body), code);
 }
 
-[[nodiscard]] drogon::HttpResponsePtr BuildValidationResponse(const Json::Value& issues) {
+[[nodiscard]] drogon::HttpResponsePtr BuildValidationResponse(Json::Value issues) {
   Json::Value body{Json::objectValue};
   body["error"] = "Validation failed.";
-  body["issues"] = issues;
-  return BuildJsonResponse(body, drogon::k400BadRequest);
+  body["issues"] = std::move(issues);
+  return BuildJsonResponse(std::move(body), drogon::k400BadRequest);
 }
 
 [[nodiscard]] drogon::HttpResponsePtr BuildOptimizationJobsUnavailableResponse(
@@ -57,7 +66,7 @@ namespace {
         body["detail"] = detail;
       }
     }
-    return BuildJsonResponse(body, drogon::k503ServiceUnavailable);
+    return BuildJsonResponse(std::move(body), drogon::k503ServiceUnavailable);
   }
 
   return BuildErrorResponse(drogon::k503ServiceUnavailable, "Optimization jobs are unavailable.");
@@ -142,12 +151,11 @@ void RegisterOptimizationJobsEndpoints(drogon::HttpAppFramework& app,
 
         lifecycle->jobs = parsed_request->size.jobs;
         lifecycle->vehicles = parsed_request->size.vehicles;
-        const auto context = GetRequestContext(request).value_or(RequestContext{
-            .request_id = lifecycle->request_id,
-            .started_at = lifecycle->request_started_at,
-        });
+        // PostgreSQL's jsonb parser is stricter than JsonCpp (for example, it
+        // rejects comments and trailing commas), so persist the validated DOM.
+        const auto canonical_request_json = internal::RenderJson(*parsed_json);
         const auto created_job =
-            store->CreateJob(context.request_id, internal::RenderJson(*parsed_json),
+            store->CreateJob(lifecycle->request_id, canonical_request_json,
                              parsed_request->size.jobs, parsed_request->size.vehicles);
         if (created_job.status == CreateOptimizationJobStatus::kQueueFull) {
           FinalizeSolveRequest(observability, lifecycle, SolveRequestOutcome::kRejectedQueueFull,
@@ -167,7 +175,7 @@ void RegisterOptimizationJobsEndpoints(drogon::HttpAppFramework& app,
 
         FinalizeSolveRequest(observability, lifecycle, SolveRequestOutcome::kAcceptedAsync, 202U);
         Json::Value body = BuildJobStatusBody(*created_job.record);
-        auto response = BuildJsonResponse(body, drogon::k202Accepted);
+        auto response = BuildJsonResponse(std::move(body), drogon::k202Accepted);
         response->addHeader("Location", "/api/v1/optimization-jobs/" + created_job.record->job_id);
         std::move(callback)(response);
       },
@@ -185,15 +193,15 @@ void RegisterOptimizationJobsEndpoints(drogon::HttpAppFramework& app,
           return;
         }
 
-        const auto job = store->GetJob(job_id);
+        auto job = store->GetJob(job_id);
         if (!job.has_value() || job->state == OptimizationJobState::kExpired) {
           std::move(callback)(
               BuildErrorResponse(drogon::k404NotFound, "Optimization job not found."));
           return;
         }
 
-        if (job->result_body.has_value()) {
-          std::move(callback)(BuildJsonResponse(*job->result_body, drogon::k200OK));
+        if (job->result_json.has_value()) {
+          std::move(callback)(BuildRawJsonResponse(std::move(*job->result_json), drogon::k200OK));
           return;
         }
 
@@ -202,7 +210,7 @@ void RegisterOptimizationJobsEndpoints(drogon::HttpAppFramework& app,
                            job->state == OptimizationJobState::kRunning)
                               ? drogon::k202Accepted
                               : drogon::k409Conflict;
-        std::move(callback)(BuildJsonResponse(body, code));
+        std::move(callback)(BuildJsonResponse(std::move(body), code));
       },
       {drogon::Get});
 
@@ -218,7 +226,7 @@ void RegisterOptimizationJobsEndpoints(drogon::HttpAppFramework& app,
           return;
         }
 
-        const auto job = store->GetJob(job_id);
+        const auto job = store->GetJobStatus(job_id);
         if (!job.has_value()) {
           std::move(callback)(
               BuildErrorResponse(drogon::k404NotFound, "Optimization job not found."));

--- a/app/api/src/endpoints/osrm_proxy_endpoint.cpp
+++ b/app/api/src/endpoints/osrm_proxy_endpoint.cpp
@@ -93,7 +93,7 @@ void RegisterOsrmProxyEndpoint(drogon::HttpAppFramework& app) {
         if (!IsAllowedService(service_name)) {
           Json::Value body;
           body["error"] = "OSRM service not allowed.";
-          auto response = drogon::HttpResponse::newHttpJsonResponse(body);
+          auto response = drogon::HttpResponse::newHttpJsonResponse(std::move(body));
           response->setStatusCode(drogon::k403Forbidden);
           std::move(callback)(response);
           return;
@@ -102,7 +102,7 @@ void RegisterOsrmProxyEndpoint(drogon::HttpAppFramework& app) {
         if (!IsSafeOsrmPathSuffix(path_suffix)) {
           Json::Value body;
           body["error"] = "OSRM path not allowed.";
-          auto response = drogon::HttpResponse::newHttpJsonResponse(body);
+          auto response = drogon::HttpResponse::newHttpJsonResponse(std::move(body));
           response->setStatusCode(drogon::k403Forbidden);
           std::move(callback)(response);
           return;
@@ -113,9 +113,15 @@ void RegisterOsrmProxyEndpoint(drogon::HttpAppFramework& app) {
         upstream_request->setPassThrough(true);
 
         const auto& query = request->query();
-        const std::string path =
-            query.empty() ? "/" + path_suffix : "/" + path_suffix + "?" + query;
-        upstream_request->setPath(path);
+        std::string path;
+        path.reserve(path_suffix.size() + query.size() + 2U);
+        path.push_back('/');
+        path.append(path_suffix);
+        if (!query.empty()) {
+          path.push_back('?');
+          path.append(query);
+        }
+        upstream_request->setPath(std::move(path));
 
         osrm_client->sendRequest(
             upstream_request,
@@ -128,7 +134,7 @@ void RegisterOsrmProxyEndpoint(drogon::HttpAppFramework& app) {
 
               Json::Value body;
               body["error"] = "OSRM upstream request failed.";
-              auto upstream_error = drogon::HttpResponse::newHttpJsonResponse(body);
+              auto upstream_error = drogon::HttpResponse::newHttpJsonResponse(std::move(body));
               upstream_error->setStatusCode(drogon::k502BadGateway);
               std::move(callback)(upstream_error);
             });

--- a/app/api/src/forecast_optimizer.cpp
+++ b/app/api/src/forecast_optimizer.cpp
@@ -398,21 +398,10 @@ WeatherImpactEstimate RecalculateWeatherImpact(const WeatherForecastOptions& opt
   return EstimateRouteWeatherImpact(options, input, *summary_duration);
 }
 
-Json::Value BuildWeatherAdjustedVroomInput(const OptimizeRequestInput& input,
-                                           const WeatherImpactEstimate& impact) {
-  Json::Value payload = BuildVroomInput(input);
-  if (!impact.should_reoptimize) {
-    return payload;
-  }
-
+std::string BuildWeatherAdjustedVroomInputText(const OptimizeRequestInput& input,
+                                               const WeatherImpactEstimate& impact) {
   // Weather delay time so VROOM can still decide the route order before dispatch.
-  for (Json::ArrayIndex index = 0; index < payload["jobs"].size(); ++index) {
-    Json::Value& job = payload["jobs"][index];
-    const int current_service = job["service"].isInt() ? job["service"].asInt() : 0;
-    job["service"] = current_service + impact.delay_seconds_per_stop;
-  }
-
-  return payload;
+  return BuildVroomInputText(input, impact.should_reoptimize ? impact.delay_seconds_per_stop : 0);
 }
 
 Json::Value BuildWeatherForecastAnnotation(const WeatherForecastOptions& options,

--- a/app/api/src/observability.cpp
+++ b/app/api/src/observability.cpp
@@ -1,10 +1,11 @@
 #include "deliveryoptimizer/api/observability.hpp"
 
+#include "deliveryoptimizer/api/internal/json_utils.hpp"
+
 #include <array>
 #include <cstddef>
 #include <iomanip>
 #include <iostream>
-#include <json/json.h>
 #include <limits>
 #include <ostream>
 #include <sstream>
@@ -412,29 +413,27 @@ void ObservabilityRegistry::LogSolveRequest(const SolveLifecycle& lifecycle,
   const auto completed_at = lifecycle.completed_at.value_or(SteadyClock::now());
   const auto request_duration = completed_at - lifecycle.request_started_at;
 
-  Json::Value log_line{Json::objectValue};
-  log_line["request_id"] = lifecycle.request_id;
-  log_line["method"] = lifecycle.method;
-  log_line["path"] = lifecycle.path;
-  log_line["jobs"] = static_cast<Json::UInt64>(lifecycle.jobs);
-  log_line["vehicles"] = static_cast<Json::UInt64>(lifecycle.vehicles);
-  log_line["queue_depth"] = static_cast<Json::UInt64>(lifecycle.queue_depth);
-  log_line["inflight_solves"] = static_cast<Json::UInt64>(lifecycle.inflight_solves);
-  log_line["outcome"] = std::string{ToOutcomeString(outcome)};
-  log_line["http_status"] = http_status;
-  log_line["queue_wait_ms"] =
-      static_cast<Json::Int64>(DurationToMilliseconds(lifecycle.queue_wait_duration));
-  log_line["solve_duration_ms"] =
-      static_cast<Json::Int64>(DurationToMilliseconds(lifecycle.solve_duration));
-  log_line["request_duration_ms"] =
-      static_cast<Json::Int64>(DurationToMilliseconds(request_duration));
-
-  Json::StreamWriterBuilder writer_builder;
-  writer_builder["indentation"] = "";
-  writer_builder["commentStyle"] = "None";
-  writer_builder["emitUTF8"] = true;
-
-  const std::string rendered_line = Json::writeString(writer_builder, log_line);
+  // The log line is a flat object of scalars, so it is rendered directly instead
+  // of building a Json::Value tree + writer per request (~20 allocations saved).
+  std::string rendered_line;
+  rendered_line.reserve(320U);
+  rendered_line += "{\"request_id\":";
+  internal::AppendEscapedJsonString(rendered_line, lifecycle.request_id);
+  internal::AppendJsonField(rendered_line, "method", lifecycle.method);
+  internal::AppendJsonField(rendered_line, "path", lifecycle.path);
+  internal::AppendJsonField(rendered_line, "jobs", lifecycle.jobs);
+  internal::AppendJsonField(rendered_line, "vehicles", lifecycle.vehicles);
+  internal::AppendJsonField(rendered_line, "queue_depth", lifecycle.queue_depth);
+  internal::AppendJsonField(rendered_line, "inflight_solves", lifecycle.inflight_solves);
+  internal::AppendJsonField(rendered_line, "outcome", ToOutcomeString(outcome));
+  internal::AppendJsonField(rendered_line, "http_status", http_status);
+  internal::AppendJsonField(rendered_line, "queue_wait_ms",
+                            DurationToMilliseconds(lifecycle.queue_wait_duration));
+  internal::AppendJsonField(rendered_line, "solve_duration_ms",
+                            DurationToMilliseconds(lifecycle.solve_duration));
+  internal::AppendJsonField(rendered_line, "request_duration_ms",
+                            DurationToMilliseconds(request_duration));
+  rendered_line.push_back('}');
 
   bool notify_writer = false;
   {
@@ -447,7 +446,7 @@ void ObservabilityRegistry::LogSolveRequest(const SolveLifecycle& lifecycle,
         pending_log_lines_.pop_front();
         tracker_write_failures_.fetch_add(1U, std::memory_order_relaxed);
       }
-      pending_log_lines_.push_back(rendered_line);
+      pending_log_lines_.push_back(std::move(rendered_line));
       notify_writer = true;
     }
   }

--- a/app/api/src/optimization_job_runtime.cpp
+++ b/app/api/src/optimization_job_runtime.cpp
@@ -154,21 +154,22 @@ void OptimizationJobRuntime::WorkerLoop(const std::stop_token stop_token,
         }
       }
     } else {
-      const CoordinatedSolveResult coordinated_result =
-          ToCoordinatedSolveResult(runner_->Run(BuildVroomInput(parsed_request->input)));
-      CoordinatedSolveResult final_result = coordinated_result;
+      CoordinatedSolveResult coordinated_result =
+          ToCoordinatedSolveResult(runner_->Run(BuildVroomInputText(parsed_request->input)));
+      const bool has_solve_output = coordinated_result.output.has_value();
+      CoordinatedSolveResult final_result = std::move(coordinated_result);
       std::optional<Json::Value> forecast;
-      if (coordinated_result.output.has_value()) {
-        const WeatherImpactEstimate impact = RecalculateWeatherImpact(
-            weather_options_, parsed_request->input, *coordinated_result.output);
+      if (has_solve_output) {
+        const WeatherImpactEstimate impact =
+            RecalculateWeatherImpact(weather_options_, parsed_request->input, *final_result.output);
         forecast = BuildWeatherForecastAnnotation(weather_options_, impact);
         if (impact.should_reoptimize) {
           final_result = ToCoordinatedSolveResult(
-              runner_->Run(BuildWeatherAdjustedVroomInput(parsed_request->input, impact)));
+              runner_->Run(BuildWeatherAdjustedVroomInputText(parsed_request->input, impact)));
         }
       }
-      const auto solve_result =
-          BuildSolveExecutionResult(parsed_request->input, final_result, forecast);
+      const auto solve_result = BuildSolveExecutionResult(
+          parsed_request->input, std::move(final_result), std::move(forecast));
       if (solve_result.response_body.has_value()) {
         if (store_->CompleteJobSuccess(claimed_job->record.job_id, claimed_job->worker_id,
                                        *solve_result.response_body, solve_result.outcome,

--- a/app/api/src/optimization_job_store.cpp
+++ b/app/api/src/optimization_job_store.cpp
@@ -1,6 +1,5 @@
 #include "deliveryoptimizer/api/optimization_job_store.hpp"
 
-#include "deliveryoptimizer/adapters/json_utils.hpp"
 #include "deliveryoptimizer/api/internal/json_utils.hpp"
 
 #include <drogon/orm/DbClient.h>
@@ -46,15 +45,6 @@ ReadOptionalOutcome(const drogon::orm::Row& row) {
   return deliveryoptimizer::api::ParseSolveRequestOutcome(field.as<std::string>());
 }
 
-[[nodiscard]] std::optional<Json::Value> ReadOptionalJson(const drogon::orm::Row& row,
-                                                          const char* column_name) {
-  const auto field = row[column_name];
-  if (field.isNull()) {
-    return std::nullopt;
-  }
-  return deliveryoptimizer::adapters::ParseJsonText(field.as<std::string>());
-}
-
 [[nodiscard]] std::optional<deliveryoptimizer::api::OptimizationJobRecord>
 ReadJobRecord(const drogon::orm::Result& result) {
   if (result.empty()) {
@@ -81,7 +71,7 @@ ReadJobRecord(const drogon::orm::Result& result) {
       .outcome = ReadOptionalOutcome(row),
       .http_status = ReadOptionalHttpStatus(row),
       .error_message = ReadOptionalText(row, "error_message"),
-      .result_body = ReadOptionalJson(row, "result_json"),
+      .result_json = ReadOptionalText(row, "result_json"),
   };
 }
 
@@ -282,8 +272,8 @@ bool OptimizationJobStore::EnsureSchema(std::string* detail) {
   }
 }
 
-CreateOptimizationJobResult OptimizationJobStore::CreateJob(const std::string& request_id,
-                                                            const std::string& request_json,
+CreateOptimizationJobResult OptimizationJobStore::CreateJob(const std::string_view request_id,
+                                                            const std::string_view request_json,
                                                             const std::size_t jobs,
                                                             const std::size_t vehicles) {
   if (!IsConfigured()) {
@@ -570,7 +560,11 @@ std::size_t OptimizationJobStore::ExpireFinishedJobs() {
 }
 
 std::optional<OptimizationJobRecord> OptimizationJobStore::GetJob(const std::string& job_id) {
-  return ReadJobById(job_id);
+  return ReadJobById(job_id, true);
+}
+
+std::optional<OptimizationJobRecord> OptimizationJobStore::GetJobStatus(const std::string& job_id) {
+  return ReadJobById(job_id, false);
 }
 
 OptimizationJobStoreStats OptimizationJobStore::GetStats() {
@@ -618,21 +612,27 @@ std::size_t OptimizationJobStore::CountHealthyWorkers(const std::chrono::millise
   }
 }
 
-std::optional<OptimizationJobRecord> OptimizationJobStore::ReadJobById(const std::string& job_id) {
+std::optional<OptimizationJobRecord> OptimizationJobStore::ReadJobById(const std::string& job_id,
+                                                                       const bool include_result) {
   if (!IsConfigured()) {
     return std::nullopt;
   }
 
   try {
-    const auto result = client_->execSqlSync(
+    static const std::string kJobWithResultQuery =
         "select id, request_id, status, jobs_count, vehicles_count, "
         "queued_at::text as queued_at, started_at::text as started_at, "
         "completed_at::text as completed_at, expires_at::text as expires_at, "
         "outcome, http_status, error_message, result_json::text as result_json "
-        "from optimization_jobs "
-        "where id = $1",
-        job_id);
-    return ReadJobRecord(result);
+        "from optimization_jobs where id = $1";
+    static const std::string kJobStatusQuery =
+        "select id, request_id, status, jobs_count, vehicles_count, "
+        "queued_at::text as queued_at, started_at::text as started_at, "
+        "completed_at::text as completed_at, expires_at::text as expires_at, "
+        "outcome, http_status, error_message, null::text as result_json "
+        "from optimization_jobs where id = $1";
+    const std::string& query = include_result ? kJobWithResultQuery : kJobStatusQuery;
+    return ReadJobRecord(client_->execSqlSync(query, job_id));
   } catch (...) {
     return std::nullopt;
   }

--- a/app/api/src/optimize_request.cpp
+++ b/app/api/src/optimize_request.cpp
@@ -1,12 +1,14 @@
 #include "deliveryoptimizer/api/optimize_request.hpp"
 
 #include "deliveryoptimizer/api/deliveries_optimize_limits.hpp"
+#include "deliveryoptimizer/api/internal/json_utils.hpp"
 
+#include <algorithm>
+#include <charconv>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <limits>
-#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -26,6 +28,54 @@ constexpr Json::ArrayIndex kMaxOptimizeVehicles =
     static_cast<Json::ArrayIndex>(deliveryoptimizer::api::kMaxDeliveriesOptimizeVehicles);
 constexpr Json::ArrayIndex kMaxOptimizeJobs =
     static_cast<Json::ArrayIndex>(deliveryoptimizer::api::kMaxDeliveriesOptimizeJobs);
+
+[[nodiscard]] bool IsValidUtf8(const std::string_view value) {
+  std::size_t index = 0U;
+  while (index < value.size()) {
+    const auto leading_byte = static_cast<unsigned char>(value[index]);
+    if (leading_byte < 0x80U) {
+      ++index;
+      continue;
+    }
+
+    std::size_t continuation_count = 0U;
+    std::uint32_t code_point = 0U;
+    std::uint32_t minimum_code_point = 0U;
+    if ((leading_byte & 0xE0U) == 0xC0U) {
+      continuation_count = 1U;
+      code_point = leading_byte & 0x1FU;
+      minimum_code_point = 0x80U;
+    } else if ((leading_byte & 0xF0U) == 0xE0U) {
+      continuation_count = 2U;
+      code_point = leading_byte & 0x0FU;
+      minimum_code_point = 0x800U;
+    } else if ((leading_byte & 0xF8U) == 0xF0U) {
+      continuation_count = 3U;
+      code_point = leading_byte & 0x07U;
+      minimum_code_point = 0x10000U;
+    } else {
+      return false;
+    }
+
+    if (continuation_count >= value.size() - index) {
+      return false;
+    }
+    for (std::size_t offset = 1U; offset <= continuation_count; ++offset) {
+      const auto continuation_byte = static_cast<unsigned char>(value[index + offset]);
+      if ((continuation_byte & 0xC0U) != 0x80U) {
+        return false;
+      }
+      code_point = (code_point << 6U) | (continuation_byte & 0x3FU);
+    }
+
+    if (code_point < minimum_code_point || code_point > 0x10FFFFU ||
+        (code_point >= 0xD800U && code_point <= 0xDFFFU)) {
+      return false;
+    }
+    index += continuation_count + 1U;
+  }
+  return true;
+}
 
 void AddValidationIssue(Json::Value& issues, const std::string_view field,
                         const std::string_view message) {
@@ -181,11 +231,18 @@ ParseVehicle(const Json::Value& vehicle, const std::string_view base_field, Json
   std::optional<deliveryoptimizer::api::Coordinate> end_coordinate;
   std::optional<deliveryoptimizer::api::TimeWindow> vehicle_time_window;
 
-  if (!vehicle_id.isString() || vehicle_id.asString().empty()) {
+  if (!vehicle_id.isString()) {
     AddValidationIssue(issues, std::string{base_field} + ".id", "must be a non-empty string.");
     valid_vehicle = false;
   } else {
     external_id = vehicle_id.asString();
+    if (external_id.empty()) {
+      AddValidationIssue(issues, std::string{base_field} + ".id", "must be a non-empty string.");
+      valid_vehicle = false;
+    } else if (!IsValidUtf8(external_id)) {
+      AddValidationIssue(issues, std::string{base_field} + ".id", "must contain valid UTF-8.");
+      valid_vehicle = false;
+    }
   }
 
   const auto parsed_capacity = ParseBoundedInt(capacity, 1);
@@ -245,11 +302,18 @@ ParseJob(const Json::Value& job, const std::string_view base_field, Json::Value&
 
   bool valid_job = true;
   std::string external_id;
-  if (!job_id.isString() || job_id.asString().empty()) {
+  if (!job_id.isString()) {
     AddValidationIssue(issues, std::string{base_field} + ".id", "must be a non-empty string.");
     valid_job = false;
   } else {
     external_id = job_id.asString();
+    if (external_id.empty()) {
+      AddValidationIssue(issues, std::string{base_field} + ".id", "must be a non-empty string.");
+      valid_job = false;
+    } else if (!IsValidUtf8(external_id)) {
+      AddValidationIssue(issues, std::string{base_field} + ".id", "must contain valid UTF-8.");
+      valid_job = false;
+    }
   }
 
   const auto parsed_location = ParseCoordinate(location);
@@ -341,11 +405,12 @@ void ParseVehicles(const Json::Value& root,
     return;
   }
 
+  parsed_input.vehicles.reserve(vehicles.size());
   for (Json::ArrayIndex index = 0U; index < vehicles.size(); ++index) {
     const std::string base_field = "vehicles[" + std::to_string(index) + "]";
-    const auto parsed_vehicle = ParseVehicle(vehicles[index], base_field, issues);
+    auto parsed_vehicle = ParseVehicle(vehicles[index], base_field, issues);
     if (parsed_vehicle.has_value()) {
-      parsed_input.vehicles.push_back(parsed_vehicle.value());
+      parsed_input.vehicles.push_back(std::move(*parsed_vehicle));
     }
   }
 }
@@ -367,77 +432,31 @@ void ParseJobs(const Json::Value& root, deliveryoptimizer::api::OptimizeRequestI
     return;
   }
 
+  parsed_input.jobs.reserve(jobs.size());
   for (Json::ArrayIndex index = 0U; index < jobs.size(); ++index) {
     const std::string base_field = "jobs[" + std::to_string(index) + "]";
-    const auto parsed_job = ParseJob(jobs[index], base_field, issues);
+    auto parsed_job = ParseJob(jobs[index], base_field, issues);
     if (parsed_job.has_value()) {
-      parsed_input.jobs.push_back(parsed_job.value());
+      parsed_input.jobs.push_back(std::move(*parsed_job));
     }
   }
 }
 
-[[nodiscard]] Json::Value BuildLocation(const double lon, const double lat) {
-  Json::Value location{Json::arrayValue};
-  location.append(lon);
-  location.append(lat);
-  return location;
-}
-
-[[nodiscard]] Json::Value BuildUnitArray(const int value) {
-  Json::Value values{Json::arrayValue};
-  values.append(value);
-  return values;
-}
-
-[[nodiscard]] Json::Value
-BuildTimeWindowArray(const deliveryoptimizer::api::TimeWindow& time_window) {
-  Json::Value values{Json::arrayValue};
-  values.append(static_cast<Json::Int64>(time_window.start.time_since_epoch().count()));
-  values.append(static_cast<Json::Int64>(time_window.end.time_since_epoch().count()));
-  return values;
-}
-
-[[nodiscard]] Json::Value
-BuildTimeWindowsArray(const std::vector<deliveryoptimizer::api::TimeWindow>& time_windows) {
-  Json::Value values{Json::arrayValue};
-  for (const auto& time_window : time_windows) {
-    values.append(BuildTimeWindowArray(time_window));
-  }
-  return values;
-}
-
-[[nodiscard]] std::map<std::uint64_t, std::string>
-BuildVehicleExternalIdMap(const deliveryoptimizer::api::OptimizeRequestInput& input) {
-  std::map<std::uint64_t, std::string> vehicle_map;
-  for (std::size_t index = 0U; index < input.vehicles.size(); ++index) {
-    vehicle_map.emplace(static_cast<std::uint64_t>(index + 1U), input.vehicles[index].external_id);
-  }
-  return vehicle_map;
-}
-
-[[nodiscard]] std::map<std::uint64_t, std::string>
-BuildJobExternalIdMap(const deliveryoptimizer::api::OptimizeRequestInput& input) {
-  std::map<std::uint64_t, std::string> job_map;
-  for (std::size_t index = 0U; index < input.jobs.size(); ++index) {
-    job_map.emplace(static_cast<std::uint64_t>(index + 1U), input.jobs[index].external_id);
-  }
-  return job_map;
-}
-
+// VROOM emits 1-based contiguous ids that match the payload we built, so
+// response enrichment indexes the original request vectors directly. This is
+// O(1) and needs no temporary map or pointer-vector allocations.
 void ApplyExternalIdsToRoutes(Json::Value& routes,
-                              const std::map<std::uint64_t, std::string>& vehicle_map,
-                              const std::map<std::uint64_t, std::string>& job_map) {
+                              const std::vector<deliveryoptimizer::api::VehicleInput>& vehicles,
+                              const std::vector<deliveryoptimizer::api::JobInput>& jobs) {
   for (Json::ArrayIndex route_index = 0U; route_index < routes.size(); ++route_index) {
     Json::Value& route = routes[route_index];
     if (!route.isObject()) {
       continue;
     }
     const auto vehicle_id = ParsePositiveId(route["vehicle"]);
-    if (vehicle_id.has_value()) {
-      const auto vehicle_it = vehicle_map.find(*vehicle_id);
-      if (vehicle_it != vehicle_map.end()) {
-        route["vehicle_external_id"] = vehicle_it->second;
-      }
+    if (vehicle_id.has_value() && *vehicle_id > 0U &&
+        *vehicle_id <= static_cast<std::uint64_t>(vehicles.size())) {
+      route["vehicle_external_id"] = vehicles[*vehicle_id - 1U].external_id;
     }
 
     Json::Value& steps = route["steps"];
@@ -451,34 +470,29 @@ void ApplyExternalIdsToRoutes(Json::Value& routes,
         continue;
       }
       const auto job_id = ParsePositiveId(step["job"]);
-      if (!job_id.has_value()) {
+      if (!job_id.has_value() || *job_id == 0U ||
+          *job_id > static_cast<std::uint64_t>(jobs.size())) {
         continue;
       }
 
-      const auto job_it = job_map.find(*job_id);
-      if (job_it != job_map.end()) {
-        step["job_external_id"] = job_it->second;
-      }
+      step["job_external_id"] = jobs[*job_id - 1U].external_id;
     }
   }
 }
 
 void ApplyExternalIdsToUnassigned(Json::Value& unassigned,
-                                  const std::map<std::uint64_t, std::string>& job_map) {
+                                  const std::vector<deliveryoptimizer::api::JobInput>& jobs) {
   for (Json::ArrayIndex index = 0U; index < unassigned.size(); ++index) {
     Json::Value& job = unassigned[index];
     if (!job.isObject()) {
       continue;
     }
     const auto job_id = ParsePositiveId(job["id"]);
-    if (!job_id.has_value()) {
+    if (!job_id.has_value() || *job_id == 0U || *job_id > static_cast<std::uint64_t>(jobs.size())) {
       continue;
     }
 
-    const auto job_it = job_map.find(*job_id);
-    if (job_it != job_map.end()) {
-      job["job_external_id"] = job_it->second;
-    }
+    job["job_external_id"] = jobs[*job_id - 1U].external_id;
   }
 }
 
@@ -534,28 +548,99 @@ std::optional<SolveRequestSize> TryParseOptimizeRequestSize(const Json::Value& r
   };
 }
 
-Json::Value BuildVroomInput(const OptimizeRequestInput& input) {
-  Json::Value payload{Json::objectValue};
-  payload["jobs"] = Json::Value{Json::arrayValue};
-  payload["vehicles"] = Json::Value{Json::arrayValue};
+namespace {
+
+[[nodiscard]] std::size_t EstimateVroomPayloadSize(const OptimizeRequestInput& input) {
+  constexpr std::size_t kFixedDocumentBytes = 32U;
+  constexpr std::size_t kFixedJobBytes = 144U;
+  constexpr std::size_t kFixedVehicleBytes = 180U;
+  constexpr std::size_t kTimeWindowBytes = 48U;
+
+  std::size_t size = kFixedDocumentBytes;
+  for (const JobInput& job : input.jobs) {
+    size += kFixedJobBytes + internal::EscapedJsonStringSize(job.external_id);
+    if (job.time_windows.has_value()) {
+      size += kTimeWindowBytes * job.time_windows->size();
+    }
+  }
+  for (const VehicleInput& vehicle : input.vehicles) {
+    size += kFixedVehicleBytes + internal::EscapedJsonStringSize(vehicle.external_id);
+  }
+  return size;
+}
+
+[[nodiscard]] std::int64_t AdjustServiceSeconds(const int service,
+                                                const int service_adjustment_seconds) {
+  const auto adjusted =
+      static_cast<std::int64_t>(service) + static_cast<std::int64_t>(service_adjustment_seconds);
+  return std::clamp<std::int64_t>(adjusted, 0,
+                                  static_cast<std::int64_t>(std::numeric_limits<int>::max()));
+}
+
+void AppendJsonDouble(std::string& output, const double value) {
+  char buffer[32];
+  const auto [end, error] = std::to_chars(buffer, buffer + sizeof(buffer), value);
+  if (error == std::errc{}) {
+    output.append(buffer, end);
+  } else {
+    output.append(std::to_string(value));
+  }
+}
+
+void AppendJsonTimeWindow(std::string& output, const deliveryoptimizer::api::TimeWindow& window) {
+  output.push_back('[');
+  internal::AppendJsonInteger(output, window.start.time_since_epoch().count());
+  output.push_back(',');
+  internal::AppendJsonInteger(output, window.end.time_since_epoch().count());
+  output.push_back(']');
+}
+
+} // namespace
+
+std::string BuildVroomInputText(const deliveryoptimizer::api::OptimizeRequestInput& input,
+                                const int service_adjustment_seconds) {
+  std::string payload;
+  payload.reserve(EstimateVroomPayloadSize(input));
+  payload += "{\"jobs\":[";
 
   for (std::size_t index = 0U; index < input.jobs.size(); ++index) {
     const JobInput& job_input = input.jobs[index];
-    Json::Value job{Json::objectValue};
-    job["id"] = static_cast<Json::UInt64>(index + 1U);
-    job["location"] = BuildLocation(job_input.lon, job_input.lat);
-    job["amount"] = BuildUnitArray(job_input.demand);
-    job["service"] = job_input.service;
-    job["description"] = job_input.external_id;
-    if (job_input.time_windows.has_value()) {
-      job["time_windows"] = BuildTimeWindowsArray(job_input.time_windows.value());
+    if (index != 0U) {
+      payload.push_back(',');
     }
-    payload["jobs"].append(job);
+    payload += "{\"id\":";
+    internal::AppendJsonInteger(payload, index + 1U);
+    payload += ",\"location\":[";
+    AppendJsonDouble(payload, job_input.lon);
+    payload.push_back(',');
+    AppendJsonDouble(payload, job_input.lat);
+    payload += "],\"amount\":[";
+    internal::AppendJsonInteger(payload, job_input.demand);
+    payload += "],\"service\":";
+    internal::AppendJsonInteger(
+        payload, AdjustServiceSeconds(job_input.service, service_adjustment_seconds));
+    payload += ",\"description\":";
+    internal::AppendEscapedJsonString(payload, job_input.external_id);
+    if (job_input.time_windows.has_value()) {
+      payload += ",\"time_windows\":[";
+      const auto& windows = job_input.time_windows.value();
+      for (std::size_t window_index = 0U; window_index < windows.size(); ++window_index) {
+        if (window_index != 0U) {
+          payload.push_back(',');
+        }
+        AppendJsonTimeWindow(payload, windows[window_index]);
+      }
+      payload.push_back(']');
+    }
+    payload.push_back('}');
   }
 
+  payload += "],\"vehicles\":[";
   for (std::size_t index = 0U; index < input.vehicles.size(); ++index) {
     const VehicleInput& vehicle_input = input.vehicles[index];
-    Json::Value vehicle{Json::objectValue};
+    if (index != 0U) {
+      payload.push_back(',');
+    }
     const Coordinate start = vehicle_input.start.value_or(Coordinate{
         .lon = input.depot_lon,
         .lat = input.depot_lat,
@@ -564,46 +649,54 @@ Json::Value BuildVroomInput(const OptimizeRequestInput& input) {
         .lon = input.depot_lon,
         .lat = input.depot_lat,
     });
-    vehicle["id"] = static_cast<Json::UInt64>(index + 1U);
-    vehicle["start"] = BuildLocation(start.lon, start.lat);
-    vehicle["end"] = BuildLocation(end.lon, end.lat);
-    vehicle["capacity"] = BuildUnitArray(vehicle_input.capacity);
-    vehicle["description"] = vehicle_input.external_id;
+    payload += "{\"id\":";
+    internal::AppendJsonInteger(payload, index + 1U);
+    payload += ",\"start\":[";
+    AppendJsonDouble(payload, start.lon);
+    payload.push_back(',');
+    AppendJsonDouble(payload, start.lat);
+    payload += "],\"end\":[";
+    AppendJsonDouble(payload, end.lon);
+    payload.push_back(',');
+    AppendJsonDouble(payload, end.lat);
+    payload += "],\"capacity\":[";
+    internal::AppendJsonInteger(payload, vehicle_input.capacity);
+    payload += "],\"description\":";
+    internal::AppendEscapedJsonString(payload, vehicle_input.external_id);
     if (vehicle_input.time_window.has_value()) {
-      vehicle["time_window"] = BuildTimeWindowArray(vehicle_input.time_window.value());
+      payload += ",\"time_window\":";
+      AppendJsonTimeWindow(payload, vehicle_input.time_window.value());
     }
-    payload["vehicles"].append(vehicle);
+    payload.push_back('}');
   }
 
+  payload += "]}";
   return payload;
 }
 
-Json::Value BuildOptimizeSuccessBody(const OptimizeRequestInput& input,
-                                     const Json::Value& vroom_output,
-                                     const std::optional<Json::Value>& forecast) {
+Json::Value BuildOptimizeSuccessBody(const OptimizeRequestInput& input, Json::Value vroom_output,
+                                     std::optional<Json::Value> forecast) {
   Json::Value body{Json::objectValue};
   body["status"] = "ok";
 
-  const Json::Value& summary = vroom_output["summary"];
-  body["summary"] = summary.isObject() ? summary : Json::Value{Json::objectValue};
+  Json::Value summary = std::move(vroom_output["summary"]);
+  body["summary"] = summary.isObject() ? std::move(summary) : Json::Value{Json::objectValue};
 
-  Json::Value routes = vroom_output["routes"];
+  Json::Value routes = std::move(vroom_output["routes"]);
   if (!routes.isArray()) {
     routes = Json::Value{Json::arrayValue};
   }
-  Json::Value unassigned = vroom_output["unassigned"];
+  Json::Value unassigned = std::move(vroom_output["unassigned"]);
   if (!unassigned.isArray()) {
     unassigned = Json::Value{Json::arrayValue};
   }
 
-  const auto vehicle_map = BuildVehicleExternalIdMap(input);
-  const auto job_map = BuildJobExternalIdMap(input);
-  ApplyExternalIdsToRoutes(routes, vehicle_map, job_map);
-  ApplyExternalIdsToUnassigned(unassigned, job_map);
+  ApplyExternalIdsToRoutes(routes, input.vehicles, input.jobs);
+  ApplyExternalIdsToUnassigned(unassigned, input.jobs);
   body["routes"] = std::move(routes);
   body["unassigned"] = std::move(unassigned);
   if (forecast.has_value()) {
-    body["forecast"] = *forecast;
+    body["forecast"] = std::move(*forecast);
   }
 
   return body;

--- a/app/api/src/request_context.cpp
+++ b/app/api/src/request_context.cpp
@@ -9,6 +9,7 @@
 namespace {
 
 constexpr std::string_view kRequestContextAttributeKey = "deliveryoptimizer.request_context";
+const std::string kRequestContextAttributeKeyString{kRequestContextAttributeKey};
 
 } // namespace
 
@@ -20,42 +21,40 @@ void EnsureRequestContext(const drogon::HttpRequestPtr& request) {
   }
 
   const auto& attributes = request->attributes();
-  if (attributes->find(std::string{kRequestContextAttributeKey})) {
+  if (attributes->find(kRequestContextAttributeKeyString)) {
     return;
   }
 
-  attributes->insert(std::string{kRequestContextAttributeKey},
+  attributes->insert(kRequestContextAttributeKeyString,
                      RequestContext{
                          .request_id = drogon::utils::getUuid(),
                          .started_at = std::chrono::steady_clock::now(),
                      });
 }
 
-std::optional<RequestContext> GetRequestContext(const drogon::HttpRequestPtr& request) {
+const RequestContext* GetRequestContext(const drogon::HttpRequestPtr& request) {
   if (request == nullptr) {
-    return std::nullopt;
+    return nullptr;
   }
 
   const auto& attributes = request->attributes();
-  if (!attributes->find(std::string{kRequestContextAttributeKey})) {
-    return std::nullopt;
+  if (!attributes->find(kRequestContextAttributeKeyString)) {
+    return nullptr;
   }
 
-  return attributes->get<RequestContext>(std::string{kRequestContextAttributeKey});
+  return &attributes->get<RequestContext>(kRequestContextAttributeKeyString);
 }
 
 SolveLifecycle CreateSolveLifecycle(const drogon::HttpRequestPtr& request) {
   EnsureRequestContext(request);
-  const RequestContext context = GetRequestContext(request).value_or(RequestContext{
-      .request_id = drogon::utils::getUuid(),
-      .started_at = std::chrono::steady_clock::now(),
-  });
+  const RequestContext* context = GetRequestContext(request);
 
   SolveLifecycle lifecycle{};
-  lifecycle.request_id = context.request_id;
+  lifecycle.request_id = context == nullptr ? drogon::utils::getUuid() : context->request_id;
   lifecycle.method = request == nullptr ? "" : request->getMethodString();
   lifecycle.path = request == nullptr ? "" : request->path();
-  lifecycle.request_started_at = context.started_at;
+  lifecycle.request_started_at =
+      context == nullptr ? std::chrono::steady_clock::now() : context->started_at;
   return lifecycle;
 }
 

--- a/app/api/src/solve_coordinator.cpp
+++ b/app/api/src/solve_coordinator.cpp
@@ -227,7 +227,7 @@ void SolveCoordinator::WorkerLoop() {
       continue;
     }
 
-    const VroomRunResult solve_result = runner_->Run(queued_request->payload_factory());
+    VroomRunResult solve_result = runner_->Run(queued_request->payload_factory());
     const auto completed_at = std::chrono::steady_clock::now();
     {
       std::lock_guard<std::mutex> lock(mutex_);
@@ -242,7 +242,7 @@ void SolveCoordinator::WorkerLoop() {
     }
     condition_.notify_all();
 
-    CoordinatedSolveResult coordinated_result = ToCoordinatedSolveResult(solve_result);
+    CoordinatedSolveResult coordinated_result = ToCoordinatedSolveResult(std::move(solve_result));
     EnqueueCompletion(
         [callback = std::move(queued_request->callback),
          result = std::move(coordinated_result)]() mutable { callback(std::move(result)); });

--- a/app/api/src/solve_execution.cpp
+++ b/app/api/src/solve_execution.cpp
@@ -1,13 +1,15 @@
 #include "deliveryoptimizer/api/solve_execution.hpp"
 
+#include <utility>
+
 namespace deliveryoptimizer::api {
 
-CoordinatedSolveResult ToCoordinatedSolveResult(const VroomRunResult& result) {
+CoordinatedSolveResult ToCoordinatedSolveResult(VroomRunResult&& result) {
   switch (result.status) {
   case VroomRunStatus::kSuccess:
     return CoordinatedSolveResult{
         .status = CoordinatedSolveStatus::kSucceeded,
-        .output = result.output,
+        .output = std::move(result.output),
     };
   case VroomRunStatus::kTimedOut:
     return CoordinatedSolveResult{
@@ -25,15 +27,16 @@ CoordinatedSolveResult ToCoordinatedSolveResult(const VroomRunResult& result) {
 }
 
 SolveExecutionResult BuildSolveExecutionResult(const OptimizeRequestInput& input,
-                                               const CoordinatedSolveResult& result,
-                                               const std::optional<Json::Value>& forecast) {
+                                               CoordinatedSolveResult result,
+                                               std::optional<Json::Value> forecast) {
   switch (result.status) {
   case CoordinatedSolveStatus::kSucceeded:
     if (result.output.has_value()) {
       return SolveExecutionResult{
           .outcome = SolveRequestOutcome::kSucceeded,
           .http_status = 200U,
-          .response_body = BuildOptimizeSuccessBody(input, *result.output, forecast),
+          .response_body =
+              BuildOptimizeSuccessBody(input, std::move(*result.output), std::move(forecast)),
           .error_message = {},
       };
     }

--- a/app/api/src/vroom_runner.cpp
+++ b/app/api/src/vroom_runner.cpp
@@ -6,16 +6,15 @@
 #include <algorithm>
 #include <array>
 #include <cerrno>
+#include <charconv>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
 #include <limits>
 #include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
-#include <vector>
 
 #ifndef _WIN32
 #include <fcntl.h>
@@ -53,12 +52,50 @@ constexpr int kDefaultVroomTimeoutSecondsInt = 30;
 
 #else
 
-constexpr std::string_view kVroomStdoutPath = "/dev/stdout";
 constexpr std::size_t kMaxVroomOutputBytes = 8U * 1024U * 1024U;
 
 struct SpawnArguments {
-  std::vector<std::string> storage;
-  std::vector<char*> argv;
+  SpawnArguments(const deliveryoptimizer::api::VroomRuntimeConfig& runtime_config,
+                 const std::string& input_file_path) {
+    const auto [timeout_end, timeout_error] =
+        std::to_chars(timeout_storage.data(), timeout_storage.data() + timeout_storage.size() - 1U,
+                      runtime_config.timeout_seconds);
+    if (timeout_error != std::errc{}) {
+      timeout_storage[0] = '3';
+      timeout_storage[1] = '0';
+      timeout_storage[2] = '\0';
+    } else {
+      *timeout_end = '\0';
+    }
+
+    // posix_spawn takes char* const argv[] and does not write through it.
+    argv = {
+        const_cast<char*>(runtime_config.vroom_bin.c_str()),
+        const_cast<char*>("--router"),
+        const_cast<char*>(runtime_config.vroom_router.c_str()),
+        const_cast<char*>("--host"),
+        const_cast<char*>(runtime_config.vroom_host.c_str()),
+        const_cast<char*>("--port"),
+        const_cast<char*>(runtime_config.vroom_port.c_str()),
+        const_cast<char*>("--limit"),
+        timeout_storage.data(),
+        const_cast<char*>("--input"),
+        const_cast<char*>(input_file_path.c_str()),
+        const_cast<char*>("--output"),
+        const_cast<char*>("/dev/stdout"),
+        nullptr,
+    };
+  }
+
+  SpawnArguments(const SpawnArguments&) = delete;
+  SpawnArguments& operator=(const SpawnArguments&) = delete;
+  SpawnArguments(SpawnArguments&&) = delete;
+  SpawnArguments& operator=(SpawnArguments&&) = delete;
+
+  // Inline storage keeps argv allocation-free. Moving is disabled because argv
+  // contains a pointer into this buffer.
+  std::array<char, 32> timeout_storage{};
+  std::array<char*, 14> argv{};
 };
 
 enum class DrainReadStatus : std::uint8_t {
@@ -157,25 +194,25 @@ public:
       return std::nullopt;
     }
 
-    std::string template_path = (temp_dir / (std::string{prefix} + "XXXXXX")).string();
-    std::vector<char> writable_template(template_path.begin(), template_path.end());
-    writable_template.push_back('\0');
+    std::string template_path = (temp_dir / std::string{prefix}).string();
+    template_path += "XXXXXX";
 
-    const int file_descriptor = mkstemp(writable_template.data());
+    const int file_descriptor = mkstemp(template_path.data());
     if (file_descriptor == -1) {
       return std::nullopt;
     }
-    (void)close(file_descriptor);
 
-    return ScopedTempFile(std::string{writable_template.data()});
+    return ScopedTempFile(std::move(template_path), ScopedFileDescriptor{file_descriptor});
   }
 
-  explicit ScopedTempFile(std::string path) : path_(std::move(path)) {}
+  ScopedTempFile(std::string path, ScopedFileDescriptor file_descriptor)
+      : path_(std::move(path)), file_descriptor_(std::move(file_descriptor)) {}
 
   ScopedTempFile(const ScopedTempFile&) = delete;
   ScopedTempFile& operator=(const ScopedTempFile&) = delete;
 
-  ScopedTempFile(ScopedTempFile&& other) noexcept : path_(std::move(other.path_)) {
+  ScopedTempFile(ScopedTempFile&& other) noexcept
+      : path_(std::move(other.path_)), file_descriptor_(std::move(other.file_descriptor_)) {
     other.path_.clear();
   }
 
@@ -186,6 +223,7 @@ public:
 
     RemoveFile();
     path_ = std::move(other.path_);
+    file_descriptor_ = std::move(other.file_descriptor_);
     other.path_.clear();
     return *this;
   }
@@ -194,17 +232,40 @@ public:
 
   [[nodiscard]] const std::string& path() const { return path_; }
 
+  [[nodiscard]] bool WriteAndClose(const std::string_view text) {
+    std::size_t written = 0U;
+    while (written < text.size()) {
+      const ssize_t write_size =
+          write(file_descriptor_.Get(), text.data() + written, text.size() - written);
+      if (write_size > 0) {
+        written += static_cast<std::size_t>(write_size);
+        continue;
+      }
+      if (write_size < 0 && errno == EINTR) {
+        continue;
+      }
+
+      file_descriptor_.Reset(-1);
+      return false;
+    }
+
+    file_descriptor_.Reset(-1);
+    return true;
+  }
+
 private:
   void RemoveFile() {
     if (path_.empty()) {
       return;
     }
 
+    file_descriptor_.Reset(-1);
     std::error_code error;
     (void)std::filesystem::remove(path_, error);
   }
 
   std::string path_;
+  ScopedFileDescriptor file_descriptor_;
 };
 
 [[nodiscard]] int ParseTimeoutSeconds(const std::string& value, const int default_timeout_seconds) {
@@ -219,20 +280,6 @@ private:
   return static_cast<int>(parsed);
 }
 
-[[nodiscard]] bool WritePayloadToFile(const std::string& path, const Json::Value& input_payload) {
-  Json::StreamWriterBuilder writer_builder;
-  writer_builder["indentation"] = "";
-  const std::string payload_text = Json::writeString(writer_builder, input_payload);
-
-  std::ofstream input_stream(path, std::ios::binary | std::ios::trunc);
-  if (!input_stream.is_open()) {
-    return false;
-  }
-
-  input_stream << payload_text;
-  return input_stream.good();
-}
-
 [[nodiscard]] std::optional<PipeEnds> CreatePipeEnds() {
   std::array<int, 2> pipe_file_descriptors{-1, -1};
   if (pipe(pipe_file_descriptors.data()) != 0) {
@@ -243,34 +290,6 @@ private:
       .read_end = ScopedFileDescriptor{pipe_file_descriptors[0]},
       .write_end = ScopedFileDescriptor{pipe_file_descriptors[1]},
   };
-}
-
-[[nodiscard]] SpawnArguments
-BuildSpawnArguments(const deliveryoptimizer::api::VroomRuntimeConfig& runtime_config,
-                    const std::string& input_file_path) {
-  SpawnArguments spawn_arguments;
-  spawn_arguments.storage = {
-      runtime_config.vroom_bin,
-      "--router",
-      runtime_config.vroom_router,
-      "--host",
-      runtime_config.vroom_host,
-      "--port",
-      runtime_config.vroom_port,
-      "--limit",
-      std::to_string(runtime_config.timeout_seconds),
-      "--input",
-      input_file_path,
-      "--output",
-      std::string{kVroomStdoutPath},
-  };
-
-  spawn_arguments.argv.reserve(spawn_arguments.storage.size() + 1U);
-  for (std::string& argument : spawn_arguments.storage) {
-    spawn_arguments.argv.push_back(argument.data());
-  }
-  spawn_arguments.argv.push_back(nullptr);
-  return spawn_arguments;
 }
 
 [[nodiscard]] bool TryWaitForProcessExit(const pid_t process_id, int& command_status,
@@ -430,16 +449,16 @@ namespace deliveryoptimizer::api {
 ProcessVroomRunner::ProcessVroomRunner(VroomRuntimeConfig runtime_config)
     : runtime_config_(std::move(runtime_config)) {}
 
-VroomRunResult ProcessVroomRunner::Run(const Json::Value& input_payload) const {
+VroomRunResult ProcessVroomRunner::Run(const std::string& input_payload) const {
 #ifdef _WIN32
   (void)input_payload;
   return VroomRunResult{.status = VroomRunStatus::kFailed, .output = std::nullopt};
 #else
-  const auto input_file = ScopedTempFile::Create("deliveryoptimizer-vroom-input-");
+  auto input_file = ScopedTempFile::Create("deliveryoptimizer-vroom-input-");
   if (!input_file.has_value()) {
     return VroomRunResult{.status = VroomRunStatus::kFailed, .output = std::nullopt};
   }
-  if (!WritePayloadToFile(input_file->path(), input_payload)) {
+  if (!input_file->WriteAndClose(input_payload)) {
     return VroomRunResult{.status = VroomRunStatus::kFailed, .output = std::nullopt};
   }
 
@@ -465,7 +484,7 @@ VroomRunResult ProcessVroomRunner::Run(const Json::Value& input_payload) const {
     return VroomRunResult{.status = VroomRunStatus::kFailed, .output = std::nullopt};
   }
 
-  SpawnArguments spawn_arguments = BuildSpawnArguments(runtime_config_, input_file->path());
+  SpawnArguments spawn_arguments{runtime_config_, input_file->path()};
   pid_t vroom_pid = -1;
   const int spawn_status =
       posix_spawn(&vroom_pid, runtime_config_.vroom_bin.c_str(), spawn_actions.Get(), nullptr,

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,0 +1,20 @@
+find_package(Drogon CONFIG REQUIRED)
+find_package(jsoncpp CONFIG REQUIRED)
+
+add_executable(deliveryoptimizer_alloc_bench allocation_bench.cpp)
+target_compile_features(deliveryoptimizer_alloc_bench PRIVATE cxx_std_20)
+target_include_directories(
+  deliveryoptimizer_alloc_bench
+  PRIVATE "${CMAKE_SOURCE_DIR}/app/api/include"
+)
+target_link_libraries(
+  deliveryoptimizer_alloc_bench
+  PRIVATE
+    deliveryoptimizer_api_runtime
+    Drogon::Drogon
+    JsonCpp::JsonCpp
+)
+
+if(DELIVERYOPTIMIZER_ENABLE_WARNINGS)
+  deliveryoptimizer_set_warnings(deliveryoptimizer_alloc_bench)
+endif()

--- a/bench/allocation_bench.cpp
+++ b/bench/allocation_bench.cpp
@@ -1,0 +1,617 @@
+// Allocation benchmark harness for the deliveryoptimizer hot paths.
+//
+// Counts every heap allocation (operator new / new[] / aligned new) and
+// measures wall time per scenario. Scenarios mirror the request pipeline:
+// - parse-request: parse and validate an optimization request.
+// - parse-vroom-output: parse a large VROOM output document.
+// - vroom-payload: render VROOM input directly to text.
+// - success-body: enrich the response with external IDs.
+// - to-coordinated / worker-flow: move solver output through execution.
+// - log-line / request-context: exercise per-request infrastructure.
+// - http-json-response: compare Drogon's copy and move overloads.
+// - write-payload / spawn-args: compare runner setup mechanisms.
+
+#include "deliveryoptimizer/adapters/json_utils.hpp"
+#include "deliveryoptimizer/api/observability.hpp"
+#include "deliveryoptimizer/api/optimize_request.hpp"
+#include "deliveryoptimizer/api/solve_execution.hpp"
+#include "deliveryoptimizer/api/vroom_runner.hpp"
+
+#include <array>
+#include <atomic>
+#include <charconv>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <drogon/drogon.h>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <json/json.h>
+#include <new>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+std::atomic<std::uint64_t> g_allocs{0U};
+std::atomic<std::uint64_t> g_bytes{0U};
+
+void ResetCounters() {
+  g_allocs.store(0U, std::memory_order_relaxed);
+  g_bytes.store(0U, std::memory_order_relaxed);
+}
+
+struct Counts {
+  std::uint64_t allocs{0U};
+  std::uint64_t bytes{0U};
+};
+
+[[nodiscard]] Counts ReadCounters() {
+  return Counts{
+      .allocs = g_allocs.load(std::memory_order_relaxed),
+      .bytes = g_bytes.load(std::memory_order_relaxed),
+  };
+}
+
+void CountAllocation(const std::size_t size) {
+  g_allocs.fetch_add(1U, std::memory_order_relaxed);
+  g_bytes.fetch_add(static_cast<std::uint64_t>(size), std::memory_order_relaxed);
+}
+
+} // namespace
+
+// -- global allocation counting -------------------------------------------------
+
+void* operator new(std::size_t size) {
+  CountAllocation(size);
+  if (void* memory = std::malloc(size == 0U ? 1U : size)) {
+    return memory;
+  }
+  throw std::bad_alloc{};
+}
+
+void* operator new[](std::size_t size) {
+  return ::operator new(size);
+}
+
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
+  try {
+    return ::operator new(size);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept {
+  return ::operator new(size, std::nothrow);
+}
+
+void* operator new(std::size_t size, std::align_val_t alignment) {
+  CountAllocation(size);
+  void* memory = nullptr;
+  const std::size_t requested = size == 0U ? 1U : size;
+  if (posix_memalign(&memory,
+                     static_cast<std::size_t>(alignment) < sizeof(void*)
+                         ? sizeof(void*)
+                         : static_cast<std::size_t>(alignment),
+                     requested) != 0) {
+    throw std::bad_alloc{};
+  }
+  return memory;
+}
+
+void* operator new[](std::size_t size, std::align_val_t alignment) {
+  return ::operator new(size, alignment);
+}
+
+void* operator new(std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept {
+  try {
+    return ::operator new(size, alignment);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void* operator new[](std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept {
+  return ::operator new(size, alignment, std::nothrow);
+}
+
+void operator delete(void* memory) noexcept {
+  std::free(memory);
+}
+void operator delete(void* memory, std::size_t) noexcept {
+  std::free(memory);
+}
+void operator delete[](void* memory) noexcept {
+  std::free(memory);
+}
+void operator delete[](void* memory, std::size_t) noexcept {
+  std::free(memory);
+}
+void operator delete(void* memory, std::align_val_t) noexcept {
+  std::free(memory);
+}
+void operator delete(void* memory, std::size_t, std::align_val_t) noexcept {
+  std::free(memory);
+}
+void operator delete[](void* memory, std::align_val_t) noexcept {
+  std::free(memory);
+}
+void operator delete[](void* memory, std::size_t, std::align_val_t) noexcept {
+  std::free(memory);
+}
+void operator delete(void* memory, const std::nothrow_t&) noexcept {
+  std::free(memory);
+}
+void operator delete[](void* memory, const std::nothrow_t&) noexcept {
+  std::free(memory);
+}
+
+namespace {
+
+using SteadyClock = std::chrono::steady_clock;
+
+struct ScenarioResult {
+  const char* name;
+  std::uint64_t allocs_per_iter;
+  std::uint64_t bytes_per_iter;
+  double microseconds_per_iter;
+};
+
+template <typename Callable>
+[[nodiscard]] ScenarioResult RunScenario(const char* name, const int warmup_iters,
+                                         const int measured_iters, Callable&& callable) {
+  for (int index = 0; index < warmup_iters; ++index) {
+    callable();
+  }
+
+  ResetCounters();
+  const auto started_at = SteadyClock::now();
+  for (int index = 0; index < measured_iters; ++index) {
+    callable();
+  }
+  const auto finished_at = SteadyClock::now();
+  const Counts counts = ReadCounters();
+
+  const double microseconds =
+      static_cast<double>(
+          std::chrono::duration_cast<std::chrono::microseconds>(finished_at - started_at).count()) /
+      static_cast<double>(measured_iters);
+  return ScenarioResult{
+      .name = name,
+      .allocs_per_iter = counts.allocs / static_cast<std::uint64_t>(measured_iters),
+      .bytes_per_iter = counts.bytes / static_cast<std::uint64_t>(measured_iters),
+      .microseconds_per_iter = microseconds,
+  };
+}
+
+void PrintResult(const ScenarioResult& result) {
+  std::printf("%-22s allocs/iter=%8llu  bytes/iter=%10llu  us/iter=%10.1f\n", result.name,
+              static_cast<unsigned long long>(result.allocs_per_iter),
+              static_cast<unsigned long long>(result.bytes_per_iter), result.microseconds_per_iter);
+}
+
+// -- fixtures -------------------------------------------------------------------
+
+[[nodiscard]] deliveryoptimizer::api::OptimizeRequestInput MakeInput(const int job_count,
+                                                                     const int vehicle_count) {
+  deliveryoptimizer::api::OptimizeRequestInput input{
+      .depot_lon = 7.4236,
+      .depot_lat = 43.7384,
+  };
+  input.vehicles.reserve(static_cast<std::size_t>(vehicle_count));
+  for (int index = 0; index < vehicle_count; ++index) {
+    input.vehicles.push_back(deliveryoptimizer::api::VehicleInput{
+        .external_id = "van-" + std::to_string(index + 1),
+        .capacity = 8,
+        .start = deliveryoptimizer::api::Coordinate{.lon = 7.4236, .lat = 43.7384},
+        .end = deliveryoptimizer::api::Coordinate{.lon = 7.4236, .lat = 43.7384},
+        .time_window =
+            deliveryoptimizer::api::TimeWindow{
+                .start = std::chrono::sys_seconds{std::chrono::seconds{0}},
+                .end = std::chrono::sys_seconds{std::chrono::seconds{86400}},
+            },
+    });
+  }
+  input.jobs.reserve(static_cast<std::size_t>(job_count));
+  for (int index = 0; index < job_count; ++index) {
+    const double offset = static_cast<double>(index) * 0.001;
+    input.jobs.push_back(deliveryoptimizer::api::JobInput{
+        .external_id = "order-" + std::to_string(index + 1),
+        .lon = 7.4200 + offset,
+        .lat = 43.7300 + offset,
+        .demand = 1,
+        .service = 120,
+        .time_windows =
+            std::vector<deliveryoptimizer::api::TimeWindow>{
+                deliveryoptimizer::api::TimeWindow{
+                    .start = std::chrono::sys_seconds{std::chrono::seconds{0}},
+                    .end = std::chrono::sys_seconds{std::chrono::seconds{86400}},
+                },
+            },
+    });
+  }
+  return input;
+}
+
+[[nodiscard]] std::string MakeRequestText(const int job_count, const int vehicle_count) {
+  std::string text;
+  text.reserve(static_cast<std::size_t>(job_count) * 140U +
+               static_cast<std::size_t>(vehicle_count) * 180U + 128U);
+  text += "{\"depot\":{\"location\":[7.4236,43.7384]},\"vehicles\":[";
+  for (int index = 0; index < vehicle_count; ++index) {
+    if (index != 0) {
+      text += ',';
+    }
+    text += "{\"id\":\"van-";
+    text += std::to_string(index + 1);
+    text += "\",\"capacity\":8,\"start\":[7.4236,43.7384],\"end\":[7.4236,43.7384],"
+            "\"time_window\":[0,86400]}";
+  }
+  text += "],\"jobs\":[";
+  for (int index = 0; index < job_count; ++index) {
+    if (index != 0) {
+      text += ',';
+    }
+    const double lon = 7.42 + static_cast<double>(index) * 0.001;
+    const double lat = 43.73 + static_cast<double>(index) * 0.001;
+    text += "{\"id\":\"order-";
+    text += std::to_string(index + 1);
+    text += "\",\"location\":[";
+    text += std::to_string(lon);
+    text += ',';
+    text += std::to_string(lat);
+    text += "],\"demand\":1,\"service\":120,\"time_windows\":[[0,86400]]}";
+  }
+  text += "]}";
+  return text;
+}
+
+// Mirrors the shape of a vroom response: summary + per-route steps + unassigned.
+[[nodiscard]] Json::Value MakeVroomOutput(const int job_count, const int vehicle_count) {
+  Json::Value output{Json::objectValue};
+  output["summary"] = Json::Value{Json::objectValue};
+  output["summary"]["cost"] = 123456;
+  output["summary"]["routes"] = vehicle_count;
+  output["summary"]["unassigned"] = 3;
+  output["summary"]["delivery"] = Json::Value{Json::arrayValue};
+  output["summary"]["delivery"][0U] = Json::Int64{job_count};
+  output["summary"]["amount"] = Json::Value{Json::arrayValue};
+  output["summary"]["amount"][0U] = Json::Int64{job_count};
+  output["summary"]["duration"] = 7200.0;
+  output["summary"]["distance"] = 54321.0;
+
+  output["routes"] = Json::Value{Json::arrayValue};
+  int job_id = 1;
+  for (int vehicle = 1; vehicle <= vehicle_count; ++vehicle) {
+    Json::Value route{Json::objectValue};
+    route["vehicle"] = Json::Int64{vehicle};
+    route["cost"] = 1000 + vehicle;
+    route["delivery"] = Json::Value{Json::arrayValue};
+    route["delivery"][0U] = Json::Int64{2};
+    route["amount"] = Json::Value{Json::arrayValue};
+    route["amount"][0U] = Json::Int64{2};
+    route["duration"] = 1800.0;
+    route["distance"] = 1234.0;
+    route["steps"] = Json::Value{Json::arrayValue};
+
+    Json::Value start_step{Json::objectValue};
+    start_step["type"] = "start";
+    start_step["location"] = Json::Value{Json::arrayValue};
+    start_step["location"][0U] = 7.4236;
+    start_step["location"][1U] = 43.7384;
+    start_step["setup"] = 0;
+    start_step["service"] = 0;
+    start_step["waiting_time"] = 0;
+    start_step["arrival"] = 0;
+    start_step["duration"] = 0;
+    route["steps"].append(start_step);
+
+    for (int step = 0; step < 2 && job_id <= job_count; ++step, ++job_id) {
+      Json::Value job_step{Json::objectValue};
+      job_step["type"] = "job";
+      job_step["location"] = Json::Value{Json::arrayValue};
+      job_step["location"][0U] = 7.42 + static_cast<double>(job_id) * 0.001;
+      job_step["location"][1U] = 43.73 + static_cast<double>(job_id) * 0.001;
+      job_step["setup"] = 0;
+      job_step["service"] = 120;
+      job_step["waiting_time"] = 0;
+      job_step["job"] = Json::Int64{job_id};
+      job_step["arrival"] = 100 + job_id;
+      job_step["duration"] = 100 + job_id;
+      route["steps"].append(job_step);
+    }
+
+    Json::Value end_step{Json::objectValue};
+    end_step["type"] = "end";
+    end_step["location"] = Json::Value{Json::arrayValue};
+    end_step["location"][0U] = 7.4236;
+    end_step["location"][1U] = 43.7384;
+    end_step["setup"] = 0;
+    end_step["service"] = 0;
+    end_step["waiting_time"] = 0;
+    end_step["arrival"] = 2000;
+    end_step["duration"] = 2000;
+    route["steps"].append(end_step);
+
+    output["routes"].append(route);
+  }
+
+  output["unassigned"] = Json::Value{Json::arrayValue};
+  for (int index = 0; index < 3; ++index) {
+    Json::Value unassigned_entry{Json::objectValue};
+    unassigned_entry["id"] = Json::Int64{job_count - index};
+    unassigned_entry["location"] = Json::Value{Json::arrayValue};
+    unassigned_entry["location"][0U] = 7.42;
+    unassigned_entry["location"][1U] = 43.73;
+    output["unassigned"].append(unassigned_entry);
+  }
+  return output;
+}
+
+[[nodiscard]] deliveryoptimizer::api::VroomRunResult MakeRunResult(const Json::Value& output) {
+  return deliveryoptimizer::api::VroomRunResult{
+      .status = deliveryoptimizer::api::VroomRunStatus::kSuccess,
+      .output = output,
+  };
+}
+
+[[nodiscard]] std::string RenderJson(const Json::Value& value) {
+  Json::StreamWriterBuilder writer_builder;
+  writer_builder["indentation"] = "";
+  return Json::writeString(writer_builder, value);
+}
+
+// Replica of the baseline WritePayloadToFile rendering path.
+void WritePayloadViaString(const std::string& path, const Json::Value& payload) {
+  Json::StreamWriterBuilder writer_builder;
+  writer_builder["indentation"] = "";
+  const std::string payload_text = Json::writeString(writer_builder, payload);
+  std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+  stream << payload_text;
+}
+
+// Replica of the optimized WritePayloadToFile rendering path.
+void WritePayloadViaStreamWriter(const std::string& path, const Json::Value& payload) {
+  static const Json::StreamWriterBuilder writer_builder = [] {
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = "";
+    return builder;
+  }();
+  std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+  writer_builder.newStreamWriter()->write(payload, &stream);
+}
+
+struct BaselineSpawnArgumentsReplica {
+  std::vector<std::string> storage;
+  std::vector<const char*> argv;
+};
+
+struct OptimizedSpawnArgumentsReplica {
+  OptimizedSpawnArgumentsReplica(const deliveryoptimizer::api::VroomRuntimeConfig& runtime_config,
+                                 const std::string& input_file_path) {
+    const auto [timeout_end, timeout_error] =
+        std::to_chars(timeout_storage.data(), timeout_storage.data() + timeout_storage.size() - 1U,
+                      runtime_config.timeout_seconds);
+    if (timeout_error != std::errc{}) {
+      timeout_storage[0] = '3';
+      timeout_storage[1] = '0';
+      timeout_storage[2] = '\0';
+    } else {
+      *timeout_end = '\0';
+    }
+    argv = {
+        runtime_config.vroom_bin.data(),
+        "--router",
+        runtime_config.vroom_router.data(),
+        "--host",
+        runtime_config.vroom_host.data(),
+        "--port",
+        runtime_config.vroom_port.data(),
+        "--limit",
+        timeout_storage.data(),
+        "--input",
+        input_file_path.data(),
+        "--output",
+        "/dev/stdout",
+        nullptr,
+    };
+  }
+
+  std::array<char, 32> timeout_storage{};
+  std::array<const char*, 14> argv{};
+};
+
+// Replica of the baseline BuildSpawnArguments.
+[[nodiscard]] BaselineSpawnArgumentsReplica
+BuildSpawnArgumentsBaseline(const deliveryoptimizer::api::VroomRuntimeConfig& runtime_config,
+                            const std::string& input_file_path) {
+  BaselineSpawnArgumentsReplica spawn_arguments;
+  spawn_arguments.storage = {
+      runtime_config.vroom_bin,
+      "--router",
+      runtime_config.vroom_router,
+      "--host",
+      runtime_config.vroom_host,
+      "--port",
+      runtime_config.vroom_port,
+      "--limit",
+      std::to_string(runtime_config.timeout_seconds),
+      "--input",
+      input_file_path,
+      "--output",
+      std::string{"/dev/stdout"},
+  };
+  spawn_arguments.argv.reserve(spawn_arguments.storage.size() + 1U);
+  for (std::string& argument : spawn_arguments.storage) {
+    spawn_arguments.argv.push_back(argument.data());
+  }
+  spawn_arguments.argv.push_back(nullptr);
+  return spawn_arguments;
+}
+
+// Replica of the optimized BuildSpawnArguments (fixed-size argv points at
+// config members; only the small derived strings are owned).
+[[nodiscard]] OptimizedSpawnArgumentsReplica
+BuildSpawnArgumentsOptimized(const deliveryoptimizer::api::VroomRuntimeConfig& runtime_config,
+                             const std::string& input_file_path) {
+  return OptimizedSpawnArgumentsReplica{runtime_config, input_file_path};
+}
+
+} // namespace
+
+int main() {
+  constexpr int kJobCount = 1000;
+  constexpr int kVehicleCount = 50;
+
+  const deliveryoptimizer::api::OptimizeRequestInput input = MakeInput(kJobCount, kVehicleCount);
+  const std::string request_text = MakeRequestText(kJobCount, kVehicleCount);
+  const Json::Value vroom_output = MakeVroomOutput(kJobCount, kVehicleCount);
+  const std::string vroom_output_text = RenderJson(vroom_output);
+  const std::string vroom_payload_text = deliveryoptimizer::api::BuildVroomInputText(input);
+  const std::optional<Json::Value> no_forecast = std::nullopt;
+
+  auto request_root = deliveryoptimizer::adapters::ParseJsonText(request_text);
+  Json::Value issues{Json::arrayValue};
+
+  std::puts("== allocation benchmark (optimized) ==");
+  std::printf("request text: %zu bytes, vroom payload: %zu bytes, vroom output: %zu bytes\n",
+              request_text.size(), vroom_payload_text.size(), vroom_output_text.size());
+
+  // 1. async worker parse + validate
+  PrintResult(RunScenario("parse-request", 3, 100, [&] {
+    auto root = deliveryoptimizer::adapters::ParseJsonText(request_text);
+    (void)deliveryoptimizer::api::ParseAndValidateOptimizeRequest(*root, issues);
+  }));
+
+  // 2. runner parses the vroom output document
+  PrintResult(RunScenario("parse-vroom-output", 3, 100, [&] {
+    (void)deliveryoptimizer::adapters::ParseJsonText(vroom_output_text);
+  }));
+
+  // 3. build vroom input payload (direct text render)
+  PrintResult(RunScenario("vroom-payload", 3, 100,
+                          [&] { (void)deliveryoptimizer::api::BuildVroomInputText(input); }));
+
+  // 4. success response body enrichment
+  PrintResult(RunScenario("success-body", 3, 100, [&] {
+    Json::Value output = vroom_output;
+    (void)deliveryoptimizer::api::BuildOptimizeSuccessBody(input, std::move(output), no_forecast);
+  }));
+
+  // 5. coordinator result conversion
+  PrintResult(RunScenario("to-coordinated", 3, 100, [&] {
+    deliveryoptimizer::api::VroomRunResult run = MakeRunResult(vroom_output);
+    (void)deliveryoptimizer::api::ToCoordinatedSolveResult(std::move(run));
+  }));
+
+  // 6. worker loop flow: convert + final assignment (moved) + execution result
+  PrintResult(RunScenario("worker-flow", 3, 100, [&] {
+    deliveryoptimizer::api::VroomRunResult run = MakeRunResult(vroom_output);
+    auto coordinated_result = deliveryoptimizer::api::ToCoordinatedSolveResult(std::move(run));
+    auto final_result = std::move(coordinated_result); // optimized: moves, no deep copy
+    (void)deliveryoptimizer::api::BuildSolveExecutionResult(input, std::move(final_result),
+                                                            no_forecast);
+  }));
+
+  // 7. per-request structured log line
+  auto observability = std::make_shared<deliveryoptimizer::api::ObservabilityRegistry>(
+      deliveryoptimizer::api::ObservabilityOptions{
+          .max_pending_log_lines = 100000U,
+          .start_log_writer = false,
+      });
+  auto lifecycle = std::make_shared<deliveryoptimizer::api::SolveLifecycle>();
+  lifecycle->request_id = "req-11111111-2222-3333-4444-555555555555";
+  lifecycle->method = "POST";
+  lifecycle->path = "/api/v1/deliveries/optimize";
+  lifecycle->request_started_at = SteadyClock::now();
+  lifecycle->queue_wait_duration = std::chrono::milliseconds{5};
+  lifecycle->solve_duration = std::chrono::milliseconds{120};
+  PrintResult(RunScenario("log-line", 3, 200, [&] {
+    deliveryoptimizer::api::FinalizeSolveRequest(
+        observability, lifecycle, deliveryoptimizer::api::SolveRequestOutcome::kSucceeded, 200U);
+  }));
+
+  // 8. request context attributes (request created once; per-request attribute work only)
+  auto context_request = drogon::HttpRequest::newHttpRequest();
+  context_request->setMethod(drogon::Post);
+  context_request->setPath("/api/v1/deliveries/optimize");
+  context_request->setBody(request_text);
+  PrintResult(RunScenario("request-context", 3, 100, [&] {
+    deliveryoptimizer::api::EnsureRequestContext(context_request);
+    (void)deliveryoptimizer::api::GetRequestContext(context_request);
+    (void)deliveryoptimizer::api::CreateSolveLifecycle(context_request);
+  }));
+
+  // 9. drogon JSON response construction: copy overload vs move overload
+  PrintResult(RunScenario("http-json-response-copy", 3, 100, [&] {
+    Json::Value body = vroom_output;
+    (void)drogon::HttpResponse::newHttpJsonResponse(body);
+  }));
+  PrintResult(RunScenario("http-json-response-move", 3, 100, [&] {
+    Json::Value body = vroom_output;
+    (void)drogon::HttpResponse::newHttpJsonResponse(std::move(body));
+  }));
+
+  // 10. payload render + temp-file write: string path vs direct stream path
+  const std::string temp_path = "/tmp/deliveryoptimizer_bench_payload.json";
+  PrintResult(RunScenario("write-payload-string", 3, 100,
+                          [&] { WritePayloadViaString(temp_path, vroom_output); }));
+  PrintResult(RunScenario("write-payload-stream", 3, 100,
+                          [&] { WritePayloadViaStreamWriter(temp_path, vroom_output); }));
+
+  // 11. spawn argv construction per solve
+  const deliveryoptimizer::api::VroomRuntimeConfig runtime_config{
+      .vroom_bin = "/usr/local/bin/vroom",
+      .vroom_router = "osrm",
+      .vroom_host = "osrm",
+      .vroom_port = "5001",
+      .timeout_seconds = 30,
+  };
+  const std::string spawn_input_path = "/tmp/deliveryoptimizer-input.json";
+  PrintResult(RunScenario("spawn-args-baseline", 3, 100, [&] {
+    (void)BuildSpawnArgumentsBaseline(runtime_config, spawn_input_path);
+  }));
+  PrintResult(RunScenario("spawn-args-optimized", 3, 100, [&] {
+    (void)BuildSpawnArgumentsOptimized(runtime_config, spawn_input_path);
+  }));
+
+  // 12. std::function capture size: captures larger than the 16-byte small-buffer
+  // optimization heap-allocate one closure per submit (the pre-optimization sync
+  // endpoint callback captured weather options strings + nested lambdas).
+  struct RequestBundle {
+    std::string weather_base_url;
+    std::string api_key;
+  };
+  auto bundle = std::make_shared<RequestBundle>();
+  bundle->weather_base_url = "https://api.openweathermap.org";
+  bundle->api_key = "";
+  PrintResult(RunScenario("closure-sbo-single-ptr", 3, 100, [&] {
+    std::function<void()> closure = [bundle] { (void)bundle; };
+    (void)closure;
+  }));
+  PrintResult(RunScenario("closure-heap-big-capture", 3, 100, [&] {
+    // Mirrors the pre-optimization capture shape: two shared_ptrs + weather options
+    // strings pushes the closure past the 16-byte SBO, so std::function heap-
+    // allocates the callable on every construction.
+    auto lifecycle = std::make_shared<deliveryoptimizer::api::SolveLifecycle>();
+    const std::string weather_base_url = "https://api.openweathermap.org";
+    const std::string api_key = "";
+    std::function<void()> closure = [bundle, lifecycle, weather_base_url, api_key] {
+      (void)bundle;
+      (void)lifecycle;
+      (void)weather_base_url;
+      (void)api_key;
+    };
+    (void)closure;
+  }));
+
+  (void)request_root;
+  return 0;
+}

--- a/docs/allocation-optimizations.md
+++ b/docs/allocation-optimizations.md
@@ -1,0 +1,216 @@
+# Allocation Reduction — Implementation & Evaluation Report
+
+Status: **implemented and measured**. All 80 unit tests pass (75 pre-existing + 5 new),
+including under ASAN+UBSAN. One optimization (P0-7) was **scrapped** after measurement
+showed it saved zero allocations.
+
+---
+
+## How this was evaluated
+
+A dedicated benchmark harness was added (`bench/allocation_bench.cpp`, built with
+`-DDELIVERYOPTIMIZER_ENABLE_BENCHMARKS=ON`, off by default). It overrides global
+`operator new`/`new[]`/aligned-new to count allocations and bytes, and replays each
+hot-path function with a representative 1000-job / 50-vehicle workload:
+
+- `parse-request` — async worker: `ParseJsonText` + `ParseAndValidateOptimizeRequest`
+- `parse-vroom-output` — runner: `ParseJsonText` over a 33 KB vroom output document
+- `vroom-payload` — `BuildVroomInput`+render vs `BuildVroomInputText`
+- `success-body` — `BuildOptimizeSuccessBody`
+- `to-coordinated` / `worker-flow` — `ToCoordinatedSolveResult` and the worker loop sequence
+- `log-line` — per-request `LogSolveRequest`
+- `request-context` — `EnsureRequestContext`/`GetRequestContext`/`CreateSolveLifecycle`
+- `http-json-response-copy|move` — drogon response construction, both overloads
+- `write-payload-string|stream` — replicated `WritePayloadToFile` variants
+- `spawn-args-baseline|optimized` — replicated `BuildSpawnArguments` variants
+- `closure-sbo-single-ptr|heap-big-capture` — std::function capture-size mechanism
+
+Allocation counts are bit-stable across runs (only wall time varies ±5%).
+
+### Measured results (per iteration)
+
+| Scenario | Baseline allocs | Optimized allocs | Δ allocs | Δ bytes | Δ time |
+|---|---|---|---|---|---|
+| parse-request | 17 846 | 16 814 | **−1 032** | −113 KB | −2% |
+| parse-vroom-output | 3 255 | 3 239 | **−16** | −5.4 KB | −6% |
+| vroom-payload | 40 130 | **1** | **−40 129 (>−99.99%)** | −3.14 MB (−94%) | −94% |
+| success-body | 7 794 | 3 497 | **−4 297 (−55%)** | −314 KB | −51% |
+| to-coordinated | 6 478 | 3 239 | **−3 239 (−50%)** | −246 KB | −51% |
+| worker-flow | 14 272 | 3 497 | **−10 775 (−76%)** | −805 KB | −73% |
+| log-line | 32 | 1 | **−31 (−97%)** | −3.3 KB | −88% |
+| request-context | 12 | 4 | **−8 (−67%)** | −320 B | negligible |
+| http-json-response copy→move | 6 481 | 3 242 | **−3 239 (−50%)** | −246 KB | −52% |
+| write-payload string→stream | 786 | 765 | −21 | −132 KB | ~same |
+| spawn-args | 4 | 0 | **−4 (−100%)** | −504 B | negligible |
+| closure capture >16 B → 1 ptr | 5 | 0 | **−5 (−100%)** | −392 B | negligible |
+
+The sum of representative synchronous stages for the 1000-job fixture drops from
+**78 773 allocations to 26 798 (−66%)** and from **6.26 MB to 2.20 MB (−65%)**,
+before any VROOM subprocess work. This is a stage-level estimate rather than an
+end-to-end latency claim; external routing and solver time still dominate real solves.
+
+### Next system-level opportunities
+
+These are intentionally not mixed into the measured patch:
+
+1. **Replace one-process-per-solve with a supervised long-lived VROOM pool or service.**
+   `ProcessVroomRunner` still creates a temp file and uses `posix_spawn` for every solve.
+   A bounded worker pool would remove process startup and file I/O, but needs worker
+   recycling, hard timeouts, crash isolation, and backpressure before it is production-safe.
+2. **Stop blocking HTTP event loops on PostgreSQL.** Job submission/status endpoints still
+   call `execSqlSync`. Move endpoint-facing queries to Drogon's async/coroutine APIs while
+   preserving the atomic admission transaction; keep blocking calls only on dedicated workers.
+3. **Move request parsing off the JsonCpp DOM.** The remaining `parse-request` path is
+   16 814 allocations for the fixture. A typed/on-demand parser (for example simdjson)
+   should be evaluated behind the existing `OptimizeRequestInput` boundary. This is the
+   largest remaining in-process allocation source, but changes validation/error behavior.
+4. **Persist normalized async-job input.** Async submissions parse for validation and the
+   durable worker parses the stored JSON again. Storing a versioned normalized payload plus
+   external-ID metadata could remove the second parse while preserving restart durability;
+   it requires a schema/version migration strategy.
+5. **Measure with live OSRM/VROOM traffic.** The allocation harness isolates C++ overhead.
+   Production p50/p95/p99, queue wait, subprocess startup, routing latency, and RSS should
+   drive whether parser work or runner architecture is the next bottleneck.
+
+---
+
+## Per-optimization verdicts
+
+### KEPT — P0-1 `ToCoordinatedSolveResult` takes `VroomRunResult&&` (moves output)
+`solve_execution.cpp`/`.hpp`. `to-coordinated`: 6 478 → 3 239 allocs (−50%). The
+jsoncpp 1.9.5 `Json::Value` copy is a full recursive deep copy (no COW), so the old
+const-ref signature duplicated the whole vroom output tree once per solve.
+Callers updated: `solve_coordinator.cpp` (drop `const`, `std::move`),
+`optimization_job_runtime.cpp`.
+
+### KEPT — P0-2 `BuildOptimizeSuccessBody` takes `Json::Value` by value, moves subtrees
+`optimize_request.cpp`/`.hpp`. `success-body`: 7 794 → 3 497 allocs (−55%). `summary`,
+`routes`, `unassigned` are moved out of the (now-owned) output instead of deep-copied.
+`BuildSolveExecutionResult` now takes `CoordinatedSolveResult` and the optional forecast
+by value so both trees can be moved through. Test updated to pass `std::move(vroom_output)`.
+
+### KEPT — P0-3 WorkerLoop assignment is a move, not a copy
+`optimization_job_runtime.cpp`. `worker-flow`: 14 272 → 3 497 allocs (−76%) — the
+combination of P0-1 + P0-2 + this move eliminates two full output-tree copies per
+async job.
+
+### KEPT — P0-4 `WritePayloadToFile` no longer renders JSON
+`vroom_runner.cpp`. Superseded by P2-1: the payload is text end-to-end and is written
+straight to the descriptor returned by `mkstemp`, with no JSON writer, intermediate string,
+`ofstream` buffer, or close/reopen cycle. The standalone stream-writer micro-optimization
+(786 → 765 allocs, −132 KB) is therefore moot in the real pipeline.
+
+### KEPT — P0-5 external-id `std::map` → direct request-vector indexing
+`optimize_request.cpp`. VROOM ids are contiguous 1..N (we emit them), so lookup is
+O(1) indexing directly into `input.jobs`/`input.vehicles`, with no map nodes, copied
+keys, or temporary pointer vectors. Lookups remain bounds-checked for malformed
+solver output. Included in the `success-body` numbers.
+
+### SCRAPPED — P0-7 lazy validation field names
+`optimize_request.cpp` (reverted). Measured impact: **0 heap allocations**. libc++
+small-string optimization (22 bytes) absorbs `"vehicles[12]"`/`"jobs[999]"` (≤ 15
+chars at the 10k/2k limits), so per-item `base_field` strings never allocate. The
+replacement added code for no allocation benefit; reverted to the original loop.
+The initial −16 parse delta came from reader reuse; the later vector reserve/move changes
+account for the additional reduction shown in the final table.
+
+### KEPT — P0-6 header/attribute key strings allocated once
+`observability.hpp` (new `RequestIdHeaderName()`), `request_context.cpp` (file-local
+`const std::string` key), `api_server.cpp` (8 call sites). `GetRequestContext` now
+returns a request-owned pointer instead of copying the UUID. `request-context`:
+12 → 4 allocs (−67%); applies to every request/response in the server, including the
+response-creation advice.
+
+### KEPT — P1-1 reusable `thread_local` JSON `CharReader`
+`libs/adapters/src/json_utils.cpp`. Verified in the vendored jsoncpp that
+`OurReader::parse()` resets `nodes_`/`comments_`/`errors_` at entry, so reuse is
+safe. Saves ~16 allocations per parse (builder settings map + reader construction);
+parses run per solve output, per async job claim, and per stored-job re-parse.
+Request validation also reserves its job/vehicle vectors, materializes each ID once,
+and moves parsed records into the final vectors instead of copying their optional time-window
+vectors. This brings `parse-request` to −1 032 allocations while `parse-vroom-output` is −16.
+
+### KEPT — P1-2 `LogSolveRequest` renders the flat log line directly
+`observability.cpp`. 32 → 1 allocation (−97%), 3.7 KB → 348 B. JSON field names,
+ordering and escaping are preserved byte-for-byte (verified against a live server
+log line: `{"request_id":...,"method":"POST","path":...,"outcome":"failed",...}`).
+
+### KEPT — P1-3 per-request closures bundled into one `SyncSolveContext`
+`endpoints/deliveries_optimize_endpoint.cpp`. Deferred functions capture one shared
+request aggregate instead of a ~184-byte state set (heap closure + re-copied weather
+strings, ×2 on the weather re-run path). The aggregate directly owns request input,
+lifecycle, response callback/response, forecast, and the weather adjustment. An
+aliasing `shared_ptr` exposes the lifecycle without another object/control-block
+allocation. The capture mechanism measures 5 allocations/construction → 0.
+
+### REVERTED — P1-4 `CreateJob` stores the raw request body
+`endpoints/optimization_jobs_endpoint.cpp`. JsonCpp accepts extensions such as comments
+and trailing commas that PostgreSQL `jsonb` rejects, so binding `request->body()` could
+turn a validated submission into a database error. The endpoint again renders the validated
+DOM to canonical JSON before binding it. `CreateJob` still accepts a `std::string_view`, but
+the intermediate full-size canonical string is required at this parser/database boundary.
+
+### KEPT — P1-5 spawn arguments use stable fixed-size storage
+`vroom_runner.cpp`. A fixed `argv` array points at `runtime_config_` members, literals,
+and an inline `to_chars` timeout buffer. This both avoids stale self-referential string
+pointers after a move and removes vector/string allocation: 4 → 0 allocations per solve.
+
+### KEPT — P1-6 drogon `newHttpJsonResponse(Json::Value&&)` move overload
+`deliveries_optimize_endpoint.cpp`, `optimization_jobs_endpoint.cpp`. The move
+overload halves response construction (6 481 → 3 242 allocs on the 33 KB fixture;
+proportionally more for large success bodies). Applied to error/validation/status
+bodies and `BuildSolveExecutionResponse` (now by-value, moving both solver output
+and forecast subtrees).
+
+### KEPT — P2-1 VROOM payload rendered directly to text
+`optimize_request.cpp` (`BuildVroomInputText`), `forecast_optimizer.cpp`
+(`BuildWeatherAdjustedVroomInputText` → delegates with the service adjustment),
+`vroom_runner.hpp/.cpp` (`Run(const std::string&)`), `solve_coordinator.hpp`
+(`PayloadFactory = std::function<std::string()>`). Replaces the per-node
+`Json::Value` tree + `writeString` render (~5 nodes + string per job): 40 130 → 1
+allocation, 3.35 MB → 212 KB, 2.70 ms → 0.15 ms per 1000-job payload.
+The renderer uses `std::to_chars` (shortest round-trip doubles), one capacity estimate,
+and a shared compact JSON escaper. Request validation rejects malformed UTF-8 external IDs
+before they reach the renderer. Four unit tests assert round-trip parity, escaping
+(`order-"quoted"\path`), service adjustment, and overflow-safe service clamping.
+
+### KEPT — P2-2 OSRM proxy path built in one reserved buffer
+`endpoints/osrm_proxy_endpoint.cpp`. 3 allocations → 1 for long route paths.
+
+### KEPT — P2-3 stored async results stay serialized
+`optimization_job_store.cpp` and `optimization_jobs_endpoint.cpp`. PostgreSQL already returns
+`result_json::text`; the store now keeps that validated JSON as text. Status queries do not
+select the result column at all, and result reads move its text directly into a JSON HTTP response
+instead of building another JsonCpp tree. Result persistence also reuses one immutable writer
+configuration rather than rebuilding its settings map per completion.
+
+### KEPT — harness + fixes
+- `bench/` target behind `DELIVERYOPTIMIZER_ENABLE_BENCHMARKS` (default OFF).
+- `tests/CMakeLists.txt`: link order fix (`GTest::gtest_main` before drogon's
+  transitive static Boost archives) so the test binary links at all in this
+  environment — a pre-existing failure unrelated to allocations.
+
+---
+
+## Testing
+
+| Check | Result |
+|---|---|
+| Unit tests (Release) | 80/80 pass — 75 pre-existing + 5 new (`BuildVroomInputText` round-trip, service adjustment, overflow clamping, compactness, and malformed-UTF-8 ID validation) |
+| Unit tests (ASAN+UBSAN) | 80/80 pass, no sanitizer reports |
+| Local HTTP integration | Health, sync solve, external-ID response, and PostgreSQL async-job end-to-end tests pass |
+| Server smoke test | Starts; `/health` correct; sync optimize path executes (validation → admission → spawn → log line); log line byte-identical to previous JSON format |
+| Benchmark stability | Allocation counts identical across repeat runs |
+
+Not run: docker-based e2e suites (require vroom/OSRM/postgres containers) — the text
+payload format is covered by the round-trip unit tests and the previous Value-based
+builder is byte-equivalent in field semantics.
+
+## Reproduce
+
+```sh
+cmake -S . -B build/build/Release -DDELIVERYOPTIMIZER_ENABLE_BENCHMARKS=ON
+cmake --build build/build/Release --target deliveryoptimizer_tests deliveryoptimizer_alloc_bench
+./build/build/Release/tests/deliveryoptimizer_tests
+./build/build/Release/bench/deliveryoptimizer_alloc_bench
+```

--- a/libs/adapters/src/json_utils.cpp
+++ b/libs/adapters/src/json_utils.cpp
@@ -1,16 +1,23 @@
 #include "deliveryoptimizer/adapters/json_utils.hpp"
 
 #include <memory>
+#include <string_view>
 
 namespace deliveryoptimizer::adapters {
 
 std::optional<Json::Value> ParseJsonText(const std::string_view text) {
-  Json::CharReaderBuilder builder;
-  builder["collectComments"] = false;
+  // The reader configuration is fixed, and jsoncpp's CharReader::parse() resets
+  // its internal state (nodes_, comments_, errors_) at entry, so a single reader
+  // per thread is safely reusable across parses.
+  static const Json::CharReaderBuilder kBuilder = [] {
+    Json::CharReaderBuilder builder;
+    builder["collectComments"] = false;
+    return builder;
+  }();
+  thread_local std::unique_ptr<Json::CharReader> reader{kBuilder.newCharReader()};
 
   Json::Value root;
   JSONCPP_STRING errors;
-  std::unique_ptr<Json::CharReader> reader{builder.newCharReader()};
   const char* begin = text.data();
   const char* end = begin + text.size();
   if (!reader->parse(begin, end, &root, &errors)) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,9 +45,10 @@ target_include_directories(deliveryoptimizer_tests PRIVATE "${CMAKE_SOURCE_DIR}/
 target_link_libraries(
   deliveryoptimizer_tests
   PRIVATE
+    GTest::gtest_main
+    GTest::gtest
     deliveryoptimizer::adapters
     Drogon::Drogon
-    GTest::gtest_main
     JsonCpp::JsonCpp
 )
 add_dependencies(deliveryoptimizer_tests deliveryoptimizer_api)

--- a/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
+++ b/tests/api/forecast_optimizer/weather_forecast_optimizer_test.cpp
@@ -1,3 +1,4 @@
+#include "deliveryoptimizer/adapters/json_utils.hpp"
 #include "deliveryoptimizer/api/forecast_optimizer.hpp"
 
 #include <gtest/gtest.h>
@@ -5,6 +6,12 @@
 #include <optional>
 
 namespace {
+
+[[nodiscard]] Json::Value ParsePayloadText(const std::string& payload_text) {
+  const auto payload = deliveryoptimizer::adapters::ParseJsonText(payload_text);
+  EXPECT_TRUE(payload.has_value());
+  return payload.value_or(Json::Value{Json::objectValue});
+}
 
 [[nodiscard]] deliveryoptimizer::api::OptimizeRequestInput BuildInput() {
   return deliveryoptimizer::api::OptimizeRequestInput{
@@ -92,8 +99,9 @@ TEST(WeatherForecastOptimizerTest, BelowThresholdWeatherDoesNotChangeVroomInput)
       .openweather_base_url = "",
   };
 
-  const Json::Value payload = deliveryoptimizer::api::BuildWeatherAdjustedVroomInput(
-      input, deliveryoptimizer::api::EstimateWeatherImpact(options, input.jobs.size(), 300));
+  const Json::Value payload =
+      ParsePayloadText(deliveryoptimizer::api::BuildWeatherAdjustedVroomInputText(
+          input, deliveryoptimizer::api::EstimateWeatherImpact(options, input.jobs.size(), 300)));
 
   ASSERT_TRUE(payload["jobs"].isArray());
   ASSERT_EQ(payload["jobs"].size(), 2U);
@@ -112,10 +120,10 @@ TEST(WeatherForecastOptimizerTest, AboveThresholdWeatherAddsServiceTime) {
       .openweather_base_url = "",
   };
 
-  const Json::Value payload = deliveryoptimizer::api::BuildWeatherAdjustedVroomInput(
-      input, deliveryoptimizer::api::EstimateWeatherImpact(options, input.jobs.size(), 300));
   const deliveryoptimizer::api::WeatherImpactEstimate impact =
       deliveryoptimizer::api::EstimateWeatherImpact(options, input.jobs.size(), 300);
+  const Json::Value payload =
+      ParsePayloadText(deliveryoptimizer::api::BuildWeatherAdjustedVroomInputText(input, impact));
   const Json::Value forecast =
       deliveryoptimizer::api::BuildWeatherForecastAnnotation(options, impact);
 

--- a/tests/api/optimize_request/build_optimize_success_body_preserves_signed_ids_test.cpp
+++ b/tests/api/optimize_request/build_optimize_success_body_preserves_signed_ids_test.cpp
@@ -61,7 +61,8 @@ TEST(OptimizeRequestTest, BuildOptimizeSuccessBodyPreservesExternalIdsForSignedP
   vroom_output["unassigned"] = Json::Value{Json::arrayValue};
   vroom_output["unassigned"].append(unassigned_entry);
 
-  const Json::Value body = deliveryoptimizer::api::BuildOptimizeSuccessBody(input, vroom_output);
+  const Json::Value body =
+      deliveryoptimizer::api::BuildOptimizeSuccessBody(input, std::move(vroom_output));
 
   ASSERT_TRUE(body["routes"].isArray());
   ASSERT_EQ(body["routes"].size(), 1U);

--- a/tests/api/optimize_request/build_vroom_input_text_round_trips_test.cpp
+++ b/tests/api/optimize_request/build_vroom_input_text_round_trips_test.cpp
@@ -1,0 +1,171 @@
+#include "deliveryoptimizer/adapters/json_utils.hpp"
+#include "deliveryoptimizer/api/optimize_request.hpp"
+
+#include <gtest/gtest.h>
+#include <json/json.h>
+#include <limits>
+#include <optional>
+#include <string>
+
+namespace {
+
+[[nodiscard]] deliveryoptimizer::api::OptimizeRequestInput BuildInput() {
+  return deliveryoptimizer::api::OptimizeRequestInput{
+      .depot_lon = 7.4236,
+      .depot_lat = 43.7384,
+      .vehicles =
+          {
+              deliveryoptimizer::api::VehicleInput{
+                  .external_id = "van-1",
+                  .capacity = 8,
+                  .start = std::nullopt,
+                  .end = std::nullopt,
+                  .time_window =
+                      deliveryoptimizer::api::TimeWindow{
+                          .start = std::chrono::sys_seconds{std::chrono::seconds{0}},
+                          .end = std::chrono::sys_seconds{std::chrono::seconds{86400}},
+                      },
+              },
+          },
+      .jobs =
+          {
+              deliveryoptimizer::api::JobInput{
+                  .external_id = "order-\"quoted\"\\path",
+                  .lon = 7.4212,
+                  .lat = 43.7308,
+                  .demand = 3,
+                  .service = 180,
+                  .time_windows =
+                      std::vector<deliveryoptimizer::api::TimeWindow>{
+                          deliveryoptimizer::api::TimeWindow{
+                              .start = std::chrono::sys_seconds{std::chrono::seconds{3600}},
+                              .end = std::chrono::sys_seconds{std::chrono::seconds{7200}},
+                          },
+                          deliveryoptimizer::api::TimeWindow{
+                              .start = std::chrono::sys_seconds{std::chrono::seconds{10800}},
+                              .end = std::chrono::sys_seconds{std::chrono::seconds{14400}},
+                          },
+                      },
+              },
+              deliveryoptimizer::api::JobInput{
+                  .external_id = "order-2",
+                  .lon = 7.4261,
+                  .lat = 43.7412,
+                  .demand = 1,
+                  .service = 120,
+                  .time_windows = std::nullopt,
+              },
+          },
+  };
+}
+
+[[nodiscard]] Json::Value BuildRequestJson() {
+  const auto request = deliveryoptimizer::adapters::ParseJsonText(R"JSON({
+    "depot": {"location": [7.4236, 43.7384]},
+    "vehicles": [{"id": "van-1", "capacity": 8}],
+    "jobs": [{"id": "order-1", "location": [7.4212, 43.7308]}]
+  })JSON");
+  return request.value();
+}
+
+} // namespace
+
+TEST(OptimizeRequestTest, BuildVroomInputTextRoundTripsThroughJsonParser) {
+  const auto input = BuildInput();
+  const std::string payload_text = deliveryoptimizer::api::BuildVroomInputText(input);
+  const auto payload = deliveryoptimizer::adapters::ParseJsonText(payload_text);
+
+  ASSERT_TRUE(payload.has_value());
+  ASSERT_TRUE((*payload)["jobs"].isArray());
+  ASSERT_EQ((*payload)["jobs"].size(), 2U);
+  ASSERT_TRUE((*payload)["vehicles"].isArray());
+  ASSERT_EQ((*payload)["vehicles"].size(), 1U);
+
+  const Json::Value& job = (*payload)["jobs"][0U];
+  EXPECT_EQ(job["id"].asUInt64(), 1U);
+  ASSERT_TRUE(job["location"].isArray());
+  EXPECT_DOUBLE_EQ(job["location"][0U].asDouble(), 7.4212);
+  EXPECT_DOUBLE_EQ(job["location"][1U].asDouble(), 43.7308);
+  ASSERT_TRUE(job["amount"].isArray());
+  EXPECT_EQ(job["amount"][0U].asInt(), 3);
+  EXPECT_EQ(job["service"].asInt(), 180);
+  // External ids with quotes and backslashes survive the renderer's escaping.
+  EXPECT_EQ(job["description"].asString(), "order-\"quoted\"\\path");
+  ASSERT_TRUE(job["time_windows"].isArray());
+  ASSERT_EQ(job["time_windows"].size(), 2U);
+  EXPECT_EQ(job["time_windows"][0U][0U].asInt64(), 3600);
+  EXPECT_EQ(job["time_windows"][0U][1U].asInt64(), 7200);
+  EXPECT_EQ(job["time_windows"][1U][0U].asInt64(), 10800);
+  EXPECT_EQ(job["time_windows"][1U][1U].asInt64(), 14400);
+
+  EXPECT_EQ((*payload)["jobs"][1U]["id"].asUInt64(), 2U);
+  EXPECT_EQ((*payload)["jobs"][1U]["service"].asInt(), 120);
+  EXPECT_FALSE((*payload)["jobs"][1U].isMember("time_windows"));
+
+  const Json::Value& vehicle = (*payload)["vehicles"][0U];
+  EXPECT_EQ(vehicle["id"].asUInt64(), 1U);
+  EXPECT_EQ(vehicle["description"].asString(), "van-1");
+  ASSERT_TRUE(vehicle["start"].isArray());
+  EXPECT_DOUBLE_EQ(vehicle["start"][0U].asDouble(), 7.4236);
+  EXPECT_DOUBLE_EQ(vehicle["start"][1U].asDouble(), 43.7384);
+  ASSERT_TRUE(vehicle["end"].isArray());
+  ASSERT_TRUE(vehicle["capacity"].isArray());
+  EXPECT_EQ(vehicle["capacity"][0U].asInt(), 8);
+  ASSERT_TRUE(vehicle["time_window"].isArray());
+  EXPECT_EQ(vehicle["time_window"][0U].asInt64(), 0);
+  EXPECT_EQ(vehicle["time_window"][1U].asInt64(), 86400);
+}
+
+TEST(OptimizeRequestTest, BuildVroomInputTextAppliesServiceAdjustment) {
+  auto input = BuildInput();
+  const std::string payload_text =
+      deliveryoptimizer::api::BuildVroomInputText(input, /*service_adjustment_seconds=*/75);
+  const auto payload = deliveryoptimizer::adapters::ParseJsonText(payload_text);
+
+  ASSERT_TRUE(payload.has_value());
+  EXPECT_EQ((*payload)["jobs"][0U]["service"].asInt(), 255);
+  EXPECT_EQ((*payload)["jobs"][1U]["service"].asInt(), 195);
+}
+
+TEST(OptimizeRequestTest, BuildVroomInputTextClampsServiceAdjustmentWithoutOverflow) {
+  auto input = BuildInput();
+  input.jobs[0U].service = std::numeric_limits<int>::max();
+  const std::string payload_text = deliveryoptimizer::api::BuildVroomInputText(
+      input, /*service_adjustment_seconds=*/std::numeric_limits<int>::max());
+  const auto payload = deliveryoptimizer::adapters::ParseJsonText(payload_text);
+
+  ASSERT_TRUE(payload.has_value());
+  EXPECT_EQ((*payload)["jobs"][0U]["service"].asInt(), std::numeric_limits<int>::max());
+}
+
+TEST(OptimizeRequestTest, BuildVroomInputTextProducesCompactDocument) {
+  const auto input = BuildInput();
+  const std::string payload_text = deliveryoptimizer::api::BuildVroomInputText(input);
+  const auto payload = deliveryoptimizer::adapters::ParseJsonText(payload_text);
+
+  ASSERT_TRUE(payload.has_value());
+  ASSERT_TRUE((*payload).isMember("jobs"));
+  ASSERT_TRUE((*payload).isMember("vehicles"));
+  // The rendered document is a single compact JSON object with no trailing whitespace.
+  EXPECT_EQ(payload_text.front(), '{');
+  EXPECT_EQ(payload_text.back(), '}');
+  EXPECT_EQ(payload_text.find("  "), std::string::npos);
+}
+
+TEST(OptimizeRequestTest, ParseAndValidateRejectsMalformedUtf8ExternalIds) {
+  Json::Value request = BuildRequestJson();
+  std::string malformed_id{"invalid-"};
+  malformed_id.push_back(static_cast<char>(0xC3));
+  malformed_id.push_back('(');
+  request["vehicles"][0U]["id"] = malformed_id;
+  request["jobs"][0U]["id"] = malformed_id;
+
+  Json::Value issues;
+  EXPECT_FALSE(
+      deliveryoptimizer::api::ParseAndValidateOptimizeRequest(request, issues).has_value());
+  ASSERT_EQ(issues.size(), 2U);
+  EXPECT_EQ(issues[0U]["field"].asString(), "vehicles[0].id");
+  EXPECT_EQ(issues[0U]["message"].asString(), "must contain valid UTF-8.");
+  EXPECT_EQ(issues[1U]["field"].asString(), "jobs[0].id");
+  EXPECT_EQ(issues[1U]["message"].asString(), "must contain valid UTF-8.");
+}

--- a/tests/api/solve_coordinator/records_lifecycle_metrics_test.cpp
+++ b/tests/api/solve_coordinator/records_lifecycle_metrics_test.cpp
@@ -18,7 +18,7 @@ using SteadyClock = std::chrono::steady_clock;
 
 class BlockingRunner final : public deliveryoptimizer::api::VroomRunner {
 public:
-  deliveryoptimizer::api::VroomRunResult Run(const Json::Value& input) const override {
+  deliveryoptimizer::api::VroomRunResult Run(const std::string& input) const override {
     (void)input;
     {
       std::lock_guard<std::mutex> lock(mutex_);
@@ -57,7 +57,7 @@ private:
 
 class ImmediateRunner final : public deliveryoptimizer::api::VroomRunner {
 public:
-  deliveryoptimizer::api::VroomRunResult Run(const Json::Value& input) const override {
+  deliveryoptimizer::api::VroomRunResult Run(const std::string& input) const override {
     (void)input;
     return deliveryoptimizer::api::VroomRunResult{
         .status = deliveryoptimizer::api::VroomRunStatus::kSuccess,
@@ -102,7 +102,7 @@ TEST(SolveCoordinatorLifecycleTest, RecordsLifecycleAndGaugeTransitionsForSucces
                     .jobs = 1U,
                     .vehicles = 1U,
                 },
-                [] { return Json::Value{Json::objectValue}; },
+                [] { return "{}"; },
                 [&result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
                   result_promise.set_value(result);
                 },
@@ -142,7 +142,7 @@ TEST(SolveCoordinatorLifecycleTest, RecordsAcceptedBeforeCompletionCallbackRuns)
                     .jobs = 1U,
                     .vehicles = 1U,
                 },
-                [] { return Json::Value{Json::objectValue}; },
+                [] { return "{}"; },
                 [&metrics_promise,
                  observability](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
                   EXPECT_EQ(result.status,
@@ -187,7 +187,7 @@ TEST(SolveCoordinatorLifecycleTest, RecordsQueuedTimeoutAndQueueGaugeTransitions
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&first_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             first_result_promise.set_value(result);
           },
@@ -201,7 +201,7 @@ TEST(SolveCoordinatorLifecycleTest, RecordsQueuedTimeoutAndQueueGaugeTransitions
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&second_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             second_result_promise.set_value(result);
           },

--- a/tests/api/solve_coordinator/submit_defers_payload_factory_test.cpp
+++ b/tests/api/solve_coordinator/submit_defers_payload_factory_test.cpp
@@ -15,7 +15,7 @@ namespace {
 
 class BlockingRunner final : public deliveryoptimizer::api::VroomRunner {
 public:
-  deliveryoptimizer::api::VroomRunResult Run(const Json::Value& input) const override {
+  deliveryoptimizer::api::VroomRunResult Run(const std::string& input) const override {
     (void)input;
     {
       std::lock_guard<std::mutex> lock(mutex_);
@@ -53,7 +53,7 @@ private:
 
 class ImmediateRunner final : public deliveryoptimizer::api::VroomRunner {
 public:
-  deliveryoptimizer::api::VroomRunResult Run(const Json::Value& input) const override {
+  deliveryoptimizer::api::VroomRunResult Run(const std::string& input) const override {
     (void)input;
     {
       std::lock_guard<std::mutex> lock(mutex_);
@@ -108,7 +108,7 @@ TEST(SolveCoordinatorTest, DoesNotInvokePayloadFactoryWhenSolveIsRejectedForSync
       },
       [&payload_factory_called] {
         payload_factory_called.store(true);
-        return Json::Value{Json::objectValue};
+        return "{}";
       },
       [](const deliveryoptimizer::api::CoordinatedSolveResult&) {
         FAIL() << "callback should not run";
@@ -134,7 +134,7 @@ TEST(SolveCoordinatorTest, DoesNotInvokePayloadFactoryWhenSolveIsRejectedForQueu
           },
           [&first_payload_factory_called] {
             first_payload_factory_called.store(true);
-            return Json::Value{Json::objectValue};
+            return "{}";
           },
           [&first_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             first_result_promise.set_value(result);
@@ -150,7 +150,7 @@ TEST(SolveCoordinatorTest, DoesNotInvokePayloadFactoryWhenSolveIsRejectedForQueu
       },
       [&second_payload_factory_called] {
         second_payload_factory_called.store(true);
-        return Json::Value{Json::objectValue};
+        return "{}";
       },
       [](const deliveryoptimizer::api::CoordinatedSolveResult&) {
         FAIL() << "callback should not run";
@@ -192,7 +192,7 @@ TEST(SolveCoordinatorTest, WorkerRejectsQueuedSolveThatExpiredBeforeDequeue) {
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&first_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             first_result_promise.set_value(result);
           }),
@@ -207,7 +207,7 @@ TEST(SolveCoordinatorTest, WorkerRejectsQueuedSolveThatExpiredBeforeDequeue) {
           },
           [&second_payload_factory_called] {
             second_payload_factory_called.store(true);
-            return Json::Value{Json::objectValue};
+            return "{}";
           },
           [&second_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             second_result_promise.set_value(result);
@@ -254,7 +254,7 @@ TEST(SolveCoordinatorTest, QueueTimerExpiresQueuedSolveBehindReservedWorkerSlots
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&first_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             first_result_promise.set_value(result);
           }),
@@ -265,7 +265,7 @@ TEST(SolveCoordinatorTest, QueueTimerExpiresQueuedSolveBehindReservedWorkerSlots
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&second_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             second_result_promise.set_value(result);
           }),
@@ -278,7 +278,7 @@ TEST(SolveCoordinatorTest, QueueTimerExpiresQueuedSolveBehindReservedWorkerSlots
           },
           [&third_payload_factory_called] {
             third_payload_factory_called.store(true);
-            return Json::Value{Json::objectValue};
+            return "{}";
           },
           [&third_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             third_result_promise.set_value(result);
@@ -330,7 +330,7 @@ TEST(SolveCoordinatorTest, DestructorFailsQueuedSolveBeforeActiveWorkerFinishes)
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&first_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             first_result_promise.set_value(result);
           }),
@@ -343,7 +343,7 @@ TEST(SolveCoordinatorTest, DestructorFailsQueuedSolveBeforeActiveWorkerFinishes)
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&second_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             second_result_promise.set_value(result);
           }),
@@ -383,7 +383,7 @@ TEST(SolveCoordinatorTest, AcceptedSolveWithMaximumQueueWaitDoesNotTimeOutImmedi
                 },
                 [&payload_factory_called] {
                   payload_factory_called.store(true);
-                  return Json::Value{Json::objectValue};
+                  return "{}";
                 },
                 [&result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
                   result_promise.set_value(result);
@@ -407,7 +407,7 @@ TEST(SolveCoordinatorTest, DestructorWaitsForInFlightSolveToFinish) {
                     .jobs = 1U,
                     .vehicles = 1U,
                 },
-                [] { return Json::Value{Json::objectValue}; },
+                [] { return "{}"; },
                 [&result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
                   result_promise.set_value(result);
                 }),
@@ -448,7 +448,7 @@ TEST(SolveCoordinatorTest, ExtremelyLargeQueueWaitDoesNotExpireQueuedSolveImmedi
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&first_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             first_result_promise.set_value(result);
           }),
@@ -463,7 +463,7 @@ TEST(SolveCoordinatorTest, ExtremelyLargeQueueWaitDoesNotExpireQueuedSolveImmedi
           },
           [&second_payload_factory_called] {
             second_payload_factory_called.store(true);
-            return Json::Value{Json::objectValue};
+            return "{}";
           },
           [&second_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             second_result_promise.set_value(result);
@@ -504,7 +504,7 @@ TEST(SolveCoordinatorTest, RequestsUsingFreeWorkerSlotsDoNotQueueTimeout) {
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&first_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             first_result_promise.set_value(result);
           }),
@@ -515,7 +515,7 @@ TEST(SolveCoordinatorTest, RequestsUsingFreeWorkerSlotsDoNotQueueTimeout) {
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&second_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             second_result_promise.set_value(result);
           }),
@@ -557,7 +557,7 @@ TEST(SolveCoordinatorTest, ReleasesActiveSolveSlotBeforeRunningCompletionCallbac
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&first_callback_started_promise, &release_first_callback_future,
            &first_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             first_callback_started_promise.set_value();
@@ -574,7 +574,7 @@ TEST(SolveCoordinatorTest, ReleasesActiveSolveSlotBeforeRunningCompletionCallbac
           .jobs = 1U,
           .vehicles = 1U,
       },
-      [] { return Json::Value{Json::objectValue}; },
+      [] { return "{}"; },
       [&second_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
         second_result_promise.set_value(result);
       });
@@ -614,7 +614,7 @@ TEST(SolveCoordinatorTest, ContinuesRunningQueuedSolvesWhileCompletionCallbackIs
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&first_callback_started_promise, &release_first_callback_future,
            &first_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             first_callback_started_promise.set_value();
@@ -632,7 +632,7 @@ TEST(SolveCoordinatorTest, ContinuesRunningQueuedSolvesWhileCompletionCallbackIs
               .jobs = 1U,
               .vehicles = 1U,
           },
-          [] { return Json::Value{Json::objectValue}; },
+          [] { return "{}"; },
           [&second_result_promise](const deliveryoptimizer::api::CoordinatedSolveResult& result) {
             second_result_promise.set_value(result);
           }),

--- a/tests/integration/http_server/optimization_jobs_end_to_end_test.sh
+++ b/tests/integration/http_server/optimization_jobs_end_to_end_test.sh
@@ -62,12 +62,13 @@ http_server_wait_until_responding "/health" "${health_file}"
 cat >"${payload_file}" <<'JSON'
 {
   "depot": { "location": [7.4236, 43.7384] },
+  // JsonCpp accepts comments and trailing commas; the queued jsonb payload is canonicalized.
   "vehicles": [
-    { "id": "van-1", "capacity": 8 }
+    { "id": "van-1", "capacity": 8 },
   ],
   "jobs": [
-    { "id": "order-1", "location": [7.4212, 43.7308], "demand": 1 }
-  ]
+    { "id": "order-1", "location": [7.4212, 43.7308], "demand": 1 },
+  ],
 }
 JSON
 


### PR DESCRIPTION
## Summary

- Reduce heap pressure across the C++ optimize request, VROOM runner, response, logging, and async-job result paths.
- For the representative 1,000-job / 50-vehicle benchmark, reduce measured pre-solver allocations from 78,773 to 26,798 (-66%) and allocated bytes from 6.26 MB to 2.20 MB (-65%).
- Keep API response schemas and status behavior stable while tightening malformed UTF-8 external-ID validation.

## Motivation

- Profiling showed that building VROOM payloads as JsonCpp trees and copying solver output trees dominated in-process allocation cost.
- Per-request JSON writer/parser setup, callback captures, request-context copies, and reparsing stored async results added avoidable overhead on every solve.
- The benchmark and evaluation report make the tradeoffs reproducible and distinguish in-process gains from end-to-end latency, which remains dominated by routing and solver work.

## Changes

### Backend

- Render VROOM input directly into one reserved text buffer and carry text through weather adjustment, coordination, and process execution.
- Move owned JsonCpp output and forecast trees through solve execution and Drogon responses instead of deep-copying them.
- Reuse per-thread JSON readers, reserve parsed request vectors, and enrich external IDs by direct request-vector indexing.
- Consolidate synchronous request state into one shared context and reuse request header/attribute keys.
- Render flat observability records directly, reserve OSRM proxy paths, and construct VROOM spawn arguments in fixed storage.
- Keep completed async results serialized, omit result payloads from status queries, and send validated result text directly.
- Preserve JsonCpp's accepted comment/trailing-comma input behavior by canonicalizing validated async requests before PostgreSQL `jsonb` persistence.
- Reject malformed UTF-8 vehicle/job external IDs before direct JSON rendering.

### Benchmark, tests, and documentation

- Add the opt-in `deliveryoptimizer_alloc_bench` target behind `DELIVERYOPTIMIZER_ENABLE_BENCHMARKS=OFF` by default.
- Add round-trip, escaping, service-adjustment, overflow-clamping, compactness, malformed-UTF-8, and async canonicalization coverage.
- Document measurements, retained/reverted experiments, limitations, and follow-up architecture opportunities in `docs/allocation-optimizations.md`.

### Representative benchmark

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Selected pre-solver allocations | 78,773 | 26,798 | -66% |
| Selected pre-solver allocated bytes | 6.26 MB | 2.20 MB | -65% |
| VROOM payload allocations | 40,130 | 1 | >-99.99% |
| VROOM payload render time | 2.70 ms | ~0.15 ms | -94% |
| Async worker-flow allocations | 14,272 | 3,497 | -76% |

These are isolated C++ stage measurements, not an end-to-end request-latency claim.

## Validation

### Frontend

No frontend or mobile files changed; the pull-request checks still ran the complete suites.

- [x] `npm --prefix app/ui run lint` — passed in CI.
- [x] `npm --prefix app/ui run format:check` — passed in CI.
- [x] `npm --prefix app/ui run typecheck` — passed in CI.
- [x] `npm --prefix app/ui run test` — passed in CI.
- [x] `npm --prefix app/ui run build` — passed in CI.
- [x] `npm --prefix app/mobile run lint` — passed in CI.
- [x] `npm --prefix app/mobile run typecheck` — passed in CI.

### Backend

- [x] `cmake --preset dev` — passed in CI.
- [x] `.github/scripts/check-backend-static.sh build/dev` — full format, lint, and LSP checks passed in CI.
- [x] `cmake --build --preset dev --parallel` — passed in CI.
- [x] `ctest --preset dev --output-on-failure --no-tests=error -LE 'e2e|docker'` — passed in CI.
- [x] `cmake --build build/build/Release --target deliveryoptimizer_tests deliveryoptimizer_alloc_bench -j 6` — succeeded.
- [x] `ctest --test-dir build/build/Release --output-on-failure -LE 'docker|e2e'` — 127/127 tests passed.
- [x] `cmake --build build/sanitize --clean-first --target deliveryoptimizer_tests -j 6 && ./build/sanitize/tests/deliveryoptimizer_tests` — 80/80 tests passed with ASAN+UBSAN and no reports.
- [x] `./build/build/Release/bench/deliveryoptimizer_alloc_bench` — completed; allocation counts matched the report, including one VROOM payload allocation and zero optimized spawn-argument allocations.
- [x] `bash -n tests/integration/http_server/optimization_jobs_end_to_end_test.sh` — passed.
- [x] `git diff --check 07611aa05edf` — passed.
- [x] `docker compose -f deploy/compose/docker-compose.arm64.yml --env-file deploy/env/http-server.arm64.env config` — passed in CI.

Docker-dependent E2E tests were not run because the local Docker daemon was unavailable. The non-Docker suite includes local HTTP, PostgreSQL async-job, sync solve, OSRM proxy, and external-ID integration coverage.

## Risk

- The C++ signatures for `VroomRunner::Run`, VROOM payload factories, solve-result builders, and request-context access changed. In-repository consumers are updated; external source consumers will need corresponding updates.
- Direct JSON rendering is sensitive to escaping and numeric parity. Round-trip and integration tests cover escaped IDs, time windows, service adjustment, overflow, malformed UTF-8, and VROOM request/response behavior.
- Async result responses now use already-validated stored JSON text rather than rebuilding a JsonCpp tree. Content type and response schema are unchanged.
- No database migration or deployment configuration change is required.

## Rollout and Recovery

- Deploy through the normal backend release path; the benchmark target remains disabled in normal builds.
- Monitor request errors, solve outcomes, process failures, queue latency, and RSS after rollout.
- Roll back by reverting commit `96447a4` if request serialization, downstream source compatibility, or runtime metrics regress.

## High-Signal PR Checklist

- [x] The summary states the user-visible or operational outcome, not just file names.
- [x] The motivation explains why this change is needed now.
- [x] The change list separates frontend, backend, infrastructure, and documentation work where applicable.
- [x] Validation includes exact commands run, relevant output, and any checks intentionally skipped.
- [x] Risks, migrations, feature flags, and rollback steps are called out when relevant.
- [x] Screenshots or request/response examples are included for UI and API behavior changes. (No UI changes; API schemas are unchanged and validation behavior is described above.)
