### PR TITLE
chore(deploy): commit Firebase App Hosting config

### DIFF
--- a/app/ui/.firebaserc
+++ b/app/ui/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "b2-delivery-optimizer"
+  }
+}

--- a/app/ui/firebase.json
+++ b/app/ui/firebase.json
@@ -1,0 +1,15 @@
+{
+  "apphosting": [
+    {
+      "backendId": "delivery-optimizer",
+      "rootDir": "/",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log",
+        "functions"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation
The frontend's road-following-route fix (#202) is merged to `main` but not live in production — the frontend hasn't been redeployed since 2026-07-31, before #202 merged. Part of why redeploys get skipped is that `firebase deploy --only apphosting` config isn't in the repo at all: `app/ui/.firebaserc` and `app/ui/firebase.json` only ever existed as untracked local files on individual machines, and had already been lost once and reconstructed from a stash.

## Changes
- Add `app/ui/.firebaserc` (maps the `default` alias to the `b2-delivery-optimizer` Firebase project)
- Add `app/ui/firebase.json` (declares the App Hosting backend: `backendId: delivery-optimizer`, `rootDir: /`, standard ignore list)

No application code, build config, or runtime behavior changes — this only adds deploy tooling config that was previously untracked.

## Validation
- Inspected both files by hand: contain only a project alias and backend id/rootDir/ignore list, no secrets or credentials
- Confirmed no other `apphosting` entries exist in `firebase.json` (a past duplicate-entry issue, since fixed, is not present)
- Will confirm `firebase deploy --only apphosting` succeeds from a clean checkout using these committed files as part of the deploy immediately following this merge

## Risk
Low. These are static config files consumed only by the `firebase` CLI at deploy time — they aren't imported by application code and ship nothing to the browser bundle. Worst case is a bad `backendId`/`rootDir` value, which would fail loudly at `firebase deploy` time rather than silently misbehaving in production.

## Rollout and Recovery
No rollout beyond the normal merge — these files take effect only when someone runs `firebase deploy --only apphosting`. If the config is wrong, revert this PR or fix the values directly; there's no runtime/production impact to roll back since nothing is served from these files.
